### PR TITLE
Use monit for ports

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/kill_usb_adapter.sh
+++ b/board/piksiv3/rootfs-overlay/etc/kill_usb_adapter.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+ kill -9 `ps | grep GS0  | grep zmq_adapter | awk -F' ' '{print $1}'`

--- a/board/piksiv3/rootfs-overlay/etc/monitrc
+++ b/board/piksiv3/rootfs-overlay/etc/monitrc
@@ -62,3 +62,32 @@ check process klogd with pidfile /var/run/klogd.pid
 check process standalone_file_logger with pidfile /var/run/standalone_file_logger.pid
     start program = "/etc/init.d/S83standalone_file_logger start"
     stop program = "/etc/init.d/S83standalone_file_logger stop"
+
+check process zmq_adapter_uart0 with pidfile /var/run/zmq_adapter_uart0.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_uart0"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_uart0"
+
+check process zmq_adapter_uart1 with pidfile /var/run/zmq_adapter_uart1.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_uart1"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_uart1"
+
+check process zmq_adapter_usb0 with pidfile /var/run/zmq_adapter_usb0.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_usb0"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_usb0"
+
+check process zmq_adapter_tcp_server0 with pidfile /var/run/zmq_adapter_tcp_server0.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_tcp_server0"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_tcp_server0"
+
+check process zmq_adapter_tcp_server1 with pidfile /var/run/zmq_adapter_tcp_server1.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_tcp_server1"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_tcp_server1"
+
+check process zmq_adapter_tcp_client0 with pidfile /var/run/zmq_adapter_tcp_client0.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_tcp_client0"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_tcp_client0"
+
+check process zmq_adapter_tcp_client1 with pidfile /var/run/zmq_adapter_tcp_client1.pid
+    start program = "/etc/zmq_adapter_generic start zmq_adapter_tcp_client1"
+    stop program = "/etc/zmq_adapter_generic stop zmq_adapter_tcp_client1"
+

--- a/board/piksiv3/rootfs-overlay/etc/monitrc
+++ b/board/piksiv3/rootfs-overlay/etc/monitrc
@@ -91,3 +91,14 @@ check process zmq_adapter_tcp_client1 with pidfile /var/run/zmq_adapter_tcp_clie
     start program = "/etc/zmq_adapter_generic start zmq_adapter_tcp_client1"
     stop program = "/etc/zmq_adapter_generic stop zmq_adapter_tcp_client1"
 
+GROUP ntrip
+
+check process zmq_adapter_ntrip with pidfile /var/run/zmq_adapter_ntrip.pid
+    start program = "/etc/zmq_adapter_ntrip start"
+    stop program = "/etc/zmq_adapter_ntrip stop"
+    group ntrip
+
+check process ntrip_daemon with pidfile /var/run/ntrip_daemon.pid
+    start program = "/etc/ntrip_daemon_s start"
+    stop program = "/etc/ntrip_daemon_s stop"
+    group ntrip

--- a/board/piksiv3/rootfs-overlay/etc/ntrip_daemon_s
+++ b/board/piksiv3/rootfs-overlay/etc/ntrip_daemon_s
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+name="ntrip_daemon"
+cmd="ntrip_daemon --file /var/run/ntrip `cat /var/run/ntrip_daemon_cmd`"
+dir="/"
+user=""
+
+source /etc/init.d/template_process.inc.sh
+

--- a/board/piksiv3/rootfs-overlay/etc/zmq_adapter_generic
+++ b/board/piksiv3/rootfs-overlay/etc/zmq_adapter_generic
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+name=$2
+cmd="zmq_adapter `cat /var/run/${name}_cmd`"
+dir="/"
+user=""
+
+source /etc/init.d/template_process.inc.sh
+

--- a/board/piksiv3/rootfs-overlay/etc/zmq_adapter_ntrip
+++ b/board/piksiv3/rootfs-overlay/etc/zmq_adapter_ntrip
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+name="zmq_adapter_ntrip"
+cmd="zmq_adapter -f rtcm3 --file /var/run/ntrip -p >tcp://127.0.0.1:45031"
+dir="/"
+user=""
+
+source /etc/init.d/template_process.inc.sh
+

