### PR TITLE
turn off file_logger during upgrade

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
@@ -39,6 +39,8 @@ echo "Performing upgrade..."
 # Killing any processes that could hurt user experience
 /etc/init.d/S90monit stop
 /etc/init.d/S83zmq_adapter_rpmsg_piksi100 stop
+/etc/init.d/S83zmq_adapter_rpmsg_piksi101 stop
+/etc/init.d/S83zmq_file_logger stop
 upgrade_tool --debug $FIRMWARE | sbp_log $LOGLEVEL
 umount /media/sda1
 sync


### PR DESCRIPTION
/cc @axlan @switanis @jacobmcnamee 

I worry about having the logger going during the upgrade.