### PR TITLE
Fix firmware TFTP load from OS X tftpd

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -24,7 +24,7 @@ copy_from_net() {
   local server_ip=$1
   local filename=$2
   local uuid=`cat /factory/uuid`
-  local net_file="/PK$uuid/$filename"
+  local net_file="PK$uuid/$filename"
   local output_file="$output_path/$filename"
 
   rm -f "$output_file"


### PR DESCRIPTION
OS X tftpd doesn't like the absolute path. The linux one should work with either.

cc: @jacobmcnamee 