### PR TITLE
Set additional version information

### DIFF
--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -3,7 +3,8 @@
 UBOOT_DIR=`find $BUILD_DIR -maxdepth 1 -type d -name uboot_custom-*`
 
 generate_dev() {
-  local CFG=$1
+  local HW=$1
+  local CFG=piksiv3_$HW
   local UBOOT_BUILD_DIR=$UBOOT_DIR/build/${CFG}_dev
   local OUTPUT_DIR=$BINARIES_DIR/${CFG}_dev
 
@@ -14,9 +15,11 @@ generate_dev() {
 }
 
 generate_prod() {
-  local CFG=$1
+  local HW=$1
+  local CFG=piksiv3_$HW
   local UBOOT_BUILD_DIR=$UBOOT_DIR/build/${CFG}_prod
   local OUTPUT_DIR=$BINARIES_DIR/${CFG}_prod
+  local BR_GIT_VERSION=$(git -C $BR2_EXTERNAL rev-parse --short HEAD)
 
   mkdir -p $OUTPUT_DIR
   cp $UBOOT_BUILD_DIR/tpl/boot.bin $OUTPUT_DIR
@@ -24,10 +27,13 @@ generate_prod() {
   $UBOOT_BUILD_DIR/tools/image_table_util                                     \
   --append --print --print-images                                             \
   --out $OUTPUT_DIR/image_set.bin                                             \
+  --name "Piksi Buildroot $BR_GIT_VERSION"                                    \
+  --timestamp $(date +%s)                                                     \
+  --hardware $HW                                                              \
   --image $UBOOT_BUILD_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl      \
   --image $UBOOT_BUILD_DIR/u-boot.img --image-type uboot                      \
   --image $BINARIES_DIR/uImage.$CFG --image-type linux
 }
 
-generate_dev "piksiv3_microzed"
-generate_prod "piksiv3_microzed"
+generate_dev "microzed"
+generate_prod "microzed"

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = 8cf7c4dcc9b889cc672a8cfbf59930a440d7a0fa
+UBOOT_CUSTOM_VERSION = 9ba98aa5cca11c8fb56de944b992a1ce63d2b003
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools


### PR DESCRIPTION
Updates post image script to set additional version information.

E.g.
```
Image set header:
Name:         Piksi Buildroot 6d286b5
Version:      00000000
Timestamp:    57e19df5
Hardware:     00000001
Seq Num:      00000000
Image descriptor 0:
Type:         00000002
Name:         U-Boot 6911a76 for zynq board
Version:      00000000
Timestamp:    57e19dc3
Load Addr:    00000000
Entry Addr:   00000000
Data Offset:  00000900
Data Size:    0000eb97
Data CRC:     0f38fb72
```

TODO:
- [x] Update U-Boot pointer