### PR TITLE
Add clk_ignore_unused to bootargs

### DIFF
--- a/board/piksiv3/piksiv3_evt1.dts
+++ b/board/piksiv3/piksiv3_evt1.dts
@@ -28,7 +28,7 @@
   };
 
   chosen {
-    bootargs = "";
+    bootargs = "clk_ignore_unused";
     stdout-path = "serial0:115200n8";
   };
 

--- a/board/piksiv3/piksiv3_evt2.dts
+++ b/board/piksiv3/piksiv3_evt2.dts
@@ -28,7 +28,7 @@
   };
 
   chosen {
-    bootargs = "";
+    bootargs = "clk_ignore_unused";
     stdout-path = "serial0:115200n8";
   };
 

--- a/board/piksiv3/piksiv3_microzed.dts
+++ b/board/piksiv3/piksiv3_microzed.dts
@@ -28,7 +28,7 @@
   };
 
   chosen {
-    bootargs = "";
+    bootargs = "clk_ignore_unused";
     stdout-path = "serial0:115200n8";
   };
 


### PR DESCRIPTION
Prevents disabling of clocks unused by Linux (GPIO, SPI, etc.)