### PR TITLE
Encode MAX size when appropriate

### DIFF
--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
@@ -253,9 +253,8 @@ u8 rtcm3_obs_to_sbp(const rtcm_obs_message *rtcm_obs, msg_obs_t *sbp_obs[4],
   }
 
   if (index > 0) {
-    u8 num_obs = index % MAX_OBS_IN_SBP == 0 ? MAX_OBS_IN_SBP : index % MAX_OBS_IN_SBP;
     sizes[sbp_msg++] = sizeof(observation_header_t) +
-                              num_obs * sizeof(packed_obs_content_t);
+      (((index - 1) % MAX_OBS_IN_SBP) + 1) * sizeof(packed_obs_content_t);
     for (u8 msg = 0; msg < sbp_msg; ++msg) {
       sbp_obs[msg]->header.n_obs = ((sbp_msg << 4) | msg);
     }

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
@@ -253,8 +253,9 @@ u8 rtcm3_obs_to_sbp(const rtcm_obs_message *rtcm_obs, msg_obs_t *sbp_obs[4],
   }
 
   if (index > 0) {
+    u8 num_obs = index % MAX_OBS_IN_SBP == 0 ? MAX_OBS_IN_SBP : index % MAX_OBS_IN_SBP;
     sizes[sbp_msg++] = sizeof(observation_header_t) +
-                       index % MAX_OBS_IN_SBP * sizeof(packed_obs_content_t);
+                              num_obs * sizeof(packed_obs_content_t);
     for (u8 msg = 0; msg < sbp_msg; ++msg) {
       sbp_obs[msg]->header.n_obs = ((sbp_msg << 4) | msg);
     }

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -31,7 +31,7 @@
 #define SBP_SUB_ENDPOINT    ">tcp://127.0.0.1:43030"  /* SBP External Out */
 #define SBP_PUB_ENDPOINT    ">tcp://127.0.0.1:43031"  /* SBP External In */
 
-extern bool rtcm3_debug = false;
+bool rtcm3_debug = false;
 
 static int rtcm3_reader_handler(zloop_t *zloop, zsock_t *zsock, void *arg)
 {


### PR DESCRIPTION

This is to fix the following defect

https://github.com/swift-nav/piksi_v3_bug_tracking/issues/435

where the length of the sbp message was being set to one when we the final sbp message was of full length. This was showing up on the novatel as it often dropped to tracking 7 sats, but CORS stations rarely did

@pgrgich