### PR TITLE
Update FW ptr to latest v1.0.0-release branch (release)

### DIFF
--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,7 +15,7 @@
 
 set -xe
 
-FW_VERSION=${1:-v1.0.1}
+FW_VERSION=${1:-v1.0.1-2-g1d9a461}
 NAP_VERSION=${2:-v1.0.1}
 
 FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3


### PR DESCRIPTION
Accomodates https://github.com/swift-nav/piksi_firmware_private/pull/462.