### PR TITLE
ZMQ adapter improvements

### DIFF
--- a/package/sbp_protocol/src/filter_sbp.c
+++ b/package/sbp_protocol/src/filter_sbp.c
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <libsbp/sbp.h>
+#include <syslog.h>
 
 #define SBP_MSG_TYPE_OFFSET 1
 #define SBP_MSG_SIZE_MIN    6
@@ -64,7 +65,7 @@ static void filter_sbp_load_config(filter_sbp_state_t *s)
   /* Allocate buffer for rules */
   s->rules = malloc(rules_buffer_count * sizeof(filter_sbp_rule_t));
   if (s->rules  == NULL) {
-    printf("error allocating buffer for rules\n");
+    syslog(LOG_ERR, "error allocating buffer for rules");
     rules_buffer_count = 0;
     return;
   }
@@ -72,7 +73,7 @@ static void filter_sbp_load_config(filter_sbp_state_t *s)
   /* Open file */
   FILE *fp = fopen(s->config_file, "r");
   if (fp == NULL) {
-    printf("error opening %s\n", s->config_file);
+    syslog(LOG_ERR, "error opening %s", s->config_file);
     return;
   }
 
@@ -85,7 +86,7 @@ static void filter_sbp_load_config(filter_sbp_state_t *s)
     unsigned int msg_type;
     unsigned int divisor;
     if (sscanf(line, "%x %x", &msg_type, &divisor) != 2) {
-      printf("error parsing %s\n", s->config_file);
+      syslog(LOG_ERR, "error parsing %s", s->config_file);
       error = true;
       break;
     }
@@ -96,7 +97,7 @@ static void filter_sbp_load_config(filter_sbp_state_t *s)
       s->rules = realloc(s->rules,
                          rules_buffer_count * sizeof(filter_sbp_rule_t));
       if (s->rules  == NULL) {
-        printf("error reallocating buffer for rules\n");
+        syslog(LOG_ERR, "error reallocating buffer for rules");
         rules_buffer_count = 0;
         error = true;
         break;
@@ -131,7 +132,7 @@ void * filter_create(const char *filename)
   s->config_inotify = inotify_init1(IN_NONBLOCK);
   int wd = inotify_add_watch(s->config_inotify, filename, IN_CLOSE_WRITE);
   if ((s->config_inotify < 0) || (wd < 0)) {
-    printf("error setting up inotify on config file: %s\n", filename);
+    syslog(LOG_ERR, "error setting up inotify on config file: %s", filename);
   }
 
   return (void *)s;

--- a/package/sbp_protocol/src/framer_sbp.c
+++ b/package/sbp_protocol/src/framer_sbp.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <libsbp/sbp.h>
+#include <syslog.h>
 
 #define SBP_MSG_LEN_MAX (264)
 
@@ -106,7 +107,7 @@ uint32_t framer_process(void *state, const uint8_t *data, uint32_t data_length,
         *frame_length = c.write_offset;
         return c.read_offset;
       } else {
-        printf("SBP send error\n");
+        syslog(LOG_ERR, "SBP send error");
       }
     }
   }

--- a/package/zmq_adapter/src/Makefile
+++ b/package/zmq_adapter/src/Makefile
@@ -1,6 +1,7 @@
 TARGET=zmq_adapter
 SOURCES= \
 	zmq_adapter.c \
+	zmq_adapter_stdio.c \
 	zmq_adapter_file.c \
 	zmq_adapter_tcp_listen.c \
 	framer.c \

--- a/package/zmq_adapter/src/Makefile
+++ b/package/zmq_adapter/src/Makefile
@@ -9,7 +9,7 @@ SOURCES= \
 	filter_none.c \
 	protocols.c
 LIBS=-lczmq -lzmq -lsbp -ldl
-CFLAGS=-std=gnu11
+CFLAGS=-std=gnu11 -Wall
 
 CROSS=
 

