### PR TITLE
Rtcm 1001 1003 ms ambiguity fix

### DIFF
--- a/package/sbp_rtcm3_bridge/src/rtcm3_decode.c
+++ b/package/sbp_rtcm3_bridge/src/rtcm3_decode.c
@@ -19,8 +19,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libsbp/gnss.h>
 
-u32 pseudorange_amb[RTCM_MAX_SATS];
+typedef struct{
+  u8 amb;
+  gps_time_nano_t time_rcv;
+}decoded_ambs;
+
+decoded_ambs pseudorange_amb[RTCM_MAX_SATS];
+
+extern gps_time_nano_t time_from_rover_obs;
 
 /** Get bit field from buffer as an unsigned integer.
  * Unpacks `len` bits at bit position `pos` from the start of the buffer.
@@ -578,19 +586,43 @@ s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001) {
   return 0;
 }
 
+double gpsdifftime(const gps_time_nano_t *end, const gps_time_nano_t *beginning)
+{
+  double dt = end->tow - beginning->tow;
+  if (end->wn == WK_UNKNOWN || beginning->wn == WK_UNKNOWN) {
+    /* One or both of the week numbers is unspecified.  Assume times
+       are within +/- 0.5 weeks of each other. */
+    if (dt > WEEK_SECS / 2)
+      dt -= WEEK_SECS;
+    if (dt < -WEEK_SECS / 2)
+      dt += WEEK_SECS;
+  } else {
+    /* Week numbers were provided - use them. */
+    dt += (end->wn - beginning->wn) * WEEK_SECS;
+  }
+  return dt;
+}
+
+void adjust_ms_freq(rtcm_freq_data *freq_data, decoded_ambs amb_time, freq_enum freq){
+  freq_data->pseudorange += PRUNIT_GPS * amb_time.amb;
+  freq_data->carrier_phase += (PRUNIT_GPS * amb_time.amb) / (CLIGHT / FREQS[freq]);
+
+  double timediff = gpsdifftime(&time_from_rover_obs, &amb_time.time_rcv);
+  if(abs(timediff) > 20.0){
+    freq_data->flags.valid_pr = 0;
+    freq_data->flags.valid_cp = 0;
+    freq_data->flags.valid_lock = 0;
+    freq_data->flags.valid_cnr = 0;
+  }
+}
+
 void apply_ms_ambiguitiy(rtcm_obs_message *rtcm_msg){
   for (u8 i = 0; i < rtcm_msg->header.n_sat; i++) {
     rtcm_freq_data *l1_freq_data = &rtcm_msg->sats[i].obs[L1_FREQ];
-    rtcm_freq_data *l2_freq_data = &rtcm_msg->sats[i].obs[L2_FREQ];
+    adjust_ms_freq(l1_freq_data, pseudorange_amb[rtcm_msg->sats[i].svId], L1_FREQ);
 
-    l1_freq_data->pseudorange += PRUNIT_GPS * pseudorange_amb[rtcm_msg->sats[i].svId];
-    l1_freq_data->carrier_phase +=
-      (PRUNIT_GPS * pseudorange_amb[rtcm_msg->sats[i].svId]) /
-      (CLIGHT / FREQS[L1_FREQ]);
-    l2_freq_data->pseudorange += PRUNIT_GPS * pseudorange_amb[rtcm_msg->sats[i].svId];
-    l2_freq_data->carrier_phase +=
-      (PRUNIT_GPS * pseudorange_amb[rtcm_msg->sats[i].svId]) /
-      (CLIGHT / FREQS[L2_FREQ]);
+    rtcm_freq_data *l2_freq_data = &rtcm_msg->sats[i].obs[L2_FREQ];
+    adjust_ms_freq(l2_freq_data, pseudorange_amb[rtcm_msg->sats[i].svId], L2_FREQ);
   }
 }
 
@@ -955,8 +987,9 @@ void init_data(rtcm_sat_data *sat_data) {
   }
 }
 
-void update_pseudorange_ambiguity(gnss_signal16_t sid, double pseudorange){
+void update_pseudorange_ambiguity(gnss_signal16_t sid, gps_time_nano_t tor, double pseudorange){
   if( sid.sat >= 0 && sid.sat <= RTCM_MAX_SATS) {
-    pseudorange_amb[sid.sat] = (u32)(pseudorange / PRUNIT_GPS);
+    pseudorange_amb[sid.sat].amb = (u8)(pseudorange / PRUNIT_GPS);
+    pseudorange_amb[sid.sat].time_rcv = tor;
   }
 }

--- a/package/sbp_rtcm3_bridge/src/rtcm3_decode.h
+++ b/package/sbp_rtcm3_bridge/src/rtcm3_decode.h
@@ -29,6 +29,15 @@ void setbitsl(u8 *buff, u32 pos, u32 len, s64 data);
 #define RTCM3_PREAMBLE 0xD3   /**< RTCM v3 Frame sync / preamble byte. */
 #define PRUNIT_GPS 299792.458 /**< RTCM v3 Unit of GPS Pseudorange (m) */
 
+#define WK_UNKNOWN          -1
+#define WEEK_DAYS           7
+#define MINUTE_SECS         60
+#define HOUR_MINUTES        60
+#define DAY_HOURS           24
+#define DAY_SECS            (DAY_HOURS * HOUR_MINUTES * MINUTE_SECS)
+#define WEEK_SECS           (WEEK_DAYS * DAY_SECS)
+
+
 u16 rtcm3_write_header(const rtcm_msg_header *header, u8 num_sats, u8 *buff);
 u16 rtcm3_read_header(const u8 *buff, rtcm_msg_header *header);
 static u8 to_lock_ind(u32 time);
@@ -74,6 +83,6 @@ static s8 encode_basic_freq_data(const rtcm_freq_data *freq_data,
                                  u16 *bit);
 static void init_data(rtcm_sat_data *sat_data);
 
-void update_pseudorange_ambiguity(gnss_signal16_t sid, double pseudorange);
+void update_pseudorange_ambiguity(gnss_signal16_t sid, gps_time_nano_t tor, double pseudorange);
 
 #endif /* SWIFTNAV_RTCM3_DECODE_H */

--- a/package/sbp_rtcm3_bridge/src/rtcm3_decode.h
+++ b/package/sbp_rtcm3_bridge/src/rtcm3_decode.h
@@ -14,6 +14,7 @@
 #define SWIFTNAV_RTCM3_DECODE_H
 
 #include "rtcm3_messages.h"
+#include <libsbp/gnss.h>
 #include <stdbool.h>
 
 u32 getbitu(const u8 *buff, u32 pos, u8 len);
@@ -52,6 +53,9 @@ s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003);
 s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004);
 s8 rtcm3_decode_1005_base(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005,
                           u16 *bit);
