### PR TITLE
Download firmware from S3 and incorporate into Linux system images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 buildroot/
 .*.sw*
+build.out
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
 sudo: required
-dist: trusty
+#dist: trusty
 
 language: c
 
+services:
+  - docker
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential unzip
-  - sudo apt-get build-dep -y gcc
   - pip install --user --upgrade awscli
 
 install: true
 
 script:
-  - travis_wait 60 ./build.sh
+  - travis_wait 60 docker build -t piksi-buildroot .
 
 after_success:
+  - mkdir -p buildroot/output
+  - export CONTAINER=`docker create piksi-buildroot`
+  - docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
   - git fetch --tags --unshallow
   - PRODUCT_VERSION=v3 PRODUCT_REV=prod PRODUCT_TYPE=dev ./publish.sh buildroot/output/images/piksiv3_prod_dev/*
   - PRODUCT_VERSION=v3 PRODUCT_REV=prod PRODUCT_TYPE=prod ./publish.sh buildroot/output/images/piksiv3_prod_prod/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: required
-#dist: trusty
 
 language: c
 
@@ -9,7 +8,8 @@ services:
 before_install:
   - pip install --user --upgrade awscli
 
-install: true
+install:
+  - ./fetch_firmware.sh
 
 script:
   - travis_wait 60 docker build -t piksi-buildroot .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:trusty
+
+WORKDIR /app
+
+RUN apt-get update && apt-get -y --force-yes install \
+  build-essential \
+  git \
+  wget \
+  python \
+  unzip \
+  bc \
+  libssl-dev
+
+COPY . /app
+
+RUN /app/build.sh
+

--- a/README.md
+++ b/README.md
@@ -5,11 +5,37 @@
 [Buildroot](https://buildroot.org/) configuration for building the Piksi Multi
 Linux system image.
 
+## Fetching firmware images
+
+To build a production system image, the build process expects the following
+firmware and FPGA images to be present:
+
+```
+firmware/evt2/piksi_firmware.elf
+firmware/evt2/piksi_fpga.bit
+firmware/microzed/piksi_firmware.elf
+firmware/microzed/piksi_fpga.bit
+```
+
+You can use the following script to download these images from S3. Note that
+this script requires `awscli` to be installed and AWS credentials to be
+properly configured.
+
+``` sh
+./fetch-firmware.sh
+```
+
+Check `fetch-firmware.sh` to see which image versions are being used.
+
+Note, these firmware files are only used by the production system image. In the
+development system image these files are instead read from the network or SD
+card.
+
 ## Building
 
 ### Linux Native
 
-Ensure you have the dependencies, see `Dockerfile` for details.
+Ensure you have the dependencies, see `Dockerfile` for build dependencies.
 
 Run
 
@@ -17,12 +43,31 @@ Run
 ./build.sh
 ```
 
+### Mac OS X
+
+Native OS X builds are not supported by Buildroot. Install
+[Docker for Mac](https://docs.docker.com/engine/installation/mac/) and then
+follow the directions for installing with Docker.
+
 ### Docker
 
 Builds in a Linux container.
 
 ``` sh
 docker build -t piksi-buildroot .
+```
+
+To see the build output, tail the log file from inside Docker. First find the
+container ID by running:
+
+```
+docker ps
+```
+
+Then tail the log (replace `1a77fcce79ed` with your container ID):
+
+```
+docker exec -i -t 1a77fcce79ed tail -f /app/build.out
 ```
 
 To copy the built images out of the Docker container:
@@ -34,10 +79,4 @@ docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
 ```
 
 The buildroot images will now be in the `buildroot/output/images` folder.
-
-### Mac OS X
-
-Native OS X builds are not supported by Buildroot. Install
-[Docker for Mac](https://docs.docker.com/engine/installation/mac/) and then
-follow the directions for installing with Docker.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# Piksi v3 Buildroot
+# Piksi Multi Buildroot
 
-[Buildroot](https://buildroot.org/) for building Linux for Piksi v3. The resulting images go on the piksi's SD card. Run `./build.sh` to build locally (requires `gcc`).
+[![Build Status](https://travis-ci.org/swift-nav/piksi_buildroot.svg?branch=master)](https://travis-ci.org/swift-nav/piksi_buildroot)
+
+[Buildroot](https://buildroot.org/) configuration for building the Piksi Multi
+Linux system image.
+
+## Building
+
+### Linux Native
+
+Ensure you have the dependencies, see `Dockerfile` for details.
+
+Run
+
+``` sh
+./build.sh
+```
+
+### Docker
+
+Builds in a Linux container.
+
+``` sh
+docker build -t piksi-buildroot .
+```
+
+To copy the built images out of the Docker container:
+
+``` sh
+mkdir -p buildroot/output
+export CONTAINER=`docker create piksi-buildroot`
+docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
+```
+
+The buildroot images will now be in the `buildroot/output/images` folder.
+
+### Mac OS X
+
+Native OS X builds are not supported by Buildroot. Install
+[Docker for Mac](https://docs.docker.com/engine/installation/mac/) and then
+follow the directions for installing with Docker.
+

--- a/board/piksiv3/post_build.sh
+++ b/board/piksiv3/post_build.sh
@@ -10,8 +10,13 @@ FIRMWARE_DIR=$BASE_DIR/../../firmware
 # Create firmware directory in the rootfs
 mkdir -p $FIRMWARE_DIR_ROOTFS
 
+# Remove any existing firmware files
+rm -f $FIRMWARE_DIR_ROOTFS/piksi_firmware.elf
+rm -f $FIRMWARE_DIR_ROOTFS/piksi_fpga.bit
+
 # Install the piksi_firmware and piksi_fpga images into the rootfs
-if [ -e $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf && -e $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit ]; then
+if [ -e $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf && \
+     -e $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit ]; then
   cp $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf $FIRMWARE_DIR_ROOTFS/piksi_firmware.elf
   cp $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit $FIRMWARE_DIR_ROOTFS/piksi_fpga.bit
 else

--- a/board/piksiv3/post_build.sh
+++ b/board/piksiv3/post_build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "Installing firmware images for hardware configuration: $HW_CONFIG"
+
+ROOTFS=$1
+FIRMWARE_DIR_ROOTFS=$ROOTFS/lib/firmware
+FIRMWARE_DIR=$BASE_DIR/../../firmware
+
+# Create firmware directory in the rootfs
+mkdir -p $FIRMWARE_DIR_ROOTFS
+
+# Install the piksi_firmware and piksi_fpga images into the rootfs
+if [ -e $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf && -e $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit ]; then
+  cp $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf $FIRMWARE_DIR_ROOTFS/piksi_firmware.elf
+  cp $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit $FIRMWARE_DIR_ROOTFS/piksi_fpga.bit
+else
+  echo "*** NO FIRMWARE FILES FOUND, SKIPPING ***"
+fi
+

--- a/board/piksiv3/post_build.sh
+++ b/board/piksiv3/post_build.sh
@@ -15,8 +15,8 @@ rm -f $FIRMWARE_DIR_ROOTFS/piksi_firmware.elf
 rm -f $FIRMWARE_DIR_ROOTFS/piksi_fpga.bit
 
 # Install the piksi_firmware and piksi_fpga images into the rootfs
-if [ -e $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf && \
-     -e $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit ]; then
+if [ -e $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf ] && \
+   [ -e $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit ]; then
   cp $FIRMWARE_DIR/$HW_CONFIG/piksi_firmware.elf $FIRMWARE_DIR_ROOTFS/piksi_firmware.elf
   cp $FIRMWARE_DIR/$HW_CONFIG/piksi_fpga.bit $FIRMWARE_DIR_ROOTFS/piksi_fpga.bit
 else

--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -12,7 +12,6 @@ generate_dev() {
   cp $UBOOT_BUILD_DIR/spl/boot.bin $OUTPUT_DIR
   cp $UBOOT_BUILD_DIR/u-boot.img $OUTPUT_DIR
   cp $BINARIES_DIR/uImage.${CFG} $OUTPUT_DIR
-  cp $BINARIES_DIR/rootfs.cpio $OUTPUT_DIR
 }
 
 generate_prod() {
@@ -24,7 +23,6 @@ generate_prod() {
 
   mkdir -p $OUTPUT_DIR
   cp $UBOOT_BUILD_DIR/tpl/boot.bin $OUTPUT_DIR
-  cp $BINARIES_DIR/rootfs.cpio $OUTPUT_DIR
 
   $UBOOT_BUILD_DIR/tools/image_table_util                                     \
   --append --print --print-images                                             \

--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -40,8 +40,8 @@ generate_prod() {
 generate_dev $HW_CONFIG
 
 FIRMWARE_DIR=$TARGET_DIR/lib/firmware
-if [ -e $FIRMWARE_DIR/piksi_firmware.elf && \
-     -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
+if [ -e $FIRMWARE_DIR/piksi_firmware.elf ] && \
+   [ -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
   generate_prod $HW_CONFIG
 else
   echo "*** NO FIRMWARE FILES FOUND, NOT BUILDING PRODUCTION IMAGE ***"

--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -38,7 +38,14 @@ generate_prod() {
 }
 
 generate_dev $HW_CONFIG
-generate_prod $HW_CONFIG
+
+FIRMWARE_DIR=$TARGET_DIR/lib/firmware
+if [ -e $FIRMWARE_DIR/piksi_firmware.elf && \
+     -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
+  generate_prod $HW_CONFIG
+else
+  echo "*** NO FIRMWARE FILES FOUND, NOT BUILDING PRODUCTION IMAGE ***"
+fi
 
 # Images for this HW_CONFIG have been moved into their relavant output folder,
 # remove the copies from the root of BINARIES_DIR

--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -12,6 +12,7 @@ generate_dev() {
   cp $UBOOT_BUILD_DIR/spl/boot.bin $OUTPUT_DIR
   cp $UBOOT_BUILD_DIR/u-boot.img $OUTPUT_DIR
   cp $BINARIES_DIR/uImage.${CFG} $OUTPUT_DIR
+  cp $BINARIES_DIR/rootfs.cpio $OUTPUT_DIR
 }
 
 generate_prod() {
@@ -23,19 +24,23 @@ generate_prod() {
 
   mkdir -p $OUTPUT_DIR
   cp $UBOOT_BUILD_DIR/tpl/boot.bin $OUTPUT_DIR
+  cp $BINARIES_DIR/rootfs.cpio $OUTPUT_DIR
 
   $UBOOT_BUILD_DIR/tools/image_table_util                                     \
   --append --print --print-images                                             \
   --out $OUTPUT_DIR/image_set.bin                                             \
   --name "Piksi Buildroot $BR_GIT_VERSION"                                    \
   --timestamp $(date +%s)                                                     \
-  --hardware v3_$HW                                                              \
+  --hardware v3_$HW                                                           \
   --image $UBOOT_BUILD_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl      \
   --image $UBOOT_BUILD_DIR/u-boot.img --image-type uboot                      \
   --image $BINARIES_DIR/uImage.$CFG --image-type linux
 }
 
-generate_dev "microzed"
-generate_prod "microzed"
-generate_dev "prod"
-generate_prod "prod"
+generate_dev $HW_CONFIG
+generate_prod $HW_CONFIG
+
+# Images for this HW_CONFIG have been moved into their relavant output folder,
+# remove the copies from the root of BINARIES_DIR
+rm -f $BINARIES_DIR/uImage.*
+rm -f $BINARIES_DIR/rootfs.cpio

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -42,6 +42,18 @@ start() {
   dev_boot=`cat /proc/device-tree/chosen/bootargs |
             sed -n -e 's/^.*dev_boot=\([^ ]*\).*/\1/p'`
 
