### PR TITLE
Add packages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get -y --force-yes install \
   unzip \
   bc \
   cpio \
-  libssl-dev
+  libssl-dev \
+  ncurses-dev
 
 ENV BR2_EXTERNAL /piksi_buildroot
 WORKDIR /piksi_buildroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get -y --force-yes install \
   bc \
   cpio \
   libssl-dev \
-  ncurses-dev
+  ncurses-dev \
+  mercurial
 
 ENV BR2_EXTERNAL /piksi_buildroot
 WORKDIR /piksi_buildroot


### PR DESCRIPTION
- Allows running `make menuconfig` inside of Docker container for buildroot configuration
- Mercurial to acquire some buildroot packages, e.g. Eigen.

/cc @swift-nav/firmware 