### PR TITLE
Limit pending outgoing messages for UART and USB ZMQ adapters

### DIFF
--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -206,21 +206,21 @@ typedef struct {
 
 static adapter_config_t uart0_adapter_config = {
   .name = "uart0",
-  .opts = "--file /dev/ttyPS0",
+  .opts = "--file /dev/ttyPS0 --watermark-receive 100",
   .mode = PORT_MODE_SBP,
   .pid = 0
 };
 
 static adapter_config_t uart1_adapter_config = {
   .name = "uart1",
-  .opts = "--file /dev/ttyPS1",
+  .opts = "--file /dev/ttyPS1 --watermark-receive 100",
   .mode = PORT_MODE_SBP,
   .pid = 0
 };
 
 static adapter_config_t usb0_adapter_config = {
   .name = "usb0",
-  .opts = "--file /dev/ttyGS0",
+  .opts = "--file /dev/ttyGS0 --watermark-receive 100",
   .mode = PORT_MODE_SBP,
   .pid = 0
 };


### PR DESCRIPTION
Set the receive watermark to 100 for UART and USB ZMQ adapters. This will limit the number of messages queued within ZMQ pending transmission via those interfaces. Unfortunately the most recent data will be dropped (instead of the oldest), but this will limit the amount of buffered stale data in case the interface is temporarily blocked or cannot keep up.

TODO:
- [x] Rebase once #117 is merged

/cc @swift-nav/firmware @denniszollo 