### PR TITLE
Support for building in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 buildroot/
 .*.sw*
+build.out
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
 sudo: required
-dist: trusty
+#dist: trusty
 
 language: c
 
+services:
+  - docker
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential unzip
-  - sudo apt-get build-dep -y gcc
   - pip install --user --upgrade awscli
 
 install: true
 
 script:
-  - travis_wait 60 ./build.sh
+  - travis_wait 60 docker build -t piksi-buildroot .
 
 after_success:
+  - mkdir -p buildroot/output
+  - export CONTAINER=`docker create piksi-buildroot`
+  - docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
   - git fetch --tags --unshallow
   - PRODUCT_VERSION=v3 PRODUCT_REV=evt1 PRODUCT_TYPE=dev ./publish.sh buildroot/output/images/piksiv3_evt1_dev/*
   - PRODUCT_VERSION=v3 PRODUCT_REV=evt1 PRODUCT_TYPE=prod ./publish.sh buildroot/output/images/piksiv3_evt1_prod/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:trusty
+
+WORKDIR /app
+
+RUN apt-get update && apt-get -y --force-yes install \
+  build-essential \
+  git \
+  wget \
+  python \
+  unzip \
+  bc \
+  libssl-dev
+
+COPY . /app
+
+RUN /app/build.sh
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# Piksi v3 Buildroot
+# Piksi Multi Buildroot
 
-[Buildroot](https://buildroot.org/) for building Linux for Piksi v3. The resulting images go on the piksi's SD card. Run `./build.sh` to build locally (requires `gcc`).
+[![Build Status](https://travis-ci.org/swift-nav/piksi_buildroot.svg?branch=master)](https://travis-ci.org/swift-nav/piksi_buildroot)
+
+[Buildroot](https://buildroot.org/) configuration for building the Piksi Multi
+Linux system image.
+
+## Building
+
+### Linux Native
+
+Ensure you have the dependencies, see `Dockerfile` for details.
+
+Run
+
+``` sh
+./build.sh
+```
+
+### Docker
+
+Builds in a Linux container.
+
+``` sh
+docker build -t piksi-buildroot .
+```
+
+To copy the built images out of the Docker container:
+
+``` sh
+mkdir -p buildroot/output
+export CONTAINER=`docker create piksi-buildroot`
+docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
+```
+
+The buildroot images will now be in the `buildroot/output/images` folder.
+
+### Mac OS X
+
+Native OS X builds are not supported by Buildroot. Install
+[Docker for Mac](https://docs.docker.com/engine/installation/mac/) and then
+follow the directions for installing with Docker.
+

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,8 @@ export BR2_EXTERNAL=..
 export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export BUILD_OUTPUT=$WORKDIR/build.out
 
-touch $BUILD_OUTPUT
+# Create empty output file, or clear it if it already exists
+echo -n > $BUILD_OUTPUT
 
 dump_output() {
    echo Tailing the last 500 lines of output:

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ echo -n > $BUILD_OUTPUT
 
 dump_output() {
    echo Tailing the last 500 lines of output:
-   tail -500 $BUILD_OUTPUT  
+   tail -500 $BUILD_OUTPUT
 }
 error_handler() {
   echo ERROR: An error was encountered with the build.


### PR DESCRIPTION
**What:**
Buildroot only supports building under Linux. It would be helpful to have an easy way to build under OS X

**How:**
Using Docker we can define a repeatable build environment that can be used on any platform (including OS X). As a bonus, Docker is also supported by Travis allowing us to have consistency between our local and CI build environments.

The included Dockerfile sets up an Ubuntu linux container and installs the necessary dependencies before invoking the `build.sh` script.

**Testing:**
Tested locally on OS X as well as on Travis. S3 upload functionality on Travis and verified still working.

cc: @gsmcmullin @jacobmcnamee 