### PR TITLE
v1.1.5 plus Adel's CN0 / integration gain firmware PR [TESTING ONLY]

### DIFF
--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,10 +15,10 @@
 
 set -xe
 
-FW_VERSION=${1:-v1.1.5}
+FW_VERSION=${1:-v1.1.5-2-g126306c}
 NAP_VERSION=${2:-v1.1.5}
 
-FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3
+FW_S3_PATH=s3://swiftnav-artifacts-pull-requests/piksi_firmware_private/$FW_VERSION/v3
 NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION
 export AWS_DEFAULT_REGION="us-west-2"
 


### PR DESCRIPTION
For testing Adel's CN0 / integration gain firmware PR on top of `v1.1.5`.