### PR TITLE
Fix leap sec rounding from ns field

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.1
+GNSS_CONVERTORS_VERSION = v0.3.4
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.0
+LIBRTCM_VERSION = v0.2.3
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES


### PR DESCRIPTION
This fixes a problem where the ns field wasn't being used to calculate the glonass TOD which lead to a 1s error in the leap second calculations.