### PR TITLE
Fix script typo on usb-drive functions: reset2defaults and usb_upgrade.

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/reset2defaults.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/reset2defaults.sh
@@ -10,15 +10,15 @@ _dir_wait () {
     RET=1
     REPEATS="${1}"
     LEN_TIMEOUT_MS="${2}"
-    MNT_PATH="${4}"
-    until [ -x $FIRMWARE ] || [ $REPEATS -lt 1 ]; do
+    MNT_PATH="${3}"
+    until [ -x $MNT_PATH ] || [ $REPEATS -lt 1 ]; do
        usleep $(( $LEN_TIMEOUT_MS * 1000 ))
        let REPEATS=$REPEATS-1
     done
 }
 
 # try and mount drive for up to 5 seconds or until success 
-_dir_wait 20 250 /media/sda1
+_dir_wait 20 250 $RESETFILE
 
 if [ ! -x $RESETFILE ]; then
   echo "No reset to defaults file found"

--- a/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
@@ -10,15 +10,15 @@ _dir_wait () {
     RET=1
     REPEATS="${1}"
     LEN_TIMEOUT_MS="${2}"
-    MNT_PATH="${4}"
-    until [ -x $FIRMWARE ] || [ $REPEATS -lt 1 ]; do
+    MNT_PATH="${3}"
+    until [ -x $MNT_PATH ] || [ $REPEATS -lt 1 ]; do
        usleep $(( $LEN_TIMEOUT_MS * 1000 ))
        let REPEATS=$REPEATS-1
     done
 }
 
 # try and mount drive for up to 5 seconds or until success 
-_dir_wait 20 250 /media/sda1
+_dir_wait 20 250 $FIRMWARE
 
 if [ `echo $FIRMWARE | wc -w` != '1' ]; then
   echo 'Unable to perform upgrade: exactly one firmware image is required' | sbp_log $LOGLEVEL


### PR DESCRIPTION
The reset2defaults was only working when a firmware file existed on flash drive due to my typo.  This should fix.