### PR TITLE
updated uboot for factory hardware revision

### DIFF
--- a/package/factory_data_tool/src/factory_data_tool.c
+++ b/package/factory_data_tool/src/factory_data_tool.c
@@ -196,6 +196,10 @@ int main(int argc, char *argv[])
     factory_file_write_hex_string("mac_address",
                                    mac_address, sizeof(mac_address));
   }
+  uint32_t hardware_version;
+  if (factory_data_hardware_revision_get(factory_data, &hardware_version) == 0) {
+    factory_file_write_u32("hardware_version", hardware_version);
+  }
 
   exit(EXIT_SUCCESS);
 }

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = 1b3665029e35a52df273d1b1d66ae95630db35d6
+UBOOT_CUSTOM_VERSION = 1aeccd295d837e1dc3765f6289a539da28d0987e
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = 6b58d8e7ba10e1359c15d192a6a38872e33cb36e
+UBOOT_CUSTOM_VERSION = c0a1a0bbbb0bae138ab47f8574504e32c093d0c9
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools

--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = 1aeccd295d837e1dc3765f6289a539da28d0987e
+UBOOT_CUSTOM_VERSION = 6b58d8e7ba10e1359c15d192a6a38872e33cb36e
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools


### PR DESCRIPTION
Depends on https://github.com/swift-nav/u-boot-xlnx/pull/35 , uboot SHA must be updated when that's merged.

See also:
https://github.com/swift-nav/piksi_firmware_private/pull/852