### PR TITLE
Configure UARTs in piksi_system_daemon, implement HW flow control

### DIFF
--- a/board/piksiv3/patches/linux/0002-tty-serial-xuartps-Implement-automatic-RTC-CTS-flow-.patch
+++ b/board/piksiv3/patches/linux/0002-tty-serial-xuartps-Implement-automatic-RTC-CTS-flow-.patch
@@ -1,0 +1,66 @@
+From 2154e128f8450d285fd7b7eb8265dbe6a8c43e60 Mon Sep 17 00:00:00 2001
+From: Jacob McNamee <jacob@swiftnav.com>
+Date: Fri, 20 Jan 2017 23:03:09 -0800
+Subject: [PATCH] tty: serial: xuartps: Implement automatic RTC/CTS flow
+ control
+
+---
+ drivers/tty/serial/xilinx_uartps.c | 25 ++++++++++++++++---------
+ 1 file changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/tty/serial/xilinx_uartps.c b/drivers/tty/serial/xilinx_uartps.c
+index 6f0676b..88a2055 100644
+--- a/drivers/tty/serial/xilinx_uartps.c
++++ b/drivers/tty/serial/xilinx_uartps.c
+@@ -52,6 +52,11 @@ static int rx_timeout = 10;
+ module_param(rx_timeout, uint, S_IRUGO);
+ MODULE_PARM_DESC(rx_timeout, "Rx timeout, 1-255");
+ 
++/* RTS Trigger level */
++static int rts_trigger_level = 60;
++module_param(rts_trigger_level, uint, S_IRUGO);
++MODULE_PARM_DESC(rts_trigger_level, "RTS trigger level, 4-63 bytes");
++
+ /* Register offsets for the UART. */
+ #define CDNS_UART_CR_OFFSET		0x00  /* Control Register */
+ #define CDNS_UART_MR_OFFSET		0x04  /* Mode Register */
+@@ -688,18 +693,10 @@ static void cdns_uart_set_termios(struct uart_port *port,
+ 	unsigned int cval = 0;
+ 	unsigned int baud, minbaud, maxbaud;
+ 	unsigned long flags;
+-	unsigned int ctrl_reg, mode_reg;
++	unsigned int ctrl_reg, mode_reg, modem_ctrl_reg;
+ 
+ 	spin_lock_irqsave(&port->lock, flags);
+ 
+-	/* Wait for the transmit FIFO to empty before making changes */
+-	if (!(cdns_uart_readl(CDNS_UART_CR_OFFSET) & CDNS_UART_CR_TX_DIS)) {
+-		while (!(cdns_uart_readl(CDNS_UART_SR_OFFSET) &
+-				CDNS_UART_SR_TXEMPTY)) {
+-			cpu_relax();
+-		}
+-	}
+-
+ 	/* Disable the TX and RX to set baud rate */
+ 	ctrl_reg = cdns_uart_readl(CDNS_UART_CR_OFFSET);
+ 	ctrl_reg |= CDNS_UART_CR_TX_DIS | CDNS_UART_CR_RX_DIS;
+@@ -776,6 +773,16 @@ static void cdns_uart_set_termios(struct uart_port *port,
+ 		break;
+ 	}
+ 
++	/* Configure flow control */
++	modem_ctrl_reg = cdns_uart_readl(CDNS_UART_MODEMCR_OFFSET);
++	if (termios->c_cflag & CRTSCTS) {
++		modem_ctrl_reg |= CDNS_UART_MODEMCR_FCM;
++	} else {
++		modem_ctrl_reg &= ~CDNS_UART_MODEMCR_FCM;
++	}
++	cdns_uart_writel(rts_trigger_level, CDNS_UART_FLOWDEL_OFFSET);
++	cdns_uart_writel(modem_ctrl_reg, CDNS_UART_MODEMCR_OFFSET);
++
+ 	/* Handling Parity and Stop Bits length */
+ 	if (termios->c_cflag & CSTOPB)
+ 		cval |= CDNS_UART_MR_STOPMODE_2_BIT; /* 2 STOP bits */
+-- 
+2.6.2
+

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -20,6 +20,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/wait.h>
+#include <termios.h>
 
 #include "whitelists.h"
 
@@ -63,33 +64,98 @@ static int settings_msg_loop_interrupt(void)
   return sbp_zmq_loop_interrupt(&sbp_zmq_state);
 }
 
