### PR TITLE
Turn off serial console output

### DIFF
--- a/board/piksiv3/piksiv3_microzed.dts
+++ b/board/piksiv3/piksiv3_microzed.dts
@@ -29,7 +29,6 @@
 
   chosen {
     bootargs = "clk_ignore_unused";
-    stdout-path = "serial0:115200n8";
   };
 
   usb_phy0: phy0 {

--- a/board/piksiv3/piksiv3_prod.dts
+++ b/board/piksiv3/piksiv3_prod.dts
@@ -29,7 +29,6 @@
 
   chosen {
     bootargs = "clk_ignore_unused";
-    stdout-path = "serial0:115200n8";
   };
 
   usb_phy0: phy0 {


### PR DESCRIPTION
To re-enable:
`env set bootargs console=ttyPS1,115200`

TODO:
- [ ] Update U-Boot: https://github.com/swift-nav/u-boot-xlnx/pull/19

/cc @swift-nav/firmware 