### PR TITLE
Allow any /sda/* device to hold the FW

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/ash
 
-export FIRMWARE="/media/sda1/PiksiMulti-*.bin"
+export FIRMWARE="/media/sda*/PiksiMulti-*.bin"
 export LOGLEVEL="--warn"
 
 _dir_wait () {


### PR DESCRIPTION
should solve:
https://github.com/swift-nav/piksi_v3_bug_tracking/issues/190
We do need to consider weird cases (usb hubs, other sda devices plugged in); any thoughts?

**Testing**
 


- [x] bench testing - upgrade works on a device formatted on osx with an EFI Partition

/cc @gsmcmullin @cbeighley @zakaswift 