### PR TITLE
Default to static IP

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/network/interfaces
+++ b/board/piksiv3/rootfs-overlay/etc/network/interfaces
@@ -2,5 +2,7 @@ auto lo
 iface lo inet loopback
 
 auto eth0
-iface eth0 inet dhcp
-
+iface eth0 inet static
+    address 192.168.0.222
+    netmask 255.255.255.0
+    gateway 192.168.0.1


### PR DESCRIPTION
Use hardcoded static IP. Dev boot via network will overwrite config in `/etc/network/interfaces` at boot time with manual configuration provided by U-Boot.

This will be replaced by #46 

/cc @swift-nav/firmware 