### PR TITLE
Fix UART port mode and baud rate settings (master)

### DIFF
--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -172,6 +172,7 @@ bool port_mode_notify(struct setting *s, const char *val)
     return false;
   }
 
+  *(u8*)s->addr = port_mode;
   return true;
 }
 

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -174,6 +174,8 @@ bool port_mode_notify(struct setting *s, const char *val)
   /* Create a new zmq_adapter. */
   if (!(*pid = fork())) {
     execvp(args[0], args);
+    printf("execvp error\n");
+    exit(EXIT_FAILURE);
   }
 
   printf("zmq_adapter started with PID: %d\n", *pid);


### PR DESCRIPTION
UART port mode and baud rate settings values were not being saved due to bugs in `piksi_system_daemon`.

For baud rate, ignoring `SIGCHLD` prevented `system()` from obtaining the exit status of the child process, causing `system()` to return an error and the setting to not be committed. The requested command generally still executed.

For port mode, the setting was erroneously never committed.

Resolves https://github.com/swift-nav/piksi_v3_bug_tracking/issues/197

TODO:
- [x] Rebase once #91 is merged
- [x] Test

/cc @swift-nav/firmware 