### PR TITLE
Add sleep to upgrade init script, don't delete file or reboot afterwards

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S84upgrade_tool
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S84upgrade_tool
@@ -1,10 +1,22 @@
 #!/bin/sh
 
+_mount() {
+    [[ $# -lt 3 ]] && { 
+        echo "Usage: ${FUNCNAME} <timeout_ms> <dev> <mnt_point>"; return 1
+    }
+    repeats="${1}"
+    until mount "${2} ${3}" 2>/dev/null || [[ $repeats -lt 1 ]]; do
+       $(( repeats-- )) 
+       usleep 1000
+    done
+}
+
+
 start() {
   export FIRMWARE="/media/sda1/PiksiMulti-*.bin"
   export LOGLEVEL="--warn"
-  # Sleep briefly to allow the automounting of flashdrive
-  sleep 0.5 
+  # try and mount for up to 0.5 seconds or until success 
+  _mount 500 /dev/sda1 /media/sda1
   if [ `echo $FIRMWARE | wc -w` != '1' ]; then
     echo 'Upgrade requires exactly one firmware image' | sbp_log $LOGLEVEL
     exit

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S84upgrade_tool
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S84upgrade_tool
@@ -2,8 +2,9 @@
 
 start() {
   export FIRMWARE="/media/sda1/PiksiMulti-*.bin"
-  export LOGLEVEL="--info"
-
+  export LOGLEVEL="--warn"
+  # Sleep briefly to allow the automounting of flashdrive
+  sleep 0.5 
   if [ `echo $FIRMWARE | wc -w` != '1' ]; then
     echo 'Upgrade requires exactly one firmware image' | sbp_log $LOGLEVEL
     exit
@@ -13,12 +14,15 @@ start() {
     exit
   fi
 
-  echo "New firmware image set detected: $FIRMWARE" | sbp_log $LOGLEVEL
+  echo "New firmware image set detected: `ls $FIRMWARE`" | sbp_log $LOGLEVEL
   echo "Performing upgrade..." | sbp_log $LOGLEVEL
   upgrade_tool --debug $FIRMWARE | sbp_log $LOGLEVEL
-  rm $FIRMWARE
+  umount /media/sda1
   sync
-  reboot -f
+  while [ 1 ]; do 
+    echo "Please remove upgrade media and reboot."  | sbp_log $LOGLEVEL
+    sleep 1
+  done
 }
 
 stop() {


### PR DESCRIPTION
/cc @gsmcmullin @jacobmcnamee 

This works reliably on prod for me after adding the sleep.

- I changed the default warn level to warn (as that is the default level on the console and I wouldn't want to hide the messages)
- I also got rid of deleting the file and rebooting as it wasn't very user friendly.  This way, the user knows things were completed and isn't left guessing what happened.  Also the user would be able to take the flash drive and update another device afterwards.
- I lastly echoed the real name of the file


In the future we would like to:
- Blink PV led during upgrade
- Blink PV led afterwards differently
- make the serial output useful to someone in a plain text terminal as well as piksi console (maybe add some line breaks or something)
- Compare software versions on the file (from the header) and do not upgrade if it is identical to current software version