### PR TITLE
only set time parameters on valid time messages

### DIFF
--- a/package/sbp_rtcm3_bridge/src/sbp.h
+++ b/package/sbp_rtcm3_bridge/src/sbp.h
@@ -16,6 +16,9 @@
 #include <libpiksi/sbp_zmq_rx.h>
 #include <libpiksi/sbp_zmq_tx.h>
 
+#define TIME_SOURCE_MASK 0x07 /* Bits 0-2 */
+#define NO_TIME          0
+
 int sbp_init(sbp_zmq_rx_ctx_t *rx_ctx, sbp_zmq_tx_ctx_t *tx_ctx);
 void sbp_message_send(u8 msg_type, u8 len, u8 *payload, u16 sender_id);
 int sbp_callback_register(u16 msg_type, sbp_msg_callback_t cb, void *context);

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -108,6 +108,11 @@ static void gps_time_callback(u16 sender_id, u8 len, u8 msg[], void *context)
   (void) sender_id;
   (void) len;
   msg_gps_time_t *time = (msg_gps_time_t*)msg;
+
+  if((time->flags & TIME_SOURCE_MASK) == NO_TIME) {
+    return;
+  }
+
   gps_time_sec_t gps_time;
   gps_time.tow = time->tow * 0.001;
   gps_time.wn = time->wn;
@@ -120,6 +125,10 @@ static void utc_time_callback(u16 sender_id, u8 len, u8 msg[], void *context)
   (void) sender_id;
   (void) len;
   msg_utc_time_t *time = (msg_utc_time_t*)msg;
+
+  if((time->flags & TIME_SOURCE_MASK) == NO_TIME) {
+    return;
+  }
 
   /* work out the time of day in utc time */
   u32 utc_tod = time->hours * 3600 + time->minutes * 60 + time->seconds;


### PR DESCRIPTION
Don't set the time parameters without checking for message validity first

@mfine 