### PR TITLE
Allow write-back to optimize block writes

### DIFF
--- a/board/piksiv3/rootfs-overlay/lib/mdev/automount.sh
+++ b/board/piksiv3/rootfs-overlay/lib/mdev/automount.sh
@@ -15,7 +15,7 @@ do_mount()
 {
   mkdir -p "${destdir}/$1" || exit 1
 
-  if ! mount -t auto -o sync "/dev/$1" "${destdir}/$1"; then
+  if ! mount -t auto "/dev/$1" "${destdir}/$1"; then
     # failed to mount, clean up mountpoint
     rmdir "${destdir}/$1"
     exit 1

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -160,6 +160,7 @@ void RotatingLogger::frame_handler(const uint8_t* data, size_t size) {
   if (num_written != size) {
     // If drive is removed needs to close file imediately and not attempt to
     // open new file for a couple seconds to avoid locking mount
+    fsync(_cur_file);
     close(_cur_file);
     _cur_file = -1;
     _dest_available = false;


### PR DESCRIPTION
Fixes https://github.com/swift-nav/piksi_v3_bug_tracking/issues/641

# Explanation

Don't use the 'sync' option in the auto mount script, this allows the kernel's "write back" system to optimize writes to block devices.

Our current write back config is as follows:
```
vm.dirty_background_ratio = 10
vm.dirty_bytes = 0
vm.dirty_expire_centisecs = 3000
vm.dirty_ratio = 20
```

Which means the write cache use up 20% of the system memory.  During my testing I saw that about 110mb of memory was available, so about 21mb of writes could potentially be cached.  We can tune these parameters to reduce the impact on SBP messages that are lost if a customer pulls out a removable media drive before a flush happens.

# Testing
Loaded new automount script and ran piksi at 20MHz solution frequency overnight.  This generates about 20kB/s of data.  Then used a [test script](https://gist.github.com/silverjam/7918b05d9b5112490e8d70cb8cae4214) to look for gaps.  Using [this script](https://gist.github.com/silverjam/243188f62b58b46a1a8f8c9fd5a7fe58) (and the associated `dd.c`) we can test the raw write speed of different block sizes for the media devices we're using on OS X.

# Addendum
We also drafted [a branch](https://github.com/swift-nav/piksi_buildroot/tree/hotfix/standalone_logger_write_thread) that moved writes onto a separate thread, and manually batched writes into large blocks.  This also fixes the issue, but probably requires significantly more QA than this change.