### PR TITLE
Open pipes for O_RDWR (fix Skylark)

### DIFF
--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -1132,8 +1132,8 @@ int main(int argc, char *argv[])
     break;
 
     case IO_FILE: {
-      extern int file_loop(const char *file_path);
-      ret = file_loop(file_path);
+      extern int file_loop(const char *file_path, int need_read, int need_write);
+      ret = file_loop(file_path, zmq_pub_addr ? 1 : 0, zmq_sub_addr ? 1 : 0);
     }
     break;
 

--- a/package/zmq_adapter/src/zmq_adapter_file.c
+++ b/package/zmq_adapter/src/zmq_adapter_file.c
@@ -10,34 +10,70 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include "zmq_adapter.h"
 
-int file_loop(const char *file_path)
+static int is_pipe(const char *file_path)
 {
-  debug_printf("entered file_loop %s\n", file_path);
-  int fd_read = open(file_path, O_RDONLY);
-  if (fd_read < 0) {
-    syslog(LOG_ERR, "error opening file");
-    debug_printf("Error opening fd_read\n");
-    return 1;
+  struct stat s;
+  if (stat(file_path, &s)) {
+    debug_printf("Cannot get stats for %s\n", file_path);
+    return 0;
+  } else {
+    return S_ISFIFO(s.st_mode);
   }
-  debug_printf("Opened %s for read, fd=%d\n", file_path, fd_read);
+}
 
-  int fd_write = open(file_path, O_WRONLY);
-  if (fd_write < 0) {
-    debug_printf("Error opening fd_write\n");
-    return 1;
+int file_loop(const char *file_path, int need_read, int need_write)
+{
+  debug_printf("entered file_loop %s, need_read %d need write %d\n",
+      file_path, need_read, need_write);
+
+  int fd_read = -1, fd_write = -1;
+  int b_pipe = is_pipe(file_path);
+  debug_printf("b_pipe: %d\n", b_pipe);
+
+  if (need_read) {
+    if (b_pipe) {
+      fd_read = open(file_path, O_RDWR);
+    } else {
+      fd_read = open(file_path, O_RDONLY);
+    }
+    if (fd_read < 0) {
+      syslog(LOG_ERR, "error opening file");
+      debug_printf("Error opening fd_read\n");
+      return 1;
+    }
+    debug_printf("Opened %s for read, fd=%d\n", file_path, fd_read);
   }
-  debug_printf("Open %s for write, fd=%d\n", file_path, fd_write);
+
+  if (need_write) {
+    if (b_pipe) {
+      fd_write = open(file_path, O_RDWR);
+    } else {
+      fd_write = open(file_path, O_WRONLY);
+    }
+    if (fd_write < 0) {
+      debug_printf("Error opening fd_write\n");
+      return 1;
+    }
+    debug_printf("Open %s for write, fd=%d\n", file_path, fd_write);
+  }
 
   io_loop_start(fd_read, fd_write);
   io_loop_wait();
 
-  close(fd_read);
-  debug_printf("Closed fd_read %d\n", fd_read);
+  if (need_read) {
+    close(fd_read);
+    debug_printf("Closed fd_read %d\n", fd_read);
+  }
 
-  close(fd_write);
-  debug_printf("Closed fd_read %d\n", fd_write);
+  if (need_write) {
+    close(fd_write);
+    debug_printf("Closed fd_read %d\n", fd_write);
+  }
 
   return 0;
 }


### PR DESCRIPTION
Opening for read is blocking on a named pipe, so the zmq_adapter spawned for skylark was never getting to the main loop.