### PR TITLE
piksi_system_daemon: Use async-child to manage pppd.

### DIFF
--- a/package/piksi_system_daemon/src/async-child.c
+++ b/package/piksi_system_daemon/src/async-child.c
@@ -141,7 +141,8 @@ static int async_cleanup_dead_child(zloop_t *loop, zmq_pollitem_t *item, void *a
 int async_spawn(zloop_t *loop, char **argv,
                 void (*output_callback)(const char *buf, void *ctx),
                 void (*exit_callback)(int status, void *ctx),
-                void *external_context)
+                void *external_context,
+                int *pid)
 {
   assert(loop != NULL);
   if (!wakepipe[0]) {
@@ -201,6 +202,9 @@ int async_spawn(zloop_t *loop, char **argv,
   ctx->next = async_children;
   async_children = ctx;
   sigchld_restore(&saved_mask);
+
+  if (pid)
+    *pid = ctx->pid;
 }
 
 static void async_child_waitpid_handler(pid_t pid, int status)

--- a/package/piksi_system_daemon/src/async-child.h
+++ b/package/piksi_system_daemon/src/async-child.h
@@ -22,6 +22,7 @@ void sigchld_restore(sigset_t *saved_mask);
 int async_spawn(zloop_t *loop, char **argv,
                 void (*output_callback)(const char *buf, void *ctx),
                 void (*exit_callback)(int status, void *ctx),
-                void *external_context);
+                void *external_context,
+                int *pid);
 
 #endif

--- a/package/piksi_system_daemon/src/cellmodem.c
+++ b/package/piksi_system_daemon/src/cellmodem.c
@@ -15,8 +15,13 @@
 #include <string.h>
 #include <signal.h>
 
+#include <libpiksi/sbp_zmq_pubsub.h>
 #include <libpiksi/settings.h>
 #include <libpiksi/logging.h>
+#include <libsbp/logging.h>
+
+#include "cellmodem.h"
+#include "async-child.h"
 
 /* External settings */
 static const char * const modem_type_names[] = {"GSM", "CDMA", NULL};
@@ -25,11 +30,45 @@ static u8 modem_type = MODEM_TYPE_GSM;
 static char cellmodem_dev[32] = "ttyACM0";
 static char cellmodem_apn[32] = "INTERNET";
 static bool cellmodem_enabled;
+static bool cellmodem_debug;
 static int cellmodem_pppd_pid;
+
+static int cellmodem_notify(void *context);
+
+static void pppd_output_callback(const char *buf, void *arg)
+{
+  sbp_zmq_pubsub_ctx_t *pubsub_ctx = arg;
+  if (!cellmodem_debug)
+    return;
+
+  msg_log_t *msg = alloca(256);
+  msg->level = 7;
+  strncpy(msg->text, buf, 255);
+
+  sbp_zmq_tx_send(sbp_zmq_pubsub_tx_ctx_get(pubsub_ctx),
+                  SBP_MSG_LOG, sizeof(*msg) + strlen(buf), (void*)msg);
+}
+
+static int pppd_respawn(zloop_t *loop, int timer_id, void *arg)
+{
+  if(cellmodem_enabled && (cellmodem_pppd_pid == 0))
+    cellmodem_notify(arg);
+}
+
+static void pppd_exit_callback(int status, void *arg)
+{
+  sbp_zmq_pubsub_ctx_t *pubsub_ctx = arg;
+  cellmodem_pppd_pid = 0;
+  if (!cellmodem_enabled)
+    return;
+
+  /* Respawn dead pppd */
+  zloop_timer(sbp_zmq_pubsub_zloop_get(pubsub_ctx), 5000, 1, pppd_respawn, pubsub_ctx);
+}
 
 static int cellmodem_notify(void *context)
 {
-  (void)context;
+  sbp_zmq_pubsub_ctx_t *pubsub_ctx = context;
 
   /* Kill the old pppd, if it exists. */
   if (cellmodem_pppd_pid) {
@@ -62,31 +101,32 @@ static int cellmodem_notify(void *context)
                   NULL};
 
   /* Create a new pppd process. */
-  if (!(cellmodem_pppd_pid = fork())) {
-    execvp(args[0], args);
-    piksi_log(LOG_ERR, "execvp error");
-    exit(EXIT_FAILURE);
-  }
+  async_spawn(sbp_zmq_pubsub_zloop_get(pubsub_ctx), args,
+              pppd_output_callback, pppd_exit_callback, pubsub_ctx,
+              &cellmodem_pppd_pid);
 
   return 0;
 }
 
-int cellmodem_init(settings_ctx_t *settings_ctx)
+int cellmodem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ctx)
 {
   settings_type_t settings_type_modem_type;
   settings_type_register_enum(settings_ctx, modem_type_names,
                               &settings_type_modem_type);
   settings_register(settings_ctx, "cell_modem", "modem_type", &modem_type,
                     sizeof(modem_type), settings_type_modem_type,
-                    cellmodem_notify, NULL);
+                    cellmodem_notify, pubsub_ctx);
   settings_register(settings_ctx, "cell_modem", "device", &cellmodem_dev,
                     sizeof(cellmodem_dev), SETTINGS_TYPE_STRING,
-                    cellmodem_notify, NULL);
+                    cellmodem_notify, pubsub_ctx);
   settings_register(settings_ctx, "cell_modem", "APN", &cellmodem_apn,
                     sizeof(cellmodem_apn), SETTINGS_TYPE_STRING,
-                    cellmodem_notify, NULL);
+                    cellmodem_notify, pubsub_ctx);
   settings_register(settings_ctx, "cell_modem", "enable", &cellmodem_enabled,
                     sizeof(cellmodem_enabled), SETTINGS_TYPE_BOOL,
-                    cellmodem_notify, NULL);
+                    cellmodem_notify, pubsub_ctx);
+  settings_register(settings_ctx, "cell_modem", "debug", &cellmodem_debug,
+                    sizeof(cellmodem_debug), SETTINGS_TYPE_BOOL,
+                    NULL, NULL);
   return 0;
 }

--- a/package/piksi_system_daemon/src/cellmodem.h
+++ b/package/piksi_system_daemon/src/cellmodem.h
@@ -15,6 +15,6 @@
 
 #include <libpiksi/settings.h>
 
-int cellmodem_init(settings_ctx_t *settings_ctx);
+int cellmodem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ctx);
 
 #endif

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -451,7 +451,7 @@ static void sbp_command(u16 sender_id, u8 len, u8 msg_[], void* context)
   ctx->pubsub_ctx = pubsub_ctx;
   char *argv[] = {"upgrade_tool", "--debug", "upgrade.image_set.bin", NULL};
   async_spawn(sbp_zmq_pubsub_zloop_get(ctx->pubsub_ctx),
-              argv, command_output_cb, command_exit_cb, ctx);
+              argv, command_output_cb, command_exit_cb, ctx, NULL);
 }
 
 static int file_read_string(const char *filename, char *str, size_t str_size)
@@ -659,7 +659,7 @@ int main(void)
   ntrip_init(settings_ctx);
   skylark_init(settings_ctx);
   whitelists_init(settings_ctx);
-  cellmodem_init(settings_ctx);
+  cellmodem_init(pubsub_ctx, settings_ctx);
 
   img_tbl_settings_setup(settings_ctx);
   sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(pubsub_ctx),


### PR DESCRIPTION
Respawn pppd if it dies.
Add debug option to forward pppd stdout over sbp log.