### PR TITLE
Support incremental docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,20 @@ services:
 before_install:
   - pip install --user --upgrade awscli
 
-install:
-  - ./fetch_firmware.sh
-
 script:
-  - travis_wait 60 docker build -t piksi-buildroot .
+  - make firmware
+  - make docker-setup
+  - HW_CONFIG=prod make docker-make-image 2>&1 | tee -a build.out | grep --line-buffered '^make'
+  - HW_CONFIG=microzed make docker-make-image 2>&1 | tee -a build.out | grep --line-buffered '^make'
 
 after_success:
-  - mkdir -p buildroot/output
-  - export CONTAINER=`docker create piksi-buildroot`
-  - docker cp $CONTAINER:/app/buildroot/output/images buildroot/output
   - git fetch --tags --unshallow
   - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh buildroot/output/images/piksiv3_prod/*
   - PRODUCT_VERSION=v3 PRODUCT_REV=microzed ./publish.sh buildroot/output/images/piksiv3_microzed/*
   - SLACK_CHANNEL=github ./comment.sh
+
+after_failure:
+  - tail -n 500 build.out
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:jessie
 
-WORKDIR /app
-
 RUN apt-get update && apt-get -y --force-yes install \
   build-essential \
   git \
@@ -12,7 +10,5 @@ RUN apt-get update && apt-get -y --force-yes install \
   cpio \
   libssl-dev
 
-COPY . /app
-
-RUN HW_CONFIG=prod make image 2>&1 | tee -a build.out | grep --line-buffered '^make'
-RUN HW_CONFIG=microzed make image 2>&1 | tee -a build.out | grep --line-buffered '^make'
+ENV BR2_EXTERNAL /piksi_buildroot
+WORKDIR /piksi_buildroot

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@ ifeq ($(BUILDROOT_CONFIG),)
   BUILDROOT_CONFIG=piksiv3_defconfig
 endif
 
-.PHONY: all firmware config image
+DOCKER_ARGS:=                                                                 \
+  -e HW_CONFIG=$(HW_CONFIG)                                                   \
+  -v `pwd`:/piksi_buildroot                                                   \
+  -v `pwd`/buildroot/output/images:/piksi_buildroot/buildroot/output/images   \
+  -v piksi_buildroot-buildroot:/piksi_buildroot/buildroot
+
+.PHONY: all firmware config image docker-setup docker-make-image docker-run
 
 all: firmware image
 
@@ -21,3 +27,12 @@ config:
 image: config
 	BR2_EXTERNAL=$(BR2_EXTERNAL) HW_CONFIG=$(HW_CONFIG) make -C buildroot
 
+docker-setup:
+	docker build -t piksi_buildroot .
+	docker run $(DOCKER_ARGS) piksi_buildroot git submodule update --init
+
+docker-make-image:
+	docker run $(DOCKER_ARGS) piksi_buildroot make image
+
+docker-run:
+	docker run $(DOCKER_ARGS) -ti piksi_buildroot


### PR DESCRIPTION
- Remove buildroot build commands from dockerfile
- Add docker targets to makefile:
  - `docker-setup` - runs `docker build` to prepare docker image
  - `docker-make-image` - runs `make image` inside of docker container
  - `docker-run` - starts an interactive docker container
- Mount directories inside docker container:
  - `/piksi_buildroot` (source directory) - backed by host directory. 
  - `/piksi_buildroot/buildroot` (build directory) - backed by persistent docker volume. This avoids a significant slowdown (at least on OSX), but anything written here will not be visible on the host filesystem
  - `/piksi_buildroot/buildroot/output/images` (output directory) - backed by host directory
- Update `.travis.yml`

Example:
```shell
# one-time setup
make docker-setup
# full build
make docker-make-image
# rebuild a single package
make docker-run
cd buildroot
make piksi_system_daemon-rebuild
make
# find images on the host in piksi_buildroot/buildroot/output/images
```

Note that buildroot does _not_ automatically rebuild dependencies or handle configuration changes. In some cases a full rebuild may be necessary.

TODO:
- [ ] Update README

/cc @swift-nav/firmware