### PR TITLE
Do not delete files from output images folder

### DIFF
--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -45,7 +45,3 @@ else
   echo "*** NO FIRMWARE FILES FOUND, NOT BUILDING PRODUCTION IMAGE ***"
 fi
 
-# Images for this HW_CONFIG have been moved into their relavant output folder,
-# remove the copies from the root of BINARIES_DIR
-rm -f $BINARIES_DIR/uImage.*
-rm -f $BINARIES_DIR/rootfs.cpio


### PR DESCRIPTION
Deleting `rootfs.cpio` from `buildroot/output/images` can cause incremental builds to fail.

/cc @fnoble @swift-nav/firmware