### PR TITLE
[WIP] Use buffered IO for standalone_file_logger

### DIFF
--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -63,9 +63,9 @@ bool RotatingLogger::open_new_file() {
     perror("Max session exceeded");
     return false;
   }
-  if (_cur_file != -1) {
-    close(_cur_file);
-    _cur_file = -1;
+  if (_cur_file != nullptr) {
+    fclose(_cur_file);
+    _cur_file = nullptr;
   }
 
   int fs_status = check_disk_full();
@@ -83,11 +83,13 @@ bool RotatingLogger::open_new_file() {
   sprintf(log_name_buf, "%04lu-%05lu%s", _session_count, _minute_count,
           LOG_SUFFIX.c_str());
   // Need to use open instead of fopen to avoid locking drive
-  _cur_file = open((_out_dir + "/" + log_name_buf).c_str(), O_WRONLY | O_CREAT, 0666);
-  _dest_available = _cur_file != -1;
+  _cur_file = fopen((_out_dir + "/" + log_name_buf).c_str(), "w");
+  _dest_available = _cur_file != nullptr;
   log_msg(LOG_INFO, std::string("Opening file: ") + log_name_buf);
   if (!_dest_available) {
     log_msg(LOG_WARNING, std::string("Error openning file: ") + strerror(errno));
+  } else {
+    setvbuf(_cur_file, _write_buffer, _IOFBF, WRITE_BUF_SIZE);
   }
   return _dest_available;
 }
@@ -154,14 +156,15 @@ void RotatingLogger::frame_handler(const uint8_t* data, size_t size) {
   }
 
   size_t num_written = 0;
-  if (_cur_file != -1) {
-    num_written = write(_cur_file, data, size);
+  if (_cur_file != nullptr) {
+    num_written = fwrite(data, size, _cur_file);
   }
   if (num_written != size) {
     // If drive is removed needs to close file imediately and not attempt to
     // open new file for a couple seconds to avoid locking mount
-    fsync(_cur_file);
-    close(_cur_file);
+    fflush(_cur_file);
+    fsync(fileno(_cur_file));
+    fclose(_cur_file);
     _cur_file = -1;
     _dest_available = false;
     // wait _poll_period to check drive again
@@ -199,10 +202,12 @@ RotatingLogger::RotatingLogger(const std::string& out_dir,
       _logging_callback(logging_callback),
       // init to 0
       _session_start_time(),
-      _cur_file(-1) {}
+      _cur_file(nullptr) {}
 
 RotatingLogger::~RotatingLogger() {
-  if (_cur_file != -1) {
-    close(_cur_file);
+  if (_cur_file != nullptr) {
+    fflush(_cur_file);
+    fsync(fileno(_cur_file));
+    fclose(_cur_file);
   }
 }

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -160,6 +160,7 @@ void RotatingLogger::frame_handler(const uint8_t* data, size_t size) {
   if (num_written != size) {
     // If drive is removed needs to close file imediately and not attempt to
     // open new file for a couple seconds to avoid locking mount
+    fsync(_cur_file);
     close(_cur_file);
     _cur_file = -1;
     _dest_available = false;

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -45,6 +45,15 @@ void RotatingLogger::log_msg(int priority, const std::string &msg) {
   }
 }
 
+void RotatingLogger::close_current_file() {
+  if (_cur_file != nullptr) {
+    fflush(_cur_file);
+    fsync(fileno(_cur_file));
+    fclose(_cur_file);
+    _cur_file = nullptr;
+  }
+}
+
 int RotatingLogger::check_disk_full() {
   struct statvfs fs_stats;
   if (statvfs(_out_dir.c_str(), &fs_stats)) {
@@ -63,11 +72,7 @@ bool RotatingLogger::open_new_file() {
     perror("Max session exceeded");
     return false;
   }
-  if (_cur_file != nullptr) {
-    fclose(_cur_file);
-    _cur_file = nullptr;
-  }
-
+  close_current_file();
   int fs_status = check_disk_full();
   if (fs_status == 1) {
     log_msg(LOG_WARNING, std::string("Target dir full"));
@@ -83,7 +88,7 @@ bool RotatingLogger::open_new_file() {
   sprintf(log_name_buf, "%04lu-%05lu%s", _session_count, _minute_count,
           LOG_SUFFIX.c_str());
   // Need to use open instead of fopen to avoid locking drive
-  _cur_file = fopen((_out_dir + "/" + log_name_buf).c_str(), "w");
+  _cur_file = fopen((_out_dir + "/" + log_name_buf).c_str(), "wb");
   _dest_available = _cur_file != nullptr;
   log_msg(LOG_INFO, std::string("Opening file: ") + log_name_buf);
   if (!_dest_available) {
@@ -157,15 +162,12 @@ void RotatingLogger::frame_handler(const uint8_t* data, size_t size) {
 
   size_t num_written = 0;
   if (_cur_file != nullptr) {
-    num_written = fwrite(data, size, _cur_file);
+    num_written = fwrite(data, 1, size, _cur_file);
   }
   if (num_written != size) {
     // If drive is removed needs to close file imediately and not attempt to
     // open new file for a couple seconds to avoid locking mount
-    fflush(_cur_file);
-    fsync(fileno(_cur_file));
-    fclose(_cur_file);
-    _cur_file = -1;
+    close_current_file();
     _dest_available = false;
     // wait _poll_period to check drive again
     _session_start_time = std::chrono::steady_clock::now();
@@ -205,9 +207,5 @@ RotatingLogger::RotatingLogger(const std::string& out_dir,
       _cur_file(nullptr) {}
 
 RotatingLogger::~RotatingLogger() {
-  if (_cur_file != nullptr) {
-    fflush(_cur_file);
-    fsync(fileno(_cur_file));
-    fclose(_cur_file);
-  }
+  close_current_file();
 }

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -13,6 +13,7 @@
 #ifndef SWIFTNAV_ROTATING_LOGGER_H
 #define SWIFTNAV_ROTATING_LOGGER_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <chrono>
@@ -85,7 +86,10 @@ class RotatingLogger {
   LogCall _logging_callback;
   std::string _out_dir;
   std::chrono::time_point<std::chrono::steady_clock> _session_start_time;
-  int _cur_file;
+
+  static const size_t WRITE_BUF_SIZE = 4096;
+  uint8_t _write_buffer[WRITE_BUF_SIZE];
+  FILE* _cur_file;
 };
 
 #endif  // SWIFTNAV_ROTATING_LOGGER_H

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -76,6 +76,10 @@ class RotatingLogger {
    * print if _verbose_logging
    */
   void log_msg(int priority, const std::string &msg);
+  /** 
+   * Flush and close the current file
+   */
+  void close_current_file();
 
   bool _dest_available;
   size_t _session_count;
@@ -88,7 +92,8 @@ class RotatingLogger {
   std::chrono::time_point<std::chrono::steady_clock> _session_start_time;
 
   static const size_t WRITE_BUF_SIZE = 4096;
-  uint8_t _write_buffer[WRITE_BUF_SIZE];
+  char _write_buffer[WRITE_BUF_SIZE];
+
   FILE* _cur_file;
 };
 

--- a/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
+++ b/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
@@ -56,8 +56,7 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
 
   // invalidate current file pointer
   void SetNullFilePointer() { 
-    close(_cur_file);
-    _cur_file = -1;
+    close_current_file();
   }
 
   void SetFillThreshold(size_t threshold) { _disk_full_threshold = threshold; }
@@ -87,6 +86,8 @@ TEST_F(RotatingLoggerTest, NormalOperation) {
     MoveStartTimeBack(1);
     expected_file_content[i / 5][i % 5] = i;
   }
+
+  close_current_file();
 
   // Check that log roll overs occured and each has correct data
   for (int i = 0; i < 4; i++) {
@@ -165,6 +166,8 @@ TEST_F(RotatingLoggerTest, StartDisconnected) {
   SetOutputPath(out_dir);
   frame_handler(reinterpret_cast<uint8_t*>(&i), sizeof(int));
 
+  close_current_file();
+
   char file_name_buf[1024];
   snprintf(file_name_buf, sizeof(file_name_buf), "%s/%s", out_dir,
            expected_files);
@@ -211,6 +214,8 @@ TEST_F(RotatingLoggerTest, DisconnectReconnect) {
   SetOutputPath(out_dir);
   // 0003-00000.sbp <- 5
   frame_handler(reinterpret_cast<uint8_t*>(&i), sizeof(int));
+
+  close_current_file();
 
   for (i = 0; i < 3; i++) {
     char file_name_buf[1024];


### PR DESCRIPTION
Use standard C library buffered IO to eliminate disk writes of small buffers.  Specify a write buffer that should completed fill out at least one block/sector on the target block device.