### PR TITLE
Use ifdown -f

### DIFF
--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -334,7 +334,7 @@ static char eth_gateway[16] = "192.168.0.1";
 
 static void eth_update_config(void)
 {
-  system("ifdown eth0");
+  system("ifdown -f eth0");
 
   FILE *interfaces = fopen("/etc/network/interfaces", "w");
   if (eth_ip_mode == IP_CFG_DHCP) {


### PR DESCRIPTION
Resolves issue with the `dev` config where an initial manual configuration causes errors when `piksi_system_daemon` tries to reconfigure:
```
ifdown: interface eth0 not configured
ip: RTNETLINK answers: File exists
```

The problem appears to be that old routes / IP addresses are not cleared by `ifdown` when the interface was not brought up with `ifup`. Using `ifdown -f` should fix this.

/cc @swift-nav/firmware 