### PR TITLE
Fix S3 firmware fetch: update firmware version and NAP version.

### DIFF
--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,8 +15,8 @@
 
 set -xe
 
-FW_VERSION=${1:-v1.0.0-branch-25-g5cb0ff6}
-NAP_VERSION=${2:-SwiftNAP-v3.7.2-5-g6b697af}
+FW_VERSION=${1:-v1.0.0-branch-155-g8f9ff34}
+NAP_VERSION=${2:-v1.0.0-branch-39-gfdd7290}
 
 FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3
 NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION
@@ -45,4 +45,3 @@ download_fw() {
 
 download_fw "prod"
 download_fw "microzed"
-


### PR DESCRIPTION
Fixes issue where current S3 firmware fetch setup for build-root image
build is failing because of some NAP file renaming on S3.

/cc @denniszollo @wltr @jacobmcnamee