### PR TITLE
Increase firmware memory allocation (master)

### DIFF
--- a/board/piksiv3/piksiv3.dtsi
+++ b/board/piksiv3/piksiv3.dtsi
@@ -15,7 +15,7 @@
 / {
   remoteproc0: remoteproc@0 {
     compatible = "xlnx,zynq_remoteproc";
-    reg = < 0x1E000000 0x02000000 >;
+    reg = <0x1C000000 0x04000000>;
     interrupt-parent = <&intc>;
     interrupts =
         <0 20 4>,                                 /* GPIO */

--- a/board/piksiv3/piksiv3_microzed.dts
+++ b/board/piksiv3/piksiv3_microzed.dts
@@ -26,7 +26,7 @@
 
   memory {
     device_type = "memory";
-    reg = <0x0 0x1E000000>;
+    reg = <0x0 0x1C000000>;
   };
 
   chosen {

--- a/board/piksiv3/piksiv3_prod.dts
+++ b/board/piksiv3/piksiv3_prod.dts
@@ -26,7 +26,7 @@
 
   memory {
     device_type = "memory";
-    reg = <0x0 0x1E000000>;
+    reg = <0x0 0x1C000000>;
   };
 
   chosen {

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,7 +15,7 @@
 
 set -xe
 
-FW_VERSION=${1:-v1.0.0-branch-13-g10193c9}
+FW_VERSION=${1:-v1.0.0-branch-21-gd6e3871}
 NAP_VERSION=${2:-v1.0.1}
 
 FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3


### PR DESCRIPTION
Increase firmware memory allocation from 32MB to 64MB.

TODO:
- [ ] Update firmware https://github.com/swift-nav/piksi_firmware_private/pull/456
- [ ] Test

/cc @swift-nav/firmware @benjamin0 