### PR TITLE
Zero pppd pid

### DIFF
--- a/package/piksi_system_daemon/src/cellmodem.c
+++ b/package/piksi_system_daemon/src/cellmodem.c
@@ -34,6 +34,7 @@ static int cellmodem_notify(void *context)
     piksi_log(LOG_DEBUG,
               "Killing pppd with PID: %d (kill returned %d, errno %d)",
               cellmodem_pppd_pid, ret, errno);
+    cellmodem_pppd_pid = 0;
   }
 
   if (!cellmodem_enabled)


### PR DESCRIPTION
If the cellmodem process gets killed off, it should always have its pid zero'd. Otherwise, future configuration changes can end up HUP'ing unrelated pids.

/cc @gsmcmullin @jacobmcnamee 