### PR TITLE
Update whitelists.c

### DIFF
--- a/package/piksi_system_daemon/src/whitelists.c
+++ b/package/piksi_system_daemon/src/whitelists.c
@@ -51,7 +51,7 @@ typedef struct {
 static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   [PORT_UART0] = {
     .name = "uart0",
-    .wl = "68,72,73,74,65535"
+    .wl = "72,74,65535"
   },
   [PORT_UART1] = {
     .name = "uart1",


### PR DESCRIPTION
Customer noticed vestigal messages in the UART0 default message mask.  This reduces the UART0 default message mask for the bare minimum messages for RTK.
/cc @switanis

