### PR TITLE
Turn off serial console output

### DIFF
--- a/board/piksiv3/piksiv3_microzed.dts
+++ b/board/piksiv3/piksiv3_microzed.dts
@@ -29,7 +29,6 @@
 
   chosen {
     bootargs = "clk_ignore_unused";
-    stdout-path = "serial0:115200n8";
   };
 
   usb_phy0: phy0 {

--- a/board/piksiv3/piksiv3_prod.dts
+++ b/board/piksiv3/piksiv3_prod.dts
@@ -29,7 +29,6 @@
 
   chosen {
     bootargs = "clk_ignore_unused";
-    stdout-path = "serial0:115200n8";
   };
 
   usb_phy0: phy0 {

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = bc54bae9cb9397e1e3b20df9055bf1a5a1289cc1
+UBOOT_CUSTOM_VERSION = a2c7fed133a64cdb4cff6d200e5504b4a346424e
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools


### PR DESCRIPTION
Supersedes #51 

- Serial stdout disabled by default in device tree, re-enable via bootarg `console=ttyPS1,115200`
- U-Boot `dev` config updated to enable stdout via bootarg

TODO:
- [x] Update U-Boot: https://github.com/swift-nav/u-boot-xlnx/pull/19

/cc @swift-nav/firmware 