### PR TITLE
Use image table boot for dev config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,8 @@ after_success:
   - export CONTAINER=`docker create piksi-buildroot`
   - docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
   - git fetch --tags --unshallow
-  - PRODUCT_VERSION=v3 PRODUCT_REV=prod PRODUCT_TYPE=dev ./publish.sh buildroot/output/images/piksiv3_prod_dev/*
-  - PRODUCT_VERSION=v3 PRODUCT_REV=prod PRODUCT_TYPE=prod ./publish.sh buildroot/output/images/piksiv3_prod_prod/*
-  - PRODUCT_VERSION=v3 PRODUCT_REV=microzed PRODUCT_TYPE=dev ./publish.sh buildroot/output/images/piksiv3_microzed_dev/*
-  - PRODUCT_VERSION=v3 PRODUCT_REV=microzed PRODUCT_TYPE=prod ./publish.sh buildroot/output/images/piksiv3_microzed_prod/*
+  - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh buildroot/output/images/piksiv3_prod/*
+  - PRODUCT_VERSION=v3 PRODUCT_REV=microzed ./publish.sh buildroot/output/images/piksiv3_microzed/*
   - SLACK_CHANNEL=github ./comment.sh
 
 env:

--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -1,66 +1,62 @@
 #!/bin/sh
 
-UBOOT_DIR=`find $BUILD_DIR -maxdepth 1 -type d -name uboot_custom-*`
-FIRMWARE_DIR=$TARGET_DIR/lib/firmware
+CFG=piksiv3_$HW_CONFIG
 BR_GIT_VERSION=$(git -C $BR2_EXTERNAL describe --tags --dirty                 \
                      --always --match 'v[0-9]\.[0-9]')
 # remove the githash from the filename for useability (leave it in the header)
 FILE_GIT_VERSION=${BR_GIT_VERSION%%-g*}
 
+OUTPUT_DIR=$BINARIES_DIR/${CFG}
+FIRMWARE_DIR=$TARGET_DIR/lib/firmware
+UBOOT_BASE_DIR=`find $BUILD_DIR -maxdepth 1 -type d -name uboot_custom-*`
+UBOOT_PROD_DIR=$UBOOT_BASE_DIR/build/${CFG}_prod
+UBOOT_DEV_DIR=$UBOOT_BASE_DIR/build/${CFG}_dev
+
 generate_dev() {
-  local HW=$1
-  local CFG=piksiv3_$HW
-  local UBOOT_BUILD_DIR=$UBOOT_DIR/build/${CFG}_dev
-  local OUTPUT_DIR=$BINARIES_DIR/${CFG}_dev
+  $UBOOT_DEV_DIR/tools/mkimage                                                \
+  -A arm -T firmware -C none -O u-boot -n "FPGA bitstream"                    \
+  -d $FIRMWARE_DIR/piksi_fpga.bit                                             \
+  $OUTPUT_DIR/piksi_fpga.img
 
-  mkdir -p $OUTPUT_DIR
-  cp $BINARIES_DIR/uImage.${CFG} $OUTPUT_DIR
-
-  if [ -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
-    $UBOOT_BUILD_DIR/tools/mkimage                                            \
-    -A arm -T firmware -C none -O u-boot -n "FPGA bitstream"                  \
-    -d $FIRMWARE_DIR/piksi_fpga.bit                                           \
-    $OUTPUT_DIR/piksi_fpga.img
-
-    $UBOOT_BUILD_DIR/tools/image_table_util                                   \
-    --append --print --print-images                                           \
-    --out $OUTPUT_DIR/PiksiMulti-DEV-$FILE_GIT_VERSION.bin                    \
-    --name "Piksi Buildroot DEV $BR_GIT_VERSION"                              \
-    --timestamp $(date +%s)                                                   \
-    --hardware v3_$HW                                                         \
-    --image $UBOOT_BUILD_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl    \
-    --image $UBOOT_BUILD_DIR/u-boot.img --image-type uboot                    \
-    --image $OUTPUT_DIR/piksi_fpga.img --image-type fpga
-  fi
+  $UBOOT_DEV_DIR/tools/image_table_util                                       \
+  --append --print --print-images                                             \
+  --out $OUTPUT_DIR/PiksiMulti-DEV-$FILE_GIT_VERSION.bin                      \
+  --name "Piksi Buildroot DEV $BR_GIT_VERSION"                                \
+  --timestamp $(date +%s)                                                     \
+  --hardware v3_$HW_CONFIG                                                    \
+  --image $UBOOT_DEV_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl        \
+  --image $UBOOT_DEV_DIR/u-boot.img --image-type uboot                        \
+  --image $OUTPUT_DIR/piksi_fpga.img --image-type fpga
 
   rm $OUTPUT_DIR/piksi_fpga.img
 }
 
 generate_prod() {
-  local HW=$1
-  local CFG=piksiv3_$HW
-  local UBOOT_BUILD_DIR=$UBOOT_DIR/build/${CFG}_prod
-  local OUTPUT_DIR=$BINARIES_DIR/${CFG}_prod
-
-  mkdir -p $OUTPUT_DIR
-  cp $UBOOT_BUILD_DIR/tpl/boot.bin $OUTPUT_DIR
-
-  $UBOOT_BUILD_DIR/tools/image_table_util                                     \
+  $UBOOT_PROD_DIR/tools/image_table_util                                      \
   --append --print --print-images                                             \
   --out $OUTPUT_DIR/PiksiMulti-$FILE_GIT_VERSION.bin                          \
   --name "Piksi Buildroot $BR_GIT_VERSION"                                    \
   --timestamp $(date +%s)                                                     \
-  --hardware v3_$HW                                                           \
-  --image $UBOOT_BUILD_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl      \
-  --image $UBOOT_BUILD_DIR/u-boot.img --image-type uboot                      \
+  --hardware v3_$HW_CONFIG                                                    \
+  --image $UBOOT_PROD_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl       \
+  --image $UBOOT_PROD_DIR/u-boot.img --image-type uboot                       \
   --image $BINARIES_DIR/uImage.$CFG --image-type linux
 }
 
-generate_dev $HW_CONFIG
+mkdir -p $OUTPUT_DIR
+
+cp $UBOOT_PROD_DIR/tpl/boot.bin $OUTPUT_DIR
+cp $BINARIES_DIR/uImage.${CFG} $OUTPUT_DIR
+
+if [ -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
+  generate_dev
+else
+  echo "*** NO FPGA FIRMWARE FOUND, NOT BUILDING DEVELOPMENT IMAGE ***"
+fi
 
 if [ -e $FIRMWARE_DIR/piksi_firmware.elf ] && \
    [ -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
-  generate_prod $HW_CONFIG
+  generate_prod
 else
   echo "*** NO FIRMWARE FILES FOUND, NOT BUILDING PRODUCTION IMAGE ***"
 fi

--- a/board/piksiv3/post_image.sh
+++ b/board/piksiv3/post_image.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 UBOOT_DIR=`find $BUILD_DIR -maxdepth 1 -type d -name uboot_custom-*`
+FIRMWARE_DIR=$TARGET_DIR/lib/firmware
+BR_GIT_VERSION=$(git -C $BR2_EXTERNAL describe --tags --dirty                 \
+                     --always --match 'v[0-9]\.[0-9]')
+# remove the githash from the filename for useability (leave it in the header)
+FILE_GIT_VERSION=${BR_GIT_VERSION%%-g*}
 
 generate_dev() {
   local HW=$1
@@ -9,9 +14,26 @@ generate_dev() {
   local OUTPUT_DIR=$BINARIES_DIR/${CFG}_dev
 
   mkdir -p $OUTPUT_DIR
-  cp $UBOOT_BUILD_DIR/spl/boot.bin $OUTPUT_DIR
-  cp $UBOOT_BUILD_DIR/u-boot.img $OUTPUT_DIR
   cp $BINARIES_DIR/uImage.${CFG} $OUTPUT_DIR
+
+  if [ -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
+    $UBOOT_BUILD_DIR/tools/mkimage                                            \
+    -A arm -T firmware -C none -O u-boot -n "FPGA bitstream"                  \
+    -d $FIRMWARE_DIR/piksi_fpga.bit                                           \
+    $OUTPUT_DIR/piksi_fpga.img
+
+    $UBOOT_BUILD_DIR/tools/image_table_util                                   \
+    --append --print --print-images                                           \
+    --out $OUTPUT_DIR/PiksiMulti-DEV-$FILE_GIT_VERSION.bin                    \
+    --name "Piksi Buildroot DEV $BR_GIT_VERSION"                              \
+    --timestamp $(date +%s)                                                   \
+    --hardware v3_$HW                                                         \
+    --image $UBOOT_BUILD_DIR/spl/u-boot-spl-dtb.img --image-type uboot-spl    \
+    --image $UBOOT_BUILD_DIR/u-boot.img --image-type uboot                    \
+    --image $OUTPUT_DIR/piksi_fpga.img --image-type fpga
+  fi
+
+  rm $OUTPUT_DIR/piksi_fpga.img
 }
 
 generate_prod() {
@@ -19,15 +41,13 @@ generate_prod() {
   local CFG=piksiv3_$HW
   local UBOOT_BUILD_DIR=$UBOOT_DIR/build/${CFG}_prod
   local OUTPUT_DIR=$BINARIES_DIR/${CFG}_prod
-  local BR_GIT_VERSION=$(git -C $BR2_EXTERNAL describe --tags --dirty --always --match 'v[0-9]\.[0-9]')
-  # remove the githash from the filename for useability (leave it in the header)
-  local FILE_GIT_VERSION=${BR_GIT_VERSION%%-g*} 
+
   mkdir -p $OUTPUT_DIR
   cp $UBOOT_BUILD_DIR/tpl/boot.bin $OUTPUT_DIR
 
   $UBOOT_BUILD_DIR/tools/image_table_util                                     \
   --append --print --print-images                                             \
-  --out $OUTPUT_DIR/PiksiMulti-$FILE_GIT_VERSION.bin                           \
+  --out $OUTPUT_DIR/PiksiMulti-$FILE_GIT_VERSION.bin                          \
   --name "Piksi Buildroot $BR_GIT_VERSION"                                    \
   --timestamp $(date +%s)                                                     \
   --hardware v3_$HW                                                           \
@@ -38,7 +58,6 @@ generate_prod() {
 
 generate_dev $HW_CONFIG
 
-FIRMWARE_DIR=$TARGET_DIR/lib/firmware
 if [ -e $FIRMWARE_DIR/piksi_firmware.elf ] && \
    [ -e $FIRMWARE_DIR/piksi_fpga.bit ]; then
   generate_prod $HW_CONFIG

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = a2c7fed133a64cdb4cff6d200e5504b4a346424e
+UBOOT_CUSTOM_VERSION = 9163a035e5c0ccfeddc1a9951cbf1f57a788cef2
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools


### PR DESCRIPTION
Changes to support https://github.com/swift-nav/u-boot-xlnx/pull/20.
- Generate image set for `dev` config with U-Boot and FPGA images
- Merge `dev` and `prod` output folders

TODO:
- [x] Update U-Boot https://github.com/swift-nav/u-boot-xlnx/pull/20
- [x] Test