### PR TITLE
Coldplug modules after loading firmware

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S10mdev
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S10mdev
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Start mdev....
+#
+
+case "$1" in
+  start)
+	echo "Starting mdev..."
+	echo /sbin/mdev >/proc/sys/kernel/hotplug
+	/sbin/mdev -s
+	;;
+  stop)
+	;;
+  restart|reload)
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S99coldplug
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S99coldplug
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Coldplug modules....
+#
+
+case "$1" in
+  start)
+	echo "Coldplug modules..."
+	# coldplug modules
+	find /sys/ -name modalias -print0 | xargs -0 sort -u -z | xargs -0 modprobe -abq
+	;;
+  stop)
+	;;
+  restart|reload)
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?


### PR DESCRIPTION
Moves the coldplug part of the buildroot mdev init script to a later init script so that firmware may be copied to `/lib/firmware` before `zynq_remoteproc` is probed.