### PR TITLE
Treat 1006 message as only an XYZ source and ignore antenna height of…

### DIFF
--- a/package/sbp_rtcm3_bridge/sbp_rtcm3_bridge/src/sbp_rtcm3.c
+++ b/package/sbp_rtcm3_bridge/sbp_rtcm3_bridge/src/sbp_rtcm3.c
@@ -335,14 +335,9 @@ void sbp_to_rtcm3_1005(const msg_base_pos_ecef_t *sbp_base_pos,
 
 void rtcm3_1006_to_sbp(const rtcm_msg_1006 *rtcm_1006,
                        msg_base_pos_ecef_t *sbp_base_pos) {
-  double llh[3], xyz[3] = {rtcm_1006->msg_1005.arp_x, rtcm_1006->msg_1005.arp_y,
-                           rtcm_1006->msg_1005.arp_z};
-  wgsecef2llh(xyz, llh);
-  llh[2] += rtcm_1006->ant_height;
-  wgsllh2ecef(llh, xyz);
-  sbp_base_pos->x = xyz[0];
-  sbp_base_pos->y = xyz[1];
-  sbp_base_pos->z = xyz[2];
+  sbp_base_pos->x = rtcm_1006->msg_1005.arp_x;
+  sbp_base_pos->y = rtcm_1006->msg_1005.arp_y;
+  sbp_base_pos->z = rtcm_1006->msg_1005.arp_z;
 }
 
 void sbp_to_rtcm3_1006(const msg_base_pos_ecef_t *sbp_base_pos,

--- a/package/sbp_rtcm3_bridge/sbp_rtcm3_bridge/test/sbp_rtcm_converter_tests.c
+++ b/package/sbp_rtcm3_bridge/sbp_rtcm3_bridge/test/sbp_rtcm_converter_tests.c
@@ -241,9 +241,9 @@ void test_sbp_rtcm_converter() {
   msg1006_out.msg_1005.GAL_ind = 1;
 
   rtcm_msg_1006 msg1006_expected = msg1006;
-  msg1006_expected.msg_1005.arp_x = 3573347.3347;
-  msg1006_expected.msg_1005.arp_y = -5576347.7863;
-  msg1006_expected.msg_1005.arp_z = 2578377.2472;
+  msg1006_expected.msg_1005.arp_x = 3573346.5475;
+  msg1006_expected.msg_1005.arp_y = -5576346.5578;
+  msg1006_expected.msg_1005.arp_z = 2578376.6757;
   msg1006_expected.ant_height = 0.0;
 
   sbp_to_rtcm3_1006(&sbp_base_pos, &msg1006_out);


### PR DESCRIPTION
…fset

Changes 1006 message to behave the same as 1005 message

fixes this https://github.com/swift-nav/piksi_v3_bug_tracking/issues/412