### PR TITLE
Dzollo dev config fix

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -16,7 +16,11 @@ copy_from_sd() {
   cp "$sd_file" "$output_file"
 
   if [ ! -f "$output_file" ]; then
-    echo "ERROR: copy failed"
+    while [ 1 ]; do
+      echo "ERROR: copy of images from SD card failed. Please Reboot"
+      echo "ERROR: copy of images from SD card failed. Please Reboot" | SBP_LOG --error
+      sleep 1
+    done
   fi
 }
 
@@ -33,7 +37,11 @@ copy_from_net() {
   tftp -g -r "$net_file" -l "$output_file" -b 65464 "$server_ip"
 
   if [ ! -f "$output_file" ]; then
-    echo "ERROR: copy failed"
+    while [ 1 ]; do
+      echo "ERROR: copy of images from SD card failed. Please Reboot"
+      echo "ERROR: copy of images from SD card failed. Please Reboot" | SBP_LOG --error
+      sleep 1
+    done
   fi
 }
 

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -17,8 +17,7 @@ copy_from_sd() {
 
   if [ ! -f "$output_file" ]; then
     while [ 1 ]; do
-      echo "ERROR: copy of images from SD card failed. Please Reboot"
-      echo "ERROR: copy of images from SD card failed. Please Reboot" | SBP_LOG --error
+      echo "ERROR: copy of images from network failed. Please Reboot"
       sleep 1
     done
   fi

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S84piksi_fpga
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S84piksi_fpga
@@ -8,7 +8,11 @@ start() {
     cat "$bit" > /dev/xdevcfg
     prog_done=`cat /sys/devices/soc0/amba/f8007000.devcfg/prog_done`
     if [ "$prog_done" != "1" ]; then
-      echo "ERROR: configuration failed"
+      while [ 1 ]; do
+         echo "ERROR: FPGA configuration failed"
+         echo "ERROR: FPGA configuration failed" | SBP_LOG --error
+         sleep 1
+      done
     fi
   else
     echo "ERROR: bitstream not found"

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S84piksi_fpga
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S84piksi_fpga
@@ -8,14 +8,12 @@ start() {
     cat "$bit" > /dev/xdevcfg
     prog_done=`cat /sys/devices/soc0/amba/f8007000.devcfg/prog_done`
     if [ "$prog_done" != "1" ]; then
-      while [ 1 ]; do
-         echo "ERROR: FPGA configuration failed"
-         echo "ERROR: FPGA configuration failed" | SBP_LOG --error
-         sleep 1
-      done
+       echo "ERROR: FPGA configuration failed"
+       echo "ERROR: FPGA configuration failed" | SBP_LOG --error
     fi
   else
     echo "ERROR: bitstream not found"
+    echo "ERROR: bitstream not found" | SBP_LOG --error
   fi
 }
 


### PR DESCRIPTION
/cc @jacobmcnamee @mfine
Goal is to fail loudly if we ever are unable to configure the FPGA or RT firmware whilst in DEV mode.  Some drive tests showed up with the wrong FPGA bitstream.

Still needs to even be sniff tested and sanity checked.  This could easily have a typo or something silly.