### PR TITLE
Kill any adapter running on GS0 when spawning a new one

### DIFF
--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -181,8 +181,17 @@ static void adapter_kill(port_config_t *port_config)
 
 static int port_configure(port_config_t *port_config)
 {
+  /* kill adapter */
+  adapter_kill(port_config);
+
+  /* In case of USB adapters, sometimes we find that instances are still around.
+   * Kill them here
+   */
+  if (port_config->type == PORT_TYPE_USB) {
+    system("kill -9 `ps | grep GS0  | grep zmq_adapter | awk -F' ' '{print $1}'`");
+  }
+
   if (port_config->mode == MODE_DISABLED) {
-    adapter_kill(port_config);
     return 0;
   }
 
@@ -211,9 +220,6 @@ static int port_configure(port_config_t *port_config)
   char *args[32] = {0};
   args[0] = strtok(cmd, " ");
   for (u8 i=1; (args[i] = strtok(NULL, " ")) && i < 32; i++);
-
-  /* Kill the old zmq_adapter, if it exists. */
-  adapter_kill(port_config);
 
   piksi_log(LOG_DEBUG, "Starting zmq_adapter: %s", cmd);
 


### PR DESCRIPTION
There is a bug, hard to reproduce but frequent enough, where multiple zmq_adapters are running on ttyGS0. This results in a bunch of duplicate messages.

For the time being, I think this code will take care of it.

I noticed the problem only once and could not figure out why that happened, but this is what I noticed:
* there were only the 2 forks alive, the main process had exited
* the 2 forks had ppid=1, which I guess was inherited from the spawning process

I was going down the route of using monit for checking those processes, but that's when I saw this problem, so I know for a fact that's not a fix.

Bear with me, this is not a great solution but I think it will fix our problem for 1.2