--- a/package/piksi_system_daemon/src/async-child.c
+++ b/package/piksi_system_daemon/src/async-child.c
@@ -46,7 +46,6 @@ static void sigchld_handler(int signum)
   pid_t pid;
   int status;
   while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
-    ports_sigchld_waitpid_handler(pid, status);
     async_child_waitpid_handler(pid, status);
   }
   errno = saved_errno;

--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -161,15 +161,15 @@ static void adapter_kill(port_config_t *port_config)
 
   FILE *p = popen(exec, "r");
   if (p == NULL) {
-    piksi_log(LOG_ERR, "Unable to stop %s",
-              port_config->system_name);
+    piksi_log(LOG_ERR, "Unable to stop %s, errno %d",
+              port_config->system_name, errno);
     return;
   } 
 
   int status = pclose(p);
   if (status == -1) {
-    piksi_log(LOG_ERR, "Error stopping %s",
-              port_config->system_name);
+    piksi_log(LOG_ERR, "Error stopping %s, errno %d",
+              port_config->system_name, errno);
     return;
   }
 
@@ -212,6 +212,10 @@ static int port_configure(port_config_t *port_config)
     port_config->system_name);
 
   FILE *f = fopen(cmdline_file, "wb");
+  if (f == NULL) {
+    piksi_log(LOG_ERR, "Unable to open %s for write", cmdline_file);
+    return -1;
+  }
   fprintf(f, cmd_options);
   fclose(f);
 
@@ -381,6 +385,3 @@ int ports_init(settings_ctx_t *settings_ctx)
   return 0;
 }
 
-void ports_sigchld_waitpid_handler(pid_t pid, int status)
-{
-}

--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -187,9 +187,11 @@ static void adapter_kill(port_config_t *port_config)
     return;
   } 
 
+#if 0
   char line[128];
   while (fgets(line, sizeof(line), p) != NULL)
     fprintf(stdout, "%s", line);
+#endif
 
   int status = pclose(p);
   if (status == -1) {
@@ -197,6 +199,8 @@ static void adapter_kill(port_config_t *port_config)
               port_config->system_name);
     return;
   }
+
+  fprintf(stdout, "Done killing the adapter\n");
 
 #if 0
   /* Mask SIGCHLD while accessing adapter_pid */
@@ -258,16 +262,22 @@ static int port_configure(port_config_t *port_config)
           "/usr/bin/monit restart %s",
           port_config->system_name);
 
+  fprintf(stdout, "executing %s\n", exec);
   FILE *p = popen(exec, "r");
   if (p == NULL) {
     piksi_log(LOG_ERR, "Unable to start %s",
               port_config->system_name);
     return -1;
   } 
+  fprintf(stdout, "executed s\n", exec);
 
+#if 0
   char line[128];
   while (fgets(line, sizeof(line), p) != NULL)
     fprintf(stdout, "%s", line);
+
+  fprintf(stdout, "got lines, now close\n");
+#endif
 
   int status = pclose(p);
   if (status == -1) {
@@ -276,6 +286,8 @@ static int port_configure(port_config_t *port_config)
     return -1;
   }
 
+  fprintf(stdout, "Done configuring port %s\n",
+		  port_config->system_name);
 
 #if 0
 
@@ -453,6 +465,7 @@ int ports_init(settings_ctx_t *settings_ctx)
 
 void ports_sigchld_waitpid_handler(pid_t pid, int status)
 {
+#if 0
   int i;
   for (i = 0; i < sizeof(port_configs) / sizeof(port_configs[0]); i++) {
     port_config_t *port_config = &port_configs[i];
@@ -465,4 +478,5 @@ void ports_sigchld_waitpid_handler(pid_t pid, int status)
       }
     }
   }
+#endif
 }


### PR DESCRIPTION
Using monit for handling the zmq_adapters of the ports.

This would fix the problem when multiple zmq_adapters sometimes run on usb0.
It should also ensure that an adapter is always running on the regular ports, so this should fix the "not seeing data on UARTX" problem as well.