+  # Delete any firmware files that were already present in the rootfs.
+  # In the dev configuration we want to obtain the firmware from the SD card or
+  # network and this ensures if these files are not available from the SD card
+  # or network we will error out rather than silently falling back to the
+  # version present in the rootfs.
+  if [ -n "$dev_boot" ]; then
+    # If dev_boot is set to something (not null), then we are in the dev
+    # configuration
+    rm -f $output_path/piksi_firmware.elf
+    rm -f $output_path/piksi_fpga.bit
+  fi
+
   if [ "$dev_boot" == "sd" ]; then
     sd_path="/media/mmcblk0p1"
     copy_from_sd $sd_path "piksi_firmware.elf"

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,8 @@ export BR2_EXTERNAL=..
 export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export BUILD_OUTPUT=$WORKDIR/build.out
 
-touch $BUILD_OUTPUT
+# Create empty output file, or clear it if it already exists
+echo -n > $BUILD_OUTPUT
 
 dump_output() {
    echo Tailing the last 500 lines of output:

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,8 @@ trap 'error_handler' ERR
 git clone --depth=1 git://git.buildroot.net/buildroot -b 2016.08
 pushd buildroot
 make piksiv3_defconfig >> $BUILD_OUTPUT 2>&1
-make >> $BUILD_OUTPUT 2>&1
+HW_CONFIG="prod" make >> $BUILD_OUTPUT 2>&1
+HW_CONFIG="microzed" make >> $BUILD_OUTPUT 2>&1
 popd
 
 # The build finished without returning an error so dump a tail of the output

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ echo -n > $BUILD_OUTPUT
 
 dump_output() {
    echo Tailing the last 500 lines of output:
-   tail -500 $BUILD_OUTPUT  
+   tail -500 $BUILD_OUTPUT
 }
 error_handler() {
   echo ERROR: An error was encountered with the build.

--- a/configs/piksiv3_defconfig
+++ b/configs/piksiv3_defconfig
@@ -12,6 +12,7 @@ BR2_ROOTFS_DEVICE_TABLE="$(BR2_EXTERNAL)/board/piksiv3/device_table.txt"
 # BR2_TARGET_GENERIC_GETTY is not set
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL)/board/piksiv3/rootfs-overlay"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="$(BR2_EXTERNAL)/board/piksiv3/post_image.sh"
+BR2_ROOTFS_POST_BUILD_SCRIPT="$(BR2_EXTERNAL)/board/piksiv3/post_build.sh"
 BR2_LINUX_KERNEL=y
 BR2_LINUX_KERNEL_CUSTOM_GIT=y
 BR2_LINUX_KERNEL_CUSTOM_REPO_URL="git://github.com/Xilinx/linux-xlnx.git"

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -20,6 +20,7 @@ NAP_VERSION=v3.6.0
 
 FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3
 NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION/v3
+export AWS_DEFAULT_REGION="us-west-2"
 
 download_fw() {
   HW_CONFIG=$1
@@ -31,13 +32,14 @@ download_fw() {
   # Download piksi_firmware
   aws s3 cp $FW_S3_PATH/piksi_firmware_v3_$HW_CONFIG.elf $FIRMWARE_DIR/piksi_firmware.elf
 
-  # Microzed FPGA image breaks the naming convention so deal with it as a special case
+  # Download piksi_fpga
   if [ "$HW_CONFIG" == "microzed" ]; then
-    HW_CONFIG="microzed_nt1065"
+    # Microzed FPGA image breaks the naming convention so deal with it as a special case
+    aws s3 cp $NAP_S3_PATH/piksi_microzed_nt1065_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
+  else
+    aws s3 cp $NAP_S3_PATH/piksi_${HW_CONFIG}_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
   fi
 
-  # Download piksi_fpga
-  aws s3 cp $NAP_S3_PATH/piksi_${HW_CONFIG}_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
 }
 
 download_fw "evt2"

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,7 +15,7 @@
 
 set -xe
 
-FW_VERSION=pm_alpha_rc2
+FW_VERSION=beta_rc2
 NAP_VERSION=v3.6.0
 
 FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (C) 2016 Swift Navigation Inc.
+# Contact: Fergus Noble <fergus@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Script for downloading firmware and NAP binaries from S3 to be incorporated
+# into the Linux image.
+
+set -xe
+
+FW_VERSION=pm_alpha_rc2
+NAP_VERSION=v3.6.0
+
+FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3
+NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION/v3
+
+download_fw() {
+  HW_CONFIG=$1
+  FIRMWARE_DIR=firmware/$HW_CONFIG
+
+  # Make firmware download dir
+  mkdir -p $FIRMWARE_DIR
+
+  # Download piksi_firmware
+  aws s3 cp $FW_S3_PATH/piksi_firmware_v3_$HW_CONFIG.elf $FIRMWARE_DIR/piksi_firmware.elf
+
+  # Microzed FPGA image breaks the naming convention so deal with it as a special case
+  if [ "$HW_CONFIG" == "microzed" ]; then
+    HW_CONFIG="microzed_nt1065"
+  fi
+
+  # Download piksi_fpga
+  aws s3 cp $NAP_S3_PATH/piksi_${HW_CONFIG}_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
+}
+
+download_fw "evt2"
+download_fw "microzed"
+

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -30,7 +30,8 @@ download_fw() {
   mkdir -p $FIRMWARE_DIR
 
   # Download piksi_firmware
-  aws s3 cp $FW_S3_PATH/piksi_firmware_v3_$HW_CONFIG.elf $FIRMWARE_DIR/piksi_firmware.elf
+  aws s3 cp $FW_S3_PATH/piksi_firmware_v3_$HW_CONFIG.stripped.elf \
+    $FIRMWARE_DIR/piksi_firmware.elf
 
   # Download piksi_fpga
   if [ "$HW_CONFIG" == "microzed" ]; then

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,11 +15,11 @@
 
 set -xe
 
-FW_VERSION=beta_rc2
-NAP_VERSION=v3.6.0
+FW_VERSION=beta_rc2-14-g12b4e7e
+NAP_VERSION=v3.6.2
 
 FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3
-NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION/v3
+NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION
 export AWS_DEFAULT_REGION="us-west-2"
 
 download_fw() {
@@ -43,6 +43,6 @@ download_fw() {
 
 }
 
-download_fw "evt2"
+download_fw "prod"
 download_fw "microzed"
 


### PR DESCRIPTION
**What:**
We currently build two different system images, production (prod) and development (dev). In the development configuration the firmware and FPGA images are loaded either from the SD card or from the network over TFTP. However in the production configuration we want these images to be incorporated into the system image, and any images present on the SD card or network should be ignored. This pull request implements downloading a specified set of firmware and FPGA images and incorporating them into the system image such that they are used in the production configuration.

**How:**
A script `fetch_firmware.sh` is added which downloads the firmware images for the various hardware configurations from the S3 artifacts bucket. These images are specified by a version string in the script.

The buildroot configuration is modified to add a `post_build.sh` script which copies the firmware files into the rootfs. We also modify the dev configuration init process to ensure these files aren't used unless we are in the production configuration.

If the `fetch_firmware.sh` isn't run and there are no firmware files available then the build will still run but it will only produce a dev image, not a production image.

**Testing:**

 - Local build (Docker / OS X), no firmware files fetched
   - Dev configuration
     - [x] Boots ok with firmware / fpga image present on SD card
     - [x] Fails to boot without firmware / fpga image present on SD card
     - [x] Firmware / FPGA images not present in rootfs
   - Prod configuration
     - [x] No production images generated when no firmware files present
 - Local build (Docker / OS X), firmware files fetched
   - Dev configuration
     - [x] Boots ok with firmware / fpga image present on SD card
     - [x] Fails to boot without firmware / fpga image present on SD card
     - [x] Firmware / FPGA images present in rootfs (not necessary, but expected)
     - [x] Firmware / FPGA images not present in ramfs after init has wiped them out, if no images loaded from SD card
   - Prod configuration
     - [x] `fetch_firmware.sh` successfully downloads firmware files
     - [x] Boots ok without firmware / fpga image present on SD card
     - [x] Boots built in firmware / fpga, even if images are present on SD card
     - [x] Firmware / FPGA images present in rootfs
 - Travis build
   - [x] Succeeds
   - [x] Images uploaded to S3 artifacts
   - [x] dev image boots ok with firmware / fpga files present on SD card
   - [x] prod image boots ok without firmware / fpga files present on SD card

Closes: swift-nav/firmware_team_planning#223

Supersedes #45, moved to branch under swift-nav for credentials