### PR TITLE
Limit output buffering on physical ports

### DIFF
--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -71,7 +71,7 @@ typedef struct {
 static port_config_t port_configs[] = {
   {
     .name = "uart0",
-    .opts = "--file /dev/ttyPS0",
+    .opts = "--file /dev/ttyPS0 --nonblock --outq 4096",
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -80,7 +80,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "uart1",
-    .opts = "--file /dev/ttyPS1",
+    .opts = "--file /dev/ttyPS1 --nonblock --outq 4096",
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -89,7 +89,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "usb0",
-    .opts = "--file /dev/ttyGS0",
+    .opts = "--file /dev/ttyGS0 --nonblock --outq 4096",
     .opts_get = NULL,
     .type = PORT_TYPE_USB,
     .mode_name_default = MODE_NAME_DEFAULT,

--- a/package/zmq_adapter/src/zmq_adapter_file.c
+++ b/package/zmq_adapter/src/zmq_adapter_file.c
@@ -20,7 +20,7 @@ int file_loop(const char *file_path)
     return 1;
   }
 
-  io_loop_start(fd, fd);
+  io_loop_start(fd, dup(fd));
   io_loop_wait();
 
   close(fd);

--- a/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
@@ -72,10 +72,12 @@ int tcp_connect_loop(const char *addr)
       continue;
     }
 
-    io_loop_start(fd, fd);
+    int wfd = dup(fd);
+    io_loop_start(fd, wfd);
     io_loop_wait_one();
     io_loop_terminate();
     close(fd);
+    close(wfd);
     fd = -1;
   }
 }

--- a/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_listen.c
@@ -67,8 +67,10 @@ static void server_loop(int server_fd)
                            &client_addr_len);
 
     if (client_fd >= 0) {
-      io_loop_start(client_fd, client_fd);
+      int wfd = dup(client_fd);
+      io_loop_start(client_fd, wfd);
       close(client_fd);
+      close(wfd);
       client_fd = -1;
     } else if ((client_fd == -1) && (errno == EINTR)) {
       /* Retry if interrupted */


### PR DESCRIPTION
A proposed solution for swift-nav/firmware_team_planning#270.

Options are added to `zmq_adapter` to set the port in non-blocking mode and/or specify an output queue size limit for tty devices.

These options are added to `piksi_system_daemon` for instances of `zmq_adapter` on the uarts and gadget serial port.  This prevents excessive buffering of output data when port writes are blocked by flow control.

Stale data is still left in the output queue, but the amount is limited.  Flushing the queue with `tcflush` was not successful.