### PR TITLE
Minimal watchdog support

### DIFF
--- a/board/piksiv3/piksiv3.dtsi
+++ b/board/piksiv3/piksiv3.dtsi
@@ -51,3 +51,8 @@
 &ttc1 {
   status = "disabled";
 };
+
+&watchdog0 {
+  timeout-sec = <10>;
+  reset-on-timeout;
+};

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S95watchdog_disable
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S95watchdog_disable
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+name="watchdog_disable"
+
+start() {
+  printf "V" > /dev/watchdog
+}
+
+stop() {
+  :
+}
+
+source /etc/init.d/template_command.inc.sh

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = ccdd5b1856f3668ad68d213cbce2d51eb9e3a00c
+UBOOT_CUSTOM_VERSION = ac451bef610c4a58c6d9df20580e308e43ebd50e
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools


### PR DESCRIPTION
- Update U-Boot to enable watchdog during boot for prod config
- Add init script to disable watchdog in Linux

TODO:
- [x] Update U-Boot https://github.com/swift-nav/u-boot-xlnx/pull/26

/cc @swift-nav/firmware 