### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - make firmware
         - make docker-setup
         - bash -c "while true; do sleep 1m; echo ...; done" &
-        - make docker-make-image 2>&1 | tee -a build.out | grep --line-buffered '^>>>'
+        - set -o pipefail && make docker-make-image 2>&1 | tee -a build.out | grep --line-buffered '^>>>'
       after_success:
         - git fetch --tags --unshallow
         - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh build.out buildroot/output/images/piksiv3_prod/*
@@ -31,7 +31,7 @@ matrix:
         - make firmware
         - make docker-setup
         - bash -c "while true; do sleep 1m; echo ...; done" &
-        - make docker-make-host-image 2>&1 | tee -a host_build.out | grep --line-buffered '^>>>'
+        - set -o pipefail && make docker-make-host-image 2>&1 | tee -a host_build.out | grep --line-buffered '^>>>'
       after_success:
         - git fetch --tags --unshallow
         - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh host_build.out

--- a/package/sbp_rtcm3_bridge/sbp_rtcm3_bridge/test/Makefile
+++ b/package/sbp_rtcm3_bridge/sbp_rtcm3_bridge/test/Makefile
@@ -1,10 +1,11 @@
 TARGET=test_sbp_rtcm3_bridge
 SOURCES= \
 	rtcm_decoder_tests.c \
-	sbp_rtcm_converter_tests.c \
-	../src/sbp_rtcm3_bridge.a # should always be last
-LIBS=-lczmq -lsbp -lpiksi -lm
-CFLAGS=-std=gnu11 -I../src
+	sbp_rtcm_converter_tests.c
+LIBS= \
+	-lczmq -lsbp -lpiksi -lm \
+	../src/sbp_rtcm3_bridge.a
+CFLAGS=-std=gnu11 -z muldefs -I../src
 
 CROSS=
 

--- a/package/standalone_file_logger/standalone_file_logger/test/Makefile
+++ b/package/standalone_file_logger/standalone_file_logger/test/Makefile
@@ -1,9 +1,10 @@
 TARGET=test_standalone_file_logger
 SOURCES= \
-	run_rotating_logger_test.cc \
-	../src/standalone_file_logger.a # should always be last
-LIBS=-lczmq -lzmq -lsbp -lpiksi -lpthread -lgtest
-CFLAGS=-std=gnu++11 -I../src
+	run_rotating_logger_test.cc
+LIBS= \
+	-lczmq -lzmq -lsbp -lpiksi -lpthread -lgtest \
+	../src/standalone_file_logger.a
+CFLAGS=-std=gnu++11 -z muldefs -I../src
 
 CROSS=
 


### PR DESCRIPTION
- Add `set -o pipefail` to Travis commands
- Fix multiple definition of main() for test executables with `-z muldefs`

>The exit status of a pipeline is the exit status of the last command in the pipeline, unless the pipefail option is enabled

This was preventing the build from failing when it should have.

/cc @swift-nav/firmware @mfine 