### PR TITLE
GSerial fix

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/adapter_uart.inc.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/adapter_uart.inc.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+name="zmq_adapter_uart_$ttydev"
+cmd="zmq_adapter --file /dev/$ttydev -p >tcp://127.0.0.1:43031 -s >tcp://127.0.0.1:43030 -f sbp $filter_options"
+dir="/"
+user=""
+
+#source /etc/init.d/template_process.inc.sh
+


### PR DESCRIPTION
Fixes gserial issue that results in USB port not working and the following error:

`/etc/init.d/S83zmq_adapter_gserial: /etc/init.d/S83zmq_adapter_gserial: source: line 6: can't open '/etc/init.d/adapter_uart.inc.sh'`

cc: @denniszollo 