### PR TITLE
Update default portmode for TCP Server 1 to NMEA

### DIFF
--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -197,7 +197,7 @@ static adapter_config_t tcp_server0_adapter_config = {
 static adapter_config_t tcp_server1_adapter_config = {
   .name = "tcp_server1",
   .opts = "--tcp-l 55556",
-  .mode = PORT_MODE_SBP,
+  .mode = PORT_MODE_NMEA,
   .pid = 0
 };
 


### PR DESCRIPTION
Go back to the way it was to v1.0.11

It is convenient to have both outputs possible out-of-the box.  This way the documents are also consistent for 1.0.11 and the release.