### PR TITLE
Updated to avoid locking drive

### DIFF
--- a/host_tests/rotating_logger/run_rotating_logger_test.cc
+++ b/host_tests/rotating_logger/run_rotating_logger_test.cc
@@ -31,7 +31,7 @@ static double GetDiskDiskUsage() {
 // The fixture for testing class RotatingLogger.
 class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
  protected:
-  RotatingLoggerTest() : RotatingLogger("", 0, 0, 100, true, true) {
+  RotatingLoggerTest() : RotatingLogger("", 0, 0, 100, true) {
     rm_wrapper("*.sbp");
   }
 
@@ -49,7 +49,10 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
   }
 
   // invalidate current file pointer
-  void SetNullFilePointer() { _cur_file = NULL; }
+  void SetNullFilePointer() { 
+    close(_cur_file);
+    _cur_file = -1;
+  }
 
   void SetFillThreshold(size_t threshold) { _disk_full_threshold = threshold; }
 
@@ -85,7 +88,7 @@ TEST_F(RotatingLoggerTest, NormalOperation) {
     snprintf(file_name_buf, sizeof(file_name_buf), "%s/%s", out_dir,
              expected_files[i]);
     FILE* fd = fopen(file_name_buf, "rb");
-    ASSERT_TRUE(fd != NULL) << "Missing file " << expected_files[i];
+    ASSERT_TRUE(fd != nullptr) << "Missing file " << expected_files[i];
     int data_buf[5];
     size_t read_len = fread(data_buf, 1, sizeof(data_buf), fd);
     fclose(fd);
@@ -132,10 +135,10 @@ TEST_F(RotatingLoggerTest, DiskCheck) {
     snprintf(buff, sizeof(buff), "%s/0001-%05d.sbp", out_dir, i);
     FILE* fd = fopen(buff, "rb");
     if (i < fill_writes) {
-      ASSERT_TRUE(fd != NULL) << "Missing file " << i;
+      ASSERT_TRUE(fd != nullptr) << "Missing file " << i;
       fclose(fd);
     } else {
-      ASSERT_TRUE(fd == NULL) << "Extra file " << i;
+      ASSERT_TRUE(fd == nullptr) << "Extra file " << i;
     }
   }
 }
@@ -160,7 +163,7 @@ TEST_F(RotatingLoggerTest, StartDisconnected) {
   snprintf(file_name_buf, sizeof(file_name_buf), "%s/%s", out_dir,
            expected_files);
   FILE* fd = fopen(file_name_buf, "rb");
-  ASSERT_TRUE(fd != NULL) << "Missing file " << expected_files;
+  ASSERT_TRUE(fd != nullptr) << "Missing file " << expected_files;
   int data_buf[1];
   size_t read_len = fread(data_buf, 1, sizeof(data_buf), fd);
   fclose(fd);
@@ -208,7 +211,7 @@ TEST_F(RotatingLoggerTest, DisconnectReconnect) {
     snprintf(file_name_buf, sizeof(file_name_buf), "%s/%s", out_dir,
              expected_files[i]);
     FILE* fd = fopen(file_name_buf, "rb");
-    ASSERT_TRUE(fd != NULL) << "Missing file " << expected_files[i];
+    ASSERT_TRUE(fd != nullptr) << "Missing file " << expected_files[i];
     int data_buf[1];
     size_t read_len = fread(data_buf, 1, sizeof(data_buf), fd);
     fclose(fd);

--- a/package/rotating_zmq_logger/src/rotating_logger.h
+++ b/package/rotating_zmq_logger/src/rotating_logger.h
@@ -22,7 +22,7 @@ class RotatingLogger {
  public:
   RotatingLogger(const std::string& out_dir, size_t slice_duration,
                  size_t poll_period, size_t disk_full_threshold,
-                 bool force_flush, bool verbose_logging);
+                 bool verbose_logging);
   ~RotatingLogger();
   /*
    * try to log a data frame
@@ -63,11 +63,10 @@ class RotatingLogger {
   size_t _slice_duration;
   size_t _poll_period;
   size_t _disk_full_threshold;
-  bool _force_flush;
   bool _verbose_logging;
   std::string _out_dir;
   std::chrono::time_point<std::chrono::steady_clock> _session_start_time;
-  FILE* _cur_file;
+  int _cur_file;
 };
 
 #endif  // SWIFTNAV_ROTATING_LOGGER_H

--- a/package/rotating_zmq_logger/src/rotating_zmq_logger.cc
+++ b/package/rotating_zmq_logger/src/rotating_zmq_logger.cc
@@ -31,7 +31,6 @@ static int fill_threshold_p = FILL_THRESHOLD_DEFAULT_p;
 static const char *zmq_sub_endpoint = nullptr;
 static const char *dir_path = nullptr;
 
-static bool force_flush = false;
 static bool verbose_logging = false;
 
 static void usage(char *command) {
@@ -51,8 +50,6 @@ static void usage(char *command) {
   puts("\t--full-threshold <precent>");
   puts(
       "\t\tStop logging if disk is filled above this percentage (default: 95)");
-  puts("\t--flush");
-  puts("\t\tFlush data to file immediately");
   puts("\t-v --verbose");
   puts("\t\tWrite status to stdout");
 }
@@ -63,16 +60,15 @@ static int parse_options(int argc, char *argv[]) {
   const struct option long_opts[] = {
       {"sub", required_argument, nullptr, 's'},
       {"dir", required_argument, nullptr, 'd'},
-      {"verbose", required_argument, nullptr, 'v'},
+      {"verbose", no_argument, nullptr, 'v'},
       {"slice-duration", required_argument, nullptr, OPT_ID_DURATION},
       {"poll-period", required_argument, nullptr, OPT_ID_PERIOD},
       {"full-threshold", required_argument, nullptr, OPT_ID_THRESHOLD},
-      {"flush", no_argument, nullptr, OPT_ID_FLUSH},
       {nullptr, 0, nullptr, 0}};
 
   int c;
   int opt_index;
-  while ((c = getopt_long(argc, argv, "s:d:", long_opts, &opt_index)) != -1) {
+  while ((c = getopt_long(argc, argv, "s:d:v", long_opts, &opt_index)) != -1) {
     switch (c) {
       case 's': {
         zmq_sub_endpoint = optarg;
@@ -92,10 +88,6 @@ static int parse_options(int argc, char *argv[]) {
 
       case OPT_ID_THRESHOLD: {
         fill_threshold_p = strtol(optarg, nullptr, 10);
-      } break;
-
-      case OPT_ID_FLUSH: {
-        force_flush = true;
       } break;
 
       case 'v': {
@@ -175,7 +167,7 @@ int main(int argc, char *argv[]) {
   }
 
   RotatingLogger logger(dir_path, slice_diration_m, poll_period_s,
-                        fill_threshold_p, force_flush, verbose_logging);
+                        fill_threshold_p, verbose_logging);
 
   zsock_t *zmq_sub = zsock_new_sub(zmq_sub_endpoint, "");
   if (zmq_sub == nullptr) {


### PR DESCRIPTION
Drive would not unmount properly if USB pulled out. This switches to unbuffered writes and waits to start new file to fix issue.