### PR TITLE
Port improvements

### DIFF
--- a/package/piksi_system_daemon/src/Makefile
+++ b/package/piksi_system_daemon/src/Makefile
@@ -2,6 +2,7 @@ TARGET=piksi_system_daemon
 SOURCES= \
 	main.c \
 	protocols.c \
+	ports.c \
 	ntrip.c \
 	skylark.c \
 	whitelists.c

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -32,6 +32,7 @@
 #include <linux/if_link.h>
 
 #include "protocols.h"
+#include "ports.h"
 #include "ntrip.h"
 #include "skylark.h"
 #include "whitelists.h"
@@ -42,7 +43,6 @@
 #define PUB_ENDPOINT ">tcp://127.0.0.1:43011"
 #define SUB_ENDPOINT ">tcp://127.0.0.1:43010"
 
-#define PORT_MODE_NAME_DEFAULT "SBP"
 #define SBP_FRAMING_MAX_PAYLOAD_SIZE 255
 #define SBP_MAX_NETWORK_INTERFACES 10
 
@@ -152,225 +152,6 @@ static int flow_control_notify(void *context)
 {
   const uart_t *uart = (uart_t *)context;
   return uart_configure(uart);
-}
-
-typedef union {
-  struct {
-    uint32_t port;
-  } tcp_server_data;
-  struct {
-    char address[256];
-  } tcp_client_data;
-} port_type_opts_data_t;
-
-typedef int (*port_type_opts_get_fn_t)(char *buf, size_t buf_size,
-                                       const port_type_opts_data_t *data);
-
-static int port_tcp_server_opts_get(char *buf, size_t buf_size,
-                                    const port_type_opts_data_t *data)
-{
-  uint32_t port = data->tcp_server_data.port;
-  return snprintf(buf, buf_size, "--tcp-l %u", port);
-}
-
-static int port_tcp_client_opts_get(char *buf, size_t buf_size,
-                                    const port_type_opts_data_t *data)
-{
-  const char *address = data->tcp_client_data.address;
-  return snprintf(buf, buf_size, "--tcp-c %s", address);
-}
-
-typedef struct {
-  const char * const name;
-  const char * const opts;
-  port_type_opts_data_t type_opts_data;
-  port_type_opts_get_fn_t type_opts_get;
-  u8 mode;
-  pid_t pid;
-} adapter_config_t;
-
-static adapter_config_t uart0_adapter_config = {
-  .name = "uart0",
-  .opts = "--file /dev/ttyPS0",
-  .type_opts_get = NULL,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t uart1_adapter_config = {
-  .name = "uart1",
-  .opts = "--file /dev/ttyPS1",
-  .type_opts_get = NULL,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t usb0_adapter_config = {
-  .name = "usb0",
-  .opts = "--file /dev/ttyGS0",
-  .type_opts_get = NULL,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t tcp_server0_adapter_config = {
-  .name = "tcp_server0",
-  .opts = "",
-  .type_opts_data.tcp_server_data.port = 55555,
-  .type_opts_get = port_tcp_server_opts_get,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t tcp_server1_adapter_config = {
-  .name = "tcp_server1",
-  .opts = "",
-  .type_opts_data.tcp_server_data.port = 55556,
-  .type_opts_get = port_tcp_server_opts_get,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t tcp_client0_adapter_config = {
-  .name = "tcp_client0",
-  .opts = "",
-  .type_opts_data.tcp_client_data.address = "",
-  .type_opts_get = port_tcp_client_opts_get,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t tcp_client1_adapter_config = {
-  .name = "tcp_client1",
-  .opts = "",
-  .type_opts_data.tcp_client_data.address = "",
-  .type_opts_get = port_tcp_client_opts_get,
-  .mode = -1,
-  .pid = 0
-};
-
-static adapter_config_t * const adapter_configs[] = {
-  &uart0_adapter_config,
-  &uart1_adapter_config,
-  &usb0_adapter_config,
-  &tcp_server0_adapter_config,
-  &tcp_server1_adapter_config,
-  &tcp_client0_adapter_config,
-  &tcp_client1_adapter_config
-};
-
-static int ports_setup(const char ***port_mode_enum_names)
-{
-  /* Build list of port modes */
-  int protocols_count = protocols_count_get();
-
-  const char **enum_names =
-      (const char **)malloc((1 + protocols_count) *
-                            sizeof(*enum_names));
-  if (enum_names == NULL) {
-    return -1;
-  }
-
-  for (int i = 0; i < protocols_count; i++) {
-    const protocol_t *protocol = protocols_get(i);
-    assert(protocol != NULL);
-    enum_names[i] = protocol->setting_name;
-  }
-  enum_names[protocols_count] = NULL;
-
-  /* Determine default port mode value */
-  u8 port_mode_default = 0;
-  for (int i = 0; i < protocols_count; i++) {
-    const protocol_t *protocol = protocols_get(i);
-    assert(protocol != NULL);
-    if (strcasecmp(protocol->setting_name, PORT_MODE_NAME_DEFAULT) == 0) {
-      port_mode_default = i;
-      break;
-    }
-  }
-
-  /* Initialize default port mode */
-  for (int i = 0; i < sizeof(adapter_configs) / sizeof(adapter_configs[0]);
-       i++) {
-    adapter_configs[i]->mode = port_mode_default;
-  }
-
-  *port_mode_enum_names = enum_names;
-  return 0;
-}
-
-static int port_configure(adapter_config_t *adapter_config)
-{
-  const protocol_t *protocol = protocols_get(adapter_config->mode);
-  if (protocol == NULL) {
-    return -1;
-  }
-
-  /* Prepare the command used to launch zmq_adapter. */
-  char mode_opts[256] = {0};
-  protocol->port_adapter_opts_get(mode_opts, sizeof(mode_opts),
-                                  adapter_config->name);
-
-  char type_opts[256] = {0};
-  if (adapter_config->type_opts_get != NULL) {
-    adapter_config->type_opts_get(type_opts, sizeof(type_opts),
-                                  &adapter_config->type_opts_data);
-  }
-
-  char cmd[512];
-  snprintf(cmd, sizeof(cmd),
-           "zmq_adapter %s %s %s",
-           adapter_config->opts, type_opts, mode_opts);
-
-  /* Split the command on each space for argv */
-  char *args[100] = {0};
-  args[0] = strtok(cmd, " ");
-  for (u8 i=1; (args[i] = strtok(NULL, " ")) && i < 100; i++);
-
-  /* Kill the old zmq_adapter, if it exists. */
-  if (adapter_config->pid) {
-    int ret = kill(adapter_config->pid, SIGTERM);
-    piksi_log(LOG_DEBUG,
-              "Killing zmq_adapter with PID: %d (kill returned %d, errno %d)",
-              adapter_config->pid, ret, errno);
-  }
-
-  piksi_log(LOG_DEBUG, "Starting zmq_adapter: %s", cmd);
-
-  /* Create a new zmq_adapter. */
-  if (!(adapter_config->pid = fork())) {
-    execvp(args[0], args);
-    piksi_log(LOG_ERR, "execvp error");
-    exit(EXIT_FAILURE);
-  }
-
-  piksi_log(LOG_DEBUG, "zmq_adapter started with PID: %d",
-            adapter_config->pid);
-
-  if (adapter_config->pid < 0) {
-    /* fork() failed */
-    return -1;
-  }
-
-  return 0;
-}
-
-static int port_mode_notify(void *context)
-{
-  adapter_config_t *adapter_config = (adapter_config_t *)context;
-  return port_configure(adapter_config);
-}
-
-static int port_tcp_server_port_notify(void *context)
-{
-  adapter_config_t *adapter_config = (adapter_config_t *)context;
-  return port_configure(adapter_config);
-}
-
-static int port_tcp_client_address_notify(void *context)
-{
-  adapter_config_t *adapter_config = (adapter_config_t *)context;
-  return port_configure(adapter_config);
 }
 
 static const char const * ip_mode_enum_names[] = {"Static", "DHCP", NULL};
@@ -742,12 +523,6 @@ int main(void)
   /* Configure USB0 */
   uart_configure(&usb0);
 
-  const char **port_mode_enum_names;
-  if (ports_setup(&port_mode_enum_names) != 0) {
-    piksi_log(LOG_ERR, "error setting up ports");
-    exit(EXIT_FAILURE);
-  }
-
   /* Register settings */
   settings_type_t settings_type_baudrate;
   settings_type_register_enum(settings_ctx, baudrate_enum_names,
@@ -768,49 +543,6 @@ int main(void)
   settings_register(settings_ctx, "uart1", "flow_control", &uart1.flow_control,
                     sizeof(uart1.flow_control), settings_type_flow_control,
                     flow_control_notify, &uart1);
-
-  settings_register(settings_ctx, "tcp_server0", "port",
-                    &tcp_server0_adapter_config.type_opts_data.tcp_server_data.port,
-                    sizeof(tcp_server0_adapter_config.type_opts_data.tcp_server_data.port),
-                    SETTINGS_TYPE_INT, port_tcp_server_port_notify, &tcp_server0_adapter_config);
-  settings_register(settings_ctx, "tcp_server1", "port",
-                    &tcp_server1_adapter_config.type_opts_data.tcp_server_data.port,
-                    sizeof(tcp_server1_adapter_config.type_opts_data.tcp_server_data.port),
-                    SETTINGS_TYPE_INT, port_tcp_server_port_notify, &tcp_server1_adapter_config);
-
-  settings_register(settings_ctx, "tcp_client0", "address",
-                    tcp_client0_adapter_config.type_opts_data.tcp_client_data.address,
-                    sizeof(tcp_client0_adapter_config.type_opts_data.tcp_client_data.address),
-                    SETTINGS_TYPE_STRING, port_tcp_client_address_notify, &tcp_client0_adapter_config);
-  settings_register(settings_ctx, "tcp_client1", "address",
-                    tcp_client1_adapter_config.type_opts_data.tcp_client_data.address,
-                    sizeof(tcp_client1_adapter_config.type_opts_data.tcp_client_data.address),
-                    SETTINGS_TYPE_STRING, port_tcp_client_address_notify, &tcp_client1_adapter_config);
-
-  settings_type_t settings_type_port_mode;
-  settings_type_register_enum(settings_ctx, port_mode_enum_names,
-                              &settings_type_port_mode);
-  settings_register(settings_ctx, "uart0", "mode", &uart0_adapter_config.mode,
-                    sizeof(uart0_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &uart0_adapter_config);
-  settings_register(settings_ctx, "uart1", "mode", &uart1_adapter_config.mode,
-                    sizeof(uart1_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &uart1_adapter_config);
-  settings_register(settings_ctx, "usb0", "mode", &usb0_adapter_config.mode,
-                    sizeof(usb0_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &usb0_adapter_config);
-  settings_register(settings_ctx, "tcp_server0", "mode", &tcp_server0_adapter_config.mode,
-                    sizeof(tcp_server0_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &tcp_server0_adapter_config);
-  settings_register(settings_ctx, "tcp_server1", "mode", &tcp_server1_adapter_config.mode,
-                    sizeof(tcp_server1_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &tcp_server1_adapter_config);
-  settings_register(settings_ctx, "tcp_client0", "mode", &tcp_client0_adapter_config.mode,
-                    sizeof(tcp_client0_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &tcp_client0_adapter_config);
-  settings_register(settings_ctx, "tcp_client1", "mode", &tcp_client1_adapter_config.mode,
-                    sizeof(tcp_client1_adapter_config.mode), settings_type_port_mode,
-                    port_mode_notify, &tcp_client1_adapter_config);
 
   settings_type_t settings_type_ip_mode;
   settings_type_register_enum(settings_ctx, ip_mode_enum_names,
@@ -833,6 +565,7 @@ int main(void)
   sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(pubsub_ctx),
                                SBP_MSG_RESET_DEP, reset_callback, NULL, NULL);
 
+  ports_init(settings_ctx);
   ntrip_init(settings_ctx);
   skylark_init(settings_ctx);
   whitelists_init(settings_ctx);

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -49,8 +49,10 @@
 static void sigchld_handler(int signum)
 {
   int saved_errno = errno;
-  while (waitpid(-1, NULL, WNOHANG) > 0) {
-    ;
+  pid_t pid;
+  int status;
+  while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
+    ports_sigchld_waitpid_handler(pid, status);
   }
   errno = saved_errno;
 }

--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "ports.h"
+#include "protocols.h"
+#include <libpiksi/logging.h>
+#include <string.h>
+#include <stdio.h>
+
+#define MODE_NAME_DEFAULT "SBP"
+
+#define MODE_INVALID -1
+#define PID_INVALID 0
+
+typedef enum {
+  PORT_TYPE_UART,
+  PORT_TYPE_USB,
+  PORT_TYPE_TCP_SERVER,
+  PORT_TYPE_TCP_CLIENT
+} port_type_t;
+
+typedef union {
+  struct {
+    uint32_t port;
+  } tcp_server_data;
+  struct {
+    char address[256];
+  } tcp_client_data;
+} opts_data_t;
+
+typedef int (*opts_get_fn_t)(char *buf, size_t buf_size,
+                             const opts_data_t *opts_data);
+
+static int opts_get_tcp_server(char *buf, size_t buf_size,
+                               const opts_data_t *opts_data)
+{
+  uint32_t port = opts_data->tcp_server_data.port;
+  return snprintf(buf, buf_size, "--tcp-l %u", port);
+}
+
+static int opts_get_tcp_client(char *buf, size_t buf_size,
+                               const opts_data_t *opts_data)
+{
+  const char *address = opts_data->tcp_client_data.address;
+  return snprintf(buf, buf_size, "--tcp-c %s", address);
+}
+
+typedef struct {
+  const char * const name;
+  const char * const opts;
+  const opts_get_fn_t opts_get;
+  opts_data_t opts_data;
+  const port_type_t type;
+  u8 mode;
+  pid_t adapter_pid;
+} port_config_t;
+
+static port_config_t port_configs[] = {
+  {
+    .name = "uart0",
+    .opts = "--file /dev/ttyPS0",
+    .opts_get = NULL,
+    .type = PORT_TYPE_UART,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  },
+  {
+    .name = "uart1",
+    .opts = "--file /dev/ttyPS1",
+    .opts_get = NULL,
+    .type = PORT_TYPE_UART,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  },
+  {
+    .name = "usb0",
+    .opts = "--file /dev/ttyGS0",
+    .opts_get = NULL,
+    .type = PORT_TYPE_USB,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  },
+  {
+    .name = "tcp_server0",
+    .opts = "",
+    .opts_data.tcp_server_data.port = 55555,
+    .opts_get = opts_get_tcp_server,
+    .type = PORT_TYPE_TCP_SERVER,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  },
+  {
+    .name = "tcp_server1",
+    .opts = "",
+    .opts_data.tcp_server_data.port = 55556,
+    .opts_get = opts_get_tcp_server,
+    .type = PORT_TYPE_TCP_SERVER,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  },
+  {
+    .name = "tcp_client0",
+    .opts = "",
+    .opts_data.tcp_client_data.address = "",
+    .opts_get = opts_get_tcp_client,
+    .type = PORT_TYPE_TCP_CLIENT,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  },
+  {
+    .name = "tcp_client1",
+    .opts = "",
+    .opts_data.tcp_client_data.address = "",
+    .opts_get = opts_get_tcp_client,
+    .type = PORT_TYPE_TCP_CLIENT,
+    .mode = MODE_INVALID,
+    .adapter_pid = PID_INVALID
+  }
+};
+
+static int port_configure(port_config_t *port_config)
+{
+  const protocol_t *protocol = protocols_get(port_config->mode);
+  if (protocol == NULL) {
+    return -1;
+  }
+
+  /* Prepare the command used to launch zmq_adapter. */
+  char mode_opts[256] = {0};
+  protocol->port_adapter_opts_get(mode_opts, sizeof(mode_opts),
+                                  port_config->name);
+
+  char opts[256] = {0};
+  if (port_config->opts_get != NULL) {
+    port_config->opts_get(opts, sizeof(opts), &port_config->opts_data);
+  }
+
+  char cmd[512];
+  snprintf(cmd, sizeof(cmd),
+           "zmq_adapter %s %s %s",
+           port_config->opts, opts, mode_opts);
+
+  /* Split the command on each space for argv */
+  char *args[32] = {0};
+  args[0] = strtok(cmd, " ");
+  for (u8 i=1; (args[i] = strtok(NULL, " ")) && i < 32; i++);
+
+  /* Kill the old zmq_adapter, if it exists. */
+  if (port_config->adapter_pid > 0) {
+    int ret = kill(port_config->adapter_pid, SIGTERM);
+    piksi_log(LOG_DEBUG,
+              "Killing zmq_adapter with PID: %d (kill returned %d, errno %d)",
+              port_config->adapter_pid, ret, errno);
+    port_config->adapter_pid = 0;
+  }
+
+  piksi_log(LOG_DEBUG, "Starting zmq_adapter: %s", cmd);
+
+  /* Create a new zmq_adapter. */
+  if (!(port_config->adapter_pid = fork())) {
+    execvp(args[0], args);
+    piksi_log(LOG_ERR, "execvp error");
+    exit(EXIT_FAILURE);
+  }
+
+  piksi_log(LOG_DEBUG, "zmq_adapter started with PID: %d",
+            port_config->adapter_pid);
+
+  if (port_config->adapter_pid < 0) {
+    /* fork() failed */
+    return -1;
+  }
+
+  return 0;
+}
+
+static int setting_mode_notify(void *context)
+{
+  port_config_t *port_config = (port_config_t *)context;
+  return port_configure(port_config);
+}
+
+static int setting_tcp_server_port_notify(void *context)
+{
+  port_config_t *port_config = (port_config_t *)context;
+  return port_configure(port_config);
+}
+
+static int setting_tcp_client_address_notify(void *context)
+{
+  port_config_t *port_config = (port_config_t *)context;
+  return port_configure(port_config);
+}
+
+static int setting_mode_register(settings_ctx_t *settings_ctx,
+                                 settings_type_t settings_type,
+                                 port_config_t *port_config)
+{
+  return settings_register(settings_ctx, port_config->name, "mode",
+                           &port_config->mode, sizeof(port_config->mode),
+                           settings_type, setting_mode_notify,
+                           port_config);
+}
+
+static int setting_tcp_server_port_register(settings_ctx_t *settings_ctx,
+                                            port_config_t *port_config)
+{
+  return settings_register(settings_ctx, port_config->name, "port",
+                           &port_config->opts_data.tcp_server_data.port,
+                           sizeof(&port_config->opts_data.tcp_server_data.port),
+                           SETTINGS_TYPE_INT, setting_tcp_server_port_notify,
+                           port_config);
+}
+
+static int setting_tcp_client_address_register(settings_ctx_t *settings_ctx,
+                                               port_config_t *port_config)
+{
+  return settings_register(settings_ctx, port_config->name, "address",
+                           port_config->opts_data.tcp_client_data.address,
+                           sizeof(port_config->opts_data.tcp_client_data.address),
+                           SETTINGS_TYPE_STRING, setting_tcp_client_address_notify,
+                           port_config);
+}
+
+static int mode_enum_names_get(const char ***mode_enum_names)
+{
+  int protocols_count = protocols_count_get();
+
+  const char **enum_names =
+      (const char **)malloc((1 + protocols_count) *
+                            sizeof(*enum_names));
+  if (enum_names == NULL) {
+    return -1;
+  }
+
+  for (int i = 0; i < protocols_count; i++) {
+    const protocol_t *protocol = protocols_get(i);
+    assert(protocol != NULL);
+    enum_names[i] = protocol->setting_name;
+  }
+  enum_names[protocols_count] = NULL;
+
+  *mode_enum_names = enum_names;
+  return 0;
+}
+
+static int mode_default_get(u8 *mode_default)
+{
+  int protocols_count = protocols_count_get();
+
+  for (int i = 0; i < protocols_count; i++) {
+    const protocol_t *protocol = protocols_get(i);
+    assert(protocol != NULL);
+    if (strcasecmp(protocol->setting_name, MODE_NAME_DEFAULT) == 0) {
+      *mode_default = i;
+      return 0;
+    }
+  }
+  return -1;
+}
+
+int ports_init(settings_ctx_t *settings_ctx)
+{
+  int i;
+
+  /* Initialize default mode */
+  u8 mode_default = 0;
+  mode_default_get(&mode_default);
+
+  for (i = 0; i < sizeof(port_configs) / sizeof(port_configs[0]); i++) {
+    port_configs[i].mode = mode_default;
+  }
+
+  /* Get mode enum names */
+  const char **mode_enum_names;
+  if (mode_enum_names_get(&mode_enum_names) != 0) {
+    piksi_log(LOG_ERR, "error setting up port modes");
+    return -1;
+  }
+
+  /* Register settings types */
+  settings_type_t settings_type_mode;
+  settings_type_register_enum(settings_ctx, mode_enum_names,
+                              &settings_type_mode);
+
+  /* Register settings */
+  for (i = 0; i < sizeof(port_configs) / sizeof(port_configs[0]); i++) {
+    port_config_t *port_config = &port_configs[i];
+
+    setting_mode_register(settings_ctx, settings_type_mode, port_config);
+
+    if (port_config->type == PORT_TYPE_TCP_SERVER) {
+      setting_tcp_server_port_register(settings_ctx, port_config);
+    }
+
+    if (port_config->type == PORT_TYPE_TCP_CLIENT) {
+      setting_tcp_client_address_register(settings_ctx, port_config);
+    }
+  }
+
+  return 0;
+}

--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -122,7 +122,7 @@ static port_config_t port_configs[] = {
     .opts_data.tcp_client_data.address = "",
     .opts_get = opts_get_tcp_client,
     .type = PORT_TYPE_TCP_CLIENT,
-    .mode_name_default = MODE_NAME_DEFAULT,
+    .mode_name_default = MODE_NAME_DISABLED,
     .mode = MODE_DISABLED,
     .adapter_pid = PID_INVALID
   },
@@ -132,7 +132,7 @@ static port_config_t port_configs[] = {
     .opts_data.tcp_client_data.address = "",
     .opts_get = opts_get_tcp_client,
     .type = PORT_TYPE_TCP_CLIENT,
-    .mode_name_default = MODE_NAME_DEFAULT,
+    .mode_name_default = MODE_NAME_DISABLED,
     .mode = MODE_DISABLED,
     .adapter_pid = PID_INVALID
   }

--- a/package/piksi_system_daemon/src/ports.h
+++ b/package/piksi_system_daemon/src/ports.h
@@ -16,8 +16,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sys/wait.h>
 #include <libpiksi/settings.h>
 
 int ports_init(settings_ctx_t *settings_ctx);
+void ports_sigchld_waitpid_handler(pid_t pid, int status);
 
 #endif /* SWIFTNAV_PORTS_H */

--- a/package/piksi_system_daemon/src/ports.h
+++ b/package/piksi_system_daemon/src/ports.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SWIFTNAV_PORTS_H
+#define SWIFTNAV_PORTS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <libpiksi/settings.h>
+
+int ports_init(settings_ctx_t *settings_ctx);
+
+#endif /* SWIFTNAV_PORTS_H */


### PR DESCRIPTION
- Move ports handling into a separate file
- Add "disabled" port mode
- Check exit status of forked `zmq_adapter` processes
- Specify default mode for each port
- Disable TCP client ports by default

TODO: 
- [x] Test

/cc @swift-nav/firmware @denniszollo 