-static int uart0_baudrate = 115200;
-static int uart1_baudrate = 115200;
+static const char * const baudrate_enum[] = {
+  "1200", "2400", "4800", "9600",
+  "19200", "38400", "57600", "115200",
+  "230400", NULL
+};
+enum {
+  BAUDRATE_1200, BAUDRATE_2400, BAUDRATE_4800, BAUDRATE_9600,
+  BAUDRATE_19200, BAUDRATE_38400, BAUDRATE_57600, BAUDRATE_115200,
+  BAUDRATE_230400};
+static const u32 baudrate_val_table[] = {
+  B1200, B2400, B4800, B9600,
+  B19200, B38400, B57600, B115200,
+  B230400
+};
+static struct setting_type baudrate_settings_type;
+static int TYPE_BAUDRATE = 0;
+
+typedef struct {
+  const char *tty_path;
+  u8 baudrate;
+} uart_t;
+
+static uart_t uart0 = {
+  .tty_path = "/dev/ttyPS0",
+  .baudrate = BAUDRATE_115200
+};
+
+static uart_t uart1 = {
+  .tty_path = "/dev/ttyPS1",
+  .baudrate = BAUDRATE_115200
+};
+
+static int uart_configure(const uart_t *uart)
+{
+  int fd = open(uart->tty_path, O_RDONLY);
+  if (fd < 0) {
+    printf("error opening tty device\n");
+    return -1;
+  }
+
+  struct termios tio;
+  if (tcgetattr(fd, &tio) != 0) {
+    printf("error in tcgetattr()\n");
+    close(fd);
+    return -1;
+  }
+
+  cfmakeraw(&tio);
+  tio.c_lflag &= ~ECHO;
+  tio.c_oflag &= ~ONLCR;
+  cfsetispeed(&tio, baudrate_val_table[uart->baudrate]);
+  cfsetospeed(&tio, baudrate_val_table[uart->baudrate]);
+  tcsetattr(fd, TCSANOW, &tio);
+
+  /* Check results */
+  if (tcgetattr(fd, &tio) != 0) {
+    printf("error in tcgetattr()\n");
+    close(fd);
+    return -1;
+  }
+
+  close(fd);
+
+  if ((cfgetispeed(&tio) != baudrate_val_table[uart->baudrate]) ||
+      (cfgetospeed(&tio) != baudrate_val_table[uart->baudrate])) {
+    printf("error configuring tty\n");
+    return -1;
+  }
+
+  return 0;
+}
 
 static bool baudrate_notify(struct setting *s, const char *val)
 {
-  int baudrate;
-  bool ret = s->type->from_string(s->type->priv, &baudrate, s->len, val);
-  if (!ret) {
+  if (!s->type->from_string(s->type->priv, s->addr, s->len, val)) {
     return false;
   }
 
-  const char *dev = NULL;
-  if (s->addr == &uart0_baudrate) {
-    dev = "/dev/ttyPS0";
-  } else if (s->addr == &uart1_baudrate) {
-    dev = "/dev/ttyPS1";
+  const uart_t *uart = NULL;
+  if (s->addr == &uart0.baudrate) {
+    uart = &uart0;
+  } else if (s->addr == &uart1.baudrate) {
+    uart = &uart1;
   } else {
     return false;
   }
-  char cmd[80];
-  snprintf(cmd, sizeof(cmd), "stty -F %s %d", dev, baudrate);
-  ret = system(cmd) == 0;
 
-  if (ret) {
-    *(int*)s->addr = baudrate;
+  if (uart_configure(uart) != 0) {
+    return false;
   }
-  return ret;
+
+  return true;
 }
 
 static const char const * port_mode_enum[] = {"SBP", "NMEA", NULL};
@@ -456,9 +522,10 @@ int main(void)
   };
   settings_setup(&settings_interface);
 
+  TYPE_BAUDRATE = settings_type_register_enum(baudrate_enum, &baudrate_settings_type);
   TYPE_PORT_MODE = settings_type_register_enum(port_mode_enum, &port_mode_settings_type);
-  SETTING_NOTIFY("uart0", "baudrate", uart0_baudrate, TYPE_INT, baudrate_notify);
-  SETTING_NOTIFY("uart1", "baudrate", uart1_baudrate, TYPE_INT, baudrate_notify);
+  SETTING_NOTIFY("uart0", "baudrate", uart0.baudrate, TYPE_BAUDRATE, baudrate_notify);
+  SETTING_NOTIFY("uart1", "baudrate", uart1.baudrate, TYPE_BAUDRATE, baudrate_notify);
   SETTING_NOTIFY("uart0", "mode", uart0_mode, TYPE_PORT_MODE, port_mode_notify);
   SETTING_NOTIFY("uart1", "mode", uart1_mode, TYPE_PORT_MODE, port_mode_notify);
 

--- a/package/zmq_adapter/src/zmq_adapter_file.c
+++ b/package/zmq_adapter/src/zmq_adapter_file.c
@@ -10,9 +10,6 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <termios.h>
-#include <unistd.h>
-
 #include "zmq_adapter.h"
 
 int file_loop(const char *file_path)
@@ -21,15 +18,6 @@ int file_loop(const char *file_path)
   if (fd < 0) {
     printf("error opening file\n");
     return 1;
-  }
-
-  if (isatty(fd)) {
-    struct termios tio;
-    tcgetattr(fd, &tio);
-    cfmakeraw(&tio);
-    tio.c_lflag &= ~ECHO;
-    tio.c_oflag &= ~ONLCR;
-    tcsetattr(fd, TCSANOW, &tio);
   }
 
   io_loop_start(fd);


### PR DESCRIPTION
- Configure TTYs in `piksi_system_daemon` using `tcsetattr()` with `TCSANOW` (`stty` uses `TCSADRAIN`, which waits for pending transmit data to be flushed)
- Use enum for baud rate
- Flow control support (setting + kernel patch)

/cc @swift-nav/firmware 