### PR TITLE
Switch to using tags for release builds.

### DIFF
--- a/comment.sh
+++ b/comment.sh
@@ -26,7 +26,7 @@ BUILD_VERSION="$(git describe --tags --dirty --always)"
 BUILD_PATH="$REPO/$BUILD_VERSION"
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_BRANCH" == v*-release ]]; then
+    if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_TAG" == v* ]]; then
         COMMENT="$BUILD_PATH
 https://console.aws.amazon.com/s3/home?region=us-west-2&bucket=swiftnav-artifacts&prefix=$BUILD_PATH/"
         URL="https://slack.com/api/chat.postMessage?token=$SLACK_TOKEN&channel=$SLACK_CHANNEL"

--- a/publish.sh
+++ b/publish.sh
@@ -39,7 +39,7 @@ echo "Uploading $@ to $BUILD_PATH"
 for file in "$@"; do
     KEY="$BUILD_PATH/$(basename $file)"
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-        if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_BRANCH" == v*-release ]]; then
+        if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_TAG" == v* ]]; then
             OBJECT="s3://$BUCKET/$KEY"
             aws s3 cp "$file" "$OBJECT"
         fi


### PR DESCRIPTION
This updates the publishing / commenting scripts to use the tag builds instead of builds on the release branch to do publishing / commenting.

/cc @cbeighley 