### PR TITLE
Changes for sbp_rtcm3_bridge crash issue

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.12
+GNSS_CONVERTORS_VERSION = v0.3.17
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/sbp_rtcm3_bridge/src/Makefile
+++ b/package/sbp_rtcm3_bridge/src/Makefile
@@ -1,7 +1,7 @@
 TARGET=sbp_rtcm3_bridge
 SOURCES= sbp_rtcm3_bridge.c sbp.c
 LIBS=-lczmq -lsbp -lpiksi -lgnss-convertors
-CFLAGS=-std=gnu11 -Wmissing-prototypes -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror
+CFLAGS=-std=gnu11 -Wmissing-prototypes -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror -ggdb
 
 CROSS=
 


### PR DESCRIPTION

- Add symbols to sbp_rtcm3_bridge build
- Update gnss-convertors release version to get changes to stop crashes.