### PR TITLE
make ifup run in background to prevent blocking setting callback

### DIFF
--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -178,7 +178,7 @@ static void eth_update_config(void)
   }
   fclose(interfaces);
 
-  system("ifup eth0");
+  system("ifup eth0 &");
 }
 
 static int eth_ip_mode_notify(void *context)


### PR DESCRIPTION
Addresses https://github.com/swift-nav/piksi_v3_bug_tracking/issues/407

The issue is the ifup command triggers Udhcpc which blocks the system call