--- a/package/zmq_adapter/src/filter.c
+++ b/package/zmq_adapter/src/filter.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <syslog.h>
 
 typedef struct filter_interface_s {
   const char *name;
@@ -50,7 +51,7 @@ int filter_interface_register(const char *name,
   filter_interface_t *interface = (filter_interface_t *)
                                       malloc(sizeof(*interface));
   if (interface == NULL) {
-    printf("error allocating filter interface\n");
+    syslog(LOG_ERR, "error allocating filter interface");
     return -1;
   }
 
@@ -63,7 +64,7 @@ int filter_interface_register(const char *name,
   };
 
   if (interface->name == NULL) {
-    printf("error allocating filter interface members\n");
+    syslog(LOG_ERR, "error allocating filter interface members");
     free(interface);
     interface = NULL;
     return -1;
@@ -93,13 +94,13 @@ filter_t * filter_create(const char *name, const char *filename)
   /* Look up interface */
   filter_interface_t *interface = filter_interface_lookup(name);
   if (interface == NULL) {
-    printf("unknown filter: %s\n", name);
+    syslog(LOG_ERR, "unknown filter: %s", name);
     return NULL;
   }
 
   filter_t *filter = (filter_t *)malloc(sizeof(*filter));
   if (filter == NULL) {
-    printf("error allocating filter\n");
+    syslog(LOG_ERR, "error allocating filter");
     return NULL;
   }
 
@@ -109,7 +110,7 @@ filter_t * filter_create(const char *name, const char *filename)
   };
 
   if (filter->state == NULL) {
-    printf("error creating filter\n");
+    syslog(LOG_ERR, "error creating filter");
     free(filter);
     filter = NULL;
     return NULL;

--- a/package/zmq_adapter/src/framer.c
+++ b/package/zmq_adapter/src/framer.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <syslog.h>
 
 typedef struct framer_interface_s {
   const char *name;
@@ -50,7 +51,7 @@ int framer_interface_register(const char *name,
   framer_interface_t *interface = (framer_interface_t *)
                                       malloc(sizeof(*interface));
   if (interface == NULL) {
-    printf("error allocating framer interface\n");
+    syslog(LOG_ERR, "error allocating framer interface");
     return -1;
   }
 
@@ -63,7 +64,7 @@ int framer_interface_register(const char *name,
   };
 
   if (interface->name == NULL) {
-    printf("error allocating framer interface members\n");
+    syslog(LOG_ERR, "error allocating framer interface members");
     free(interface);
     interface = NULL;
     return -1;
@@ -93,13 +94,13 @@ framer_t * framer_create(const char *name)
   /* Look up interface */
   framer_interface_t *interface = framer_interface_lookup(name);
   if (interface == NULL) {
-    printf("unknown framer: %s\n", name);
+    syslog(LOG_ERR, "unknown framer: %s", name);
     return NULL;
   }
 
   framer_t *framer = (framer_t *)malloc(sizeof(*framer));
   if (framer == NULL) {
-    printf("error allocating framer\n");
+    syslog(LOG_ERR, "error allocating framer");
     return NULL;
   }
 
@@ -109,7 +110,7 @@ framer_t * framer_create(const char *name)
   };
 
   if (framer->state == NULL) {
-    printf("error creating framer\n");
+    syslog(LOG_ERR, "error creating framer");
     free(framer);
     framer = NULL;
     return NULL;

--- a/package/zmq_adapter/src/framer_none.c
+++ b/package/zmq_adapter/src/framer_none.c
@@ -38,7 +38,7 @@ uint32_t framer_none_process(void *state,
                              const uint8_t *data, uint32_t data_length,
                              const uint8_t **frame, uint32_t *frame_length)
 {
-  *frame = data;
+  *frame = data_length > 0 ? data : NULL;
   *frame_length = data_length;
   return data_length;
 }

--- a/package/zmq_adapter/src/protocols.c
+++ b/package/zmq_adapter/src/protocols.c
@@ -21,6 +21,7 @@
 #include <dirent.h>
 #include <limits.h>
 #include <dlfcn.h>
+#include <syslog.h>
 
 #define DLSYM_CAST(var) (*(void **) &(var))
 
@@ -91,7 +92,7 @@ static int import(const char *filename)
 
   const char *protocol_name = import_name(handle);
   if (protocol_name == NULL) {
-    printf("missing protocol_name\n");
+    syslog(LOG_ERR, "missing protocol_name");
     goto error;
   }
 
@@ -113,14 +114,14 @@ int protocols_import(const char *path)
   if (framer_interface_register("none", framer_none_create,
                                 framer_none_destroy,
                                 framer_none_process) != 0) {
-    printf("error registering none framer\n");
+    syslog(LOG_ERR, "error registering none framer");
     return -1;
   }
 
   if (filter_interface_register("none", filter_none_create,
                                 filter_none_destroy,
                                 filter_none_process) != 0) {
-    printf("error registering none filter\n");
+    syslog(LOG_ERR, "error registering none filter");
     return -1;
   }
 
@@ -140,7 +141,7 @@ int protocols_import(const char *path)
     char filename[PATH_MAX];
     snprintf(filename, sizeof(filename), "%s/%s", path, dirent->d_name);
     if (import(filename) != 0) {
-      printf("error importing %s\n", filename);
+      syslog(LOG_ERR, "error importing %s", filename);
     }
   }
 

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -551,14 +551,11 @@ static ssize_t handle_write_one_via_framer(handle_t *handle,
       continue;
     }
 
-
     /* Pass frame through filter */
     if (filter_process(handle->filter, frame, frame_length) != 0) {
       debug_printf("ignoring frame\n");
       continue;
     }
-
-    *frames_written += 1;
 
     /* Write frame to handle */
     ssize_t write_count = handle_write_all(handle, frame, frame_length);
@@ -568,6 +565,8 @@ static ssize_t handle_write_one_via_framer(handle_t *handle,
     if (write_count != frame_length) {
       printf("warning: write_count != frame_length\n");
     }
+
+    *frames_written += 1;
 
     return buffer_index;
   }
@@ -640,7 +639,7 @@ static void io_loop_pubsub(handle_t *read_handle, handle_t *write_handle)
     }
 
     /* Write to write_handle via framer */
-    ssize_t frames_written;
+    size_t frames_written;
     ssize_t write_count = handle_write_all_via_framer(write_handle,
                                                       buffer, read_count,
                                                       &frames_written);

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -23,6 +23,7 @@
 #define PROTOCOL_LIBRARY_PATH_DEFAULT "/usr/lib/zmq_protocols"
 #define READ_BUFFER_SIZE 65536
 #define REP_TIMEOUT_DEFAULT_ms 10000
+#define STARTUP_DELAY_DEFAULT_ms 0
 #define ZSOCK_RESTART_RETRY_COUNT 3
 #define ZSOCK_RESTART_RETRY_DELAY_ms 1
 #define FRAMER_NONE_NAME "none"
@@ -67,6 +68,7 @@ static const char *filter_out_name = FRAMER_NONE_NAME;
 static const char *filter_in_config = NULL;
 static const char *filter_out_config = NULL;
 static int rep_timeout_ms = REP_TIMEOUT_DEFAULT_ms;
+static int startup_delay_ms = STARTUP_DELAY_DEFAULT_ms;
 
 static const char *zmq_pub_addr = NULL;
 static const char *zmq_sub_addr = NULL;
@@ -119,6 +121,8 @@ static void usage(char *command)
   fprintf(stderr, "\nMisc options\n");
   fprintf(stderr, "\t--rep-timeout <ms>\n");
   fprintf(stderr, "\t\tresponse timeout before resetting a REP socket\n");
+  fprintf(stderr, "\t--startup-delay <ms>\n");
+  fprintf(stderr, "\t\ttime to delay after opening a ZMQ socket\n");
   fprintf(stderr, "\t--debug\n");
 }
 
@@ -129,6 +133,7 @@ static int parse_options(int argc, char *argv[])
     OPT_ID_FILE,
     OPT_ID_TCP_LISTEN,
     OPT_ID_REP_TIMEOUT,
+    OPT_ID_STARTUP_DELAY,
     OPT_ID_DEBUG,
     OPT_ID_FILTER_IN,
     OPT_ID_FILTER_OUT,
@@ -146,6 +151,7 @@ static int parse_options(int argc, char *argv[])
     {"file",              required_argument, 0, OPT_ID_FILE},
     {"tcp-l",             required_argument, 0, OPT_ID_TCP_LISTEN},
     {"rep-timeout",       required_argument, 0, OPT_ID_REP_TIMEOUT},
+    {"startup-delay",     required_argument, 0, OPT_ID_STARTUP_DELAY},
     {"filter-in",         required_argument, 0, OPT_ID_FILTER_IN},
     {"filter-out",        required_argument, 0, OPT_ID_FILTER_OUT},
     {"filter-in-config",  required_argument, 0, OPT_ID_FILTER_IN_CONFIG},
@@ -178,6 +184,11 @@ static int parse_options(int argc, char *argv[])
 
       case OPT_ID_REP_TIMEOUT: {
         rep_timeout_ms = strtol(optarg, NULL, 10);
+      }
+      break;
+
+      case OPT_ID_STARTUP_DELAY: {
+        startup_delay_ms = strtol(optarg, NULL, 10);
       }
       break;
 
@@ -396,6 +407,7 @@ static zsock_t * zsock_start(int type)
     return zsock;
   }
 
+  usleep(1000 * startup_delay_ms);
   debug_printf("opened socket: %s\n", addr);
   return zsock;
 }

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -400,9 +400,19 @@ static void zsock_restart(zsock_t **p_zsock)
 
 static ssize_t zsock_read(zsock_t *zsock, void *buffer, size_t count)
 {
-  zmsg_t *msg = zmsg_recv(zsock);
-  if (msg == NULL) {
-    return -1;
+  zmsg_t *msg;
+  while (1) {
+    msg = zmsg_recv(zsock);
+    if (msg != NULL) {
+      /* Break on success */
+      break;
+    } else if (errno == EINTR) {
+      /* Retry if interrupted */
+      continue;
+    } else {
+      /* Return error */
+      return -1;
+    }
   }
 
   size_t buffer_index = 0;
@@ -441,11 +451,20 @@ static ssize_t zsock_write(zsock_t *zsock, const void *buffer, size_t count)
     return -1;
   }
 
-  result = zmsg_send(&msg, zsock);
-  if (result != 0) {
-    zmsg_destroy(&msg);
-    assert(msg == NULL);
-    return -1;
+  while (1) {
+    result = zmsg_send(&msg, zsock);
+    if (result == 0) {
+      /* Break on success */
+      break;
+    } else if (errno == EINTR) {
+      /* Retry if interrupted */
+      continue;
+    } else {
+      /* Return error */
+      zmsg_destroy(&msg);
+      assert(msg == NULL);
+      return -1;
+    }
   }
 
   assert(msg == NULL);

--- a/package/zmq_adapter/src/zmq_adapter.h
+++ b/package/zmq_adapter/src/zmq_adapter.h
@@ -19,6 +19,6 @@
 
 #include <czmq.h>
 
-void io_loop_start(int fd);
+void io_loop_start(int read_fd, int write_fd);
 
 #endif /* SWIFTNAV_ZMQ_ADAPTER_H */

--- a/package/zmq_adapter/src/zmq_adapter.h
+++ b/package/zmq_adapter/src/zmq_adapter.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include <czmq.h>
 

--- a/package/zmq_adapter/src/zmq_adapter_file.c
+++ b/package/zmq_adapter/src/zmq_adapter_file.c
@@ -16,7 +16,7 @@ int file_loop(const char *file_path)
 {
   int fd = open(file_path, O_RDWR);
   if (fd < 0) {
-    printf("error opening file\n");
+    syslog(LOG_ERR, "error opening file");
     return 1;
   }
 

--- a/package/zmq_adapter/src/zmq_adapter_file.c
+++ b/package/zmq_adapter/src/zmq_adapter_file.c
@@ -38,4 +38,5 @@ int file_loop(const char *file_path)
 
   close(fd);
   fd = -1;
+  return 0;
 }

--- a/package/zmq_adapter/src/zmq_adapter_stdio.c
+++ b/package/zmq_adapter/src/zmq_adapter_stdio.c
@@ -12,15 +12,9 @@
 
 #include "zmq_adapter.h"
 
-int file_loop(const char *file_path)
+int stdio_loop(void)
 {
-  int fd = open(file_path, O_RDWR);
-  if (fd < 0) {
-    syslog(LOG_ERR, "error opening file");
-    return 1;
-  }
-
-  io_loop_start(fd, fd);
+  io_loop_start(STDIN_FILENO, STDOUT_FILENO);
 
   while (1) {
     int ret = waitpid(-1, NULL, 0);
@@ -36,7 +30,5 @@ int file_loop(const char *file_path)
     }
   }
 
-  close(fd);
-  fd = -1;
   return 0;
 }

--- a/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
@@ -89,7 +89,7 @@ int tcp_listen_loop(int port)
 {
   int server_fd = socket_create(port);
   if (server_fd < 0) {
-    printf("error opening TCP socket\n");
+    syslog(LOG_ERR, "error opening TCP socket");
     return 1;
   }
 

--- a/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
@@ -55,7 +55,7 @@ err:
 
 static void handle_client(int client_fd, const struct sockaddr_in *client_addr)
 {
-  io_loop_start(client_fd);
+  io_loop_start(client_fd, client_fd);
 }
 
 static void server_loop(int server_fd)

--- a/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
@@ -62,7 +62,7 @@ static void server_loop(int server_fd)
 {
   while (1) {
     struct sockaddr_in client_addr;
-    int client_addr_len = sizeof(client_addr);
+    socklen_t client_addr_len = sizeof(client_addr);
     int client_fd = accept(server_fd, (struct sockaddr *)&client_addr,
                            &client_addr_len);
 
@@ -97,4 +97,5 @@ int tcp_listen_loop(int port)
 
   close(server_fd);
   server_fd = -1;
+  return 0;
 }


### PR DESCRIPTION
- Retry on EINTR for `zmsg_send()` and `zmsg_recv()`
- Properly handle data buffered in framer
- Fix minor warnings
- Use `syslog` instead of `printf`
- `stdin` / `stdout` support
- Startup delay option (useful when sending files)

TODO:
- [x] Test


/cc @swift-nav/firmware 