### PR TITLE
Copy over config.ini with boot files

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -12,13 +12,15 @@ copy_from_sd() {
   local sd_file="$sd_path/$filename"
   local output_file="$output_path/$filename"
 
-  rm -f "$output_file"
-  echo "Copying $filename from SD card"
-  mkdir -p "$output_path"
-  cp "$sd_file" "$output_file"
+  if [ -f "$sd_file" ]; then
+    rm -f "$output_file"
+    echo "Copying $filename from SD card"
+    mkdir -p "$output_path"
+    cp "$sd_file" "$output_file"
 
-  if [ ! -f "$output_file" ]; then
-    echo "ERROR: copy failed for $output_file"
+    if [ ! -f "$output_file" ]; then
+      echo "ERROR: copy failed for $output_file"
+    fi
   fi
 }
 
@@ -29,14 +31,20 @@ copy_from_net() {
   local uuid=`cat /factory/uuid`
   local net_file="PK$uuid/$filename"
   local output_file="$output_path/$filename"
+  local tmp_file="/tmp/$filename"
 
-  rm -f "$output_file"
-  echo "Copying $filename from network"
-  mkdir -p "$output_path"
-  tftp -g -r "$net_file" -l "$output_file" -b 65464 "$server_ip"
+  echo "Retrieving $filename from network"
+  tftp -g -r "$net_file" -l "$tmp_file" -b 65464 "$server_ip"
 
-  if [ ! -f "$output_file" ]; then
-    echo "ERROR: copy failed for $output_file"
+  if [ -f "$tmp_file" ]; then
+    rm -f "$output_file"
+    echo "Copying $filename from network"
+    mkdir -p "$output_path"
+    cp "$tmp_file" "$output_file"
+
+    if [ ! -f "$output_file" ]; then
+      echo "ERROR: copy failed for $output_file"
+    fi
   fi
 }
 

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -18,7 +18,7 @@ copy_from_sd() {
   cp "$sd_file" "$output_file"
 
   if [ ! -f "$output_file" ]; then
-    echo "ERROR: copy failed"
+    echo "ERROR: copy failed for $output_file"
   fi
 }
 
@@ -36,7 +36,7 @@ copy_from_net() {
   tftp -g -r "$net_file" -l "$output_file" -b 65464 "$server_ip"
 
   if [ ! -f "$output_file" ]; then
-    echo "ERROR: copy failed"
+    echo "ERROR: copy failed for $output_file"
   fi
 }
 

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -55,7 +55,6 @@ start() {
     # configuration
     rm -f $lib_output_path/piksi_firmware.elf
     rm -f $lib_output_path/piksi_fpga.bit
-    rm -f $persistent_output_path/config.ini
   fi
 
   if [ "$dev_boot" == "sd" ]; then

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -2,11 +2,13 @@
 
 name="dev_boot"
 
-output_path="/lib/firmware"
+lib_output_path="/lib/firmware"
+persistent_output_path="/persistent"
 
 copy_from_sd() {
   local sd_path=$1
   local filename=$2
+  local output_path=$3
   local sd_file="$sd_path/$filename"
   local output_file="$output_path/$filename"
 
@@ -23,6 +25,7 @@ copy_from_sd() {
 copy_from_net() {
   local server_ip=$1
   local filename=$2
+  local output_path=$3
   local uuid=`cat /factory/uuid`
   local net_file="PK$uuid/$filename"
   local output_file="$output_path/$filename"
@@ -50,22 +53,25 @@ start() {
   if [ -n "$dev_boot" ]; then
     # If dev_boot is set to something (not null), then we are in the dev
     # configuration
-    rm -f $output_path/piksi_firmware.elf
-    rm -f $output_path/piksi_fpga.bit
+    rm -f $lib_output_path/piksi_firmware.elf
+    rm -f $lib_output_path/piksi_fpga.bit
+    rm -f $persistent_path/config.ini
   fi
 
   if [ "$dev_boot" == "sd" ]; then
     sd_path="/media/mmcblk0p1"
-    copy_from_sd $sd_path "piksi_firmware.elf"
-    copy_from_sd $sd_path "piksi_fpga.bit"
+    copy_from_sd $sd_path "piksi_firmware.elf" $lib_output_path
+    copy_from_sd $sd_path "piksi_fpga.bit" $lib_output_path
+    copy_from_sd $sd_path "config.ini" $persistent_path
   fi
 
   if [ "$dev_boot" == "net" ]; then
     # Get server ip from 'ip' bootarg
     server_ip=`cat /proc/device-tree/chosen/bootargs |
                sed -n -e 's/^.*ip=[^:]*:\([^:]*\).*/\1/p'`
-    copy_from_net $server_ip "piksi_firmware.elf"
-    copy_from_net $server_ip "piksi_fpga.bit"
+    copy_from_net $server_ip "piksi_firmware.elf" $lib_output_path
+    copy_from_net $server_ip "piksi_fpga.bit" $lib_output_path
+    copy_from_net $server_ip "config.ini" $persistent_output_path
   fi
 }
 

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -55,14 +55,14 @@ start() {
     # configuration
     rm -f $lib_output_path/piksi_firmware.elf
     rm -f $lib_output_path/piksi_fpga.bit
-    rm -f $persistent_path/config.ini
+    rm -f $persistent_output_path/config.ini
   fi
 
   if [ "$dev_boot" == "sd" ]; then
     sd_path="/media/mmcblk0p1"
     copy_from_sd $sd_path "piksi_firmware.elf" $lib_output_path
     copy_from_sd $sd_path "piksi_fpga.bit" $lib_output_path
-    copy_from_sd $sd_path "config.ini" $persistent_path
+    copy_from_sd $sd_path "config.ini" $persistent_output_path
   fi
 
   if [ "$dev_boot" == "net" ]; then

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -53,6 +53,7 @@ start() {
   if [ -n "$dev_boot" ]; then
     # If dev_boot is set to something (not null), then we are in the dev
     # configuration
+    # DO NOT remove existing persistent settings configuration
     rm -f $lib_output_path/piksi_firmware.elf
     rm -f $lib_output_path/piksi_fpga.bit
   fi
@@ -61,6 +62,7 @@ start() {
     sd_path="/media/mmcblk0p1"
     copy_from_sd $sd_path "piksi_firmware.elf" $lib_output_path
     copy_from_sd $sd_path "piksi_fpga.bit" $lib_output_path
+    # Overwrites settings if present on sd card.
     copy_from_sd $sd_path "config.ini" $persistent_output_path
   fi
 
@@ -70,6 +72,7 @@ start() {
                sed -n -e 's/^.*ip=[^:]*:\([^:]*\).*/\1/p'`
     copy_from_net $server_ip "piksi_firmware.elf" $lib_output_path
     copy_from_net $server_ip "piksi_fpga.bit" $lib_output_path
+    # Overwrite settings if present on network boot.
     copy_from_net $server_ip "config.ini" $persistent_output_path
   fi
 }


### PR DESCRIPTION
We'd like to copy over a config on boot - it provides a more reliable mechanism for ensuring configuration on startup then other means, especially sending sbp settings messages on startup.

/cc @axlan @jacobmcnamee @denniszollo 