+
+void apply_ms_ambiguitiy(rtcm_obs_message *rtcm_msg);
+
 s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005);
 s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006);
 s8 rtcm3_decode_1007_base(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007,
@@ -69,5 +73,7 @@ static s8 encode_basic_freq_data(const rtcm_freq_data *freq_data,
                                  freq_enum freq, const double *l1_pr, u8 *buff,
                                  u16 *bit);
 static void init_data(rtcm_sat_data *sat_data);
+
+void update_pseudorange_ambiguity(gnss_signal16_t sid, double pseudorange);
 
 #endif /* SWIFTNAV_RTCM3_DECODE_H */

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
@@ -24,7 +24,7 @@
 
 // time given from rover observation data. Must be maintained to within half a week of
 // the epoch of incoming RTCM data
-static gps_time_nano_t time_from_rover_obs = { .tow = 0, .ns_residual = 0, .wn = .0 };
+gps_time_nano_t time_from_rover_obs = { .tow = 0, .ns_residual = 0, .wn = .0 };
 
 static double gps_diff_time(const gps_time_nano_t *end, const gps_time_nano_t *beginning)
 {
@@ -522,6 +522,9 @@ void sbp_obs_callback(u16 sender_id, u8 len, u8 msg[], void *context)
     return;
   }
 
+  observation_header_t* obs_header = (observation_header_t*)msg;
+  gps_time_nano_t tor = obs_header->t;
+
   /* Calculate the number of observations in this message by looking at the SBP
    * `len` field. */
   u8 obs_in_msg = (len - sizeof(observation_header_t)) / sizeof(packed_obs_content_t);
@@ -534,6 +537,6 @@ void sbp_obs_callback(u16 sender_id, u8 len, u8 msg[], void *context)
     /* We're only interested in the pseudorange observation */
     double pseudorange = ((double)obs[i].P) / MSG_OBS_P_MULTIPLIER;
 
-    update_pseudorange_ambiguity(sid, pseudorange);
+    update_pseudorange_ambiguity(sid, tor, pseudorange);
   }
 }

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3.c
@@ -532,7 +532,7 @@ void sbp_obs_callback(u16 sender_id, u8 len, u8 msg[], void *context)
     gnss_signal16_t sid = obs[i].sid;
 
     /* We're only interested in the pseudorange observation */
-    double pseudorange = ((double)obs->P) / MSG_OBS_P_MULTIPLIER;
+    double pseudorange = ((double)obs[i].P) / MSG_OBS_P_MULTIPLIER;
 
     update_pseudorange_ambiguity(sid, pseudorange);
   }

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3.h
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3.h
@@ -85,5 +85,6 @@ void sbp_to_rtcm3_1006(const msg_base_pos_ecef_t *sbp_base_pos,
                        rtcm_msg_1006 *rtcm_1006);
 
 void gps_time_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+void sbp_obs_callback(u16 sender_id, u8 len, u8 msg[], void *context);
 
 #endif // PIKSI_BUILDROOT_SBP_RTCM3_H

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -139,6 +139,11 @@ int main(int argc, char *argv[])
     exit(EXIT_FAILURE);
   }
 
+  if (sbp_callback_register(SBP_MSG_OBS, sbp_obs_callback, NULL) != 0) {
+    piksi_log(LOG_ERR, "error setting SBP OBS callback");
+    exit(EXIT_FAILURE);
+  }
+
   zmq_simple_loop(sbp_zmq_pubsub_zloop_get(ctx));
 
   exit(EXIT_SUCCESS);


### PR DESCRIPTION

This is an attempt to get around the missing ms ambiguity for the condensed RTCM messages (1001,1003) if we must support these messages.

The idea is to listen to the observations being sent from the piksi, work out and store what the expected ms ambiguity would be, and then use that to decode messages 1001 and 1003. We shouldn't need to do much checking on this value, as if the rover is not sending us this message, then it doesn't matter what we decode from the reference station. (this is a big assumption)

My recommendation for the release would be to not support these messages, if this is a deal breaker for product then I think I can get this working but would want to test it thoroughly.

@denniszollo @pgrgich @mbavaro 