### PR TITLE
USB Gadget fixes

### DIFF
--- a/board/piksiv3/patches/linux/0003-gserial-Drain-tty-output-buffer-when-USB-is-connecte.patch
+++ b/board/piksiv3/patches/linux/0003-gserial-Drain-tty-output-buffer-when-USB-is-connecte.patch
@@ -1,0 +1,26 @@
+From 8301f83b6be14c75f1db261e5197de2ad1cd1463 Mon Sep 17 00:00:00 2001
+From: Gareth McMullin <gareth@blacksphere.co.nz>
+Date: Fri, 18 Aug 2017 10:55:09 +1200
+Subject: [PATCH] gserial: Drain tty output buffer when USB is connected.
+
+---
+ drivers/usb/gadget/function/u_serial.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/usb/gadget/function/u_serial.c b/drivers/usb/gadget/function/u_serial.c
+index 6af145f..e3b4952 100644
+--- a/drivers/usb/gadget/function/u_serial.c
++++ b/drivers/usb/gadget/function/u_serial.c
+@@ -720,6 +720,9 @@ static int gs_start_io(struct gs_port *port)
+ 		status = -EIO;
+ 	}
+ 
++	/* drain pending write requests */
++	gs_start_tx(port);
++
+ 	return status;
+ }
+ 
+-- 
+2.7.4
+

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -621,7 +621,6 @@ static ssize_t handle_write_one_via_framer(handle_t *handle,
 
     /* Pass frame through filter */
     if (filter_process(handle->filter, frame, frame_length) != 0) {
-      debug_printf("ignoring frame\n");
       continue;
     }
 
@@ -1037,17 +1036,16 @@ void io_loop_wait(void)
     if ((ret == -1) && (errno == EINTR)) {
       /* Retry if interrupted */
       continue;
-    } else if (ret >= 0) {
-      /* Continue on success */
-      continue;
     } else {
-      /* Break on error */
       break;
+      /* If any of the childs dies, then the parent process must exit
+         and give the chance to the system to restart it */
     }
   }
   debug_printf("Exit from io_loop_wait\n");
 }
 
+/* Used in tcp_connect */
 void io_loop_wait_one(void)
 {
   while (1) {


### PR DESCRIPTION
Test fix for: https://github.com/swift-nav/piksi_v3_bug_tracking/issues/570
- Kill zmq_adapter when the first forks dies.
- Drain tty output buffer when USB cable is connected.
