### PR TITLE
libnetwork & ntrip doc improvements

### DIFF
--- a/package/libnetwork/docs/about.md
+++ b/package/libnetwork/docs/about.md
@@ -19,9 +19,9 @@ remove the need for external, host-provided network connectivity.
 The piksi system daemon listens for Skylark configuration and starts and stops
 upload and download daemons as necessary. The upload and download daemons run
 independently for improved robustness and simplicity, pulling and pushing SBP
-data to two Skylark-specific ZeroMQ ports that are exposed on the Linux host on
-are routed to the firmware: `tcp://127.0.0.1:43080` and `tcp://127.0.0.1:43081`,
-respectively. Taken together, these run with:
+data to two Skylark-specific ZeroMQ ports that are exposed on the Linux host
+are routed to the firmware: `tcp://127.0.0.1:43080` and
+`tcp://127.0.0.1:43081`, respectively. Taken together, these run with:
 
 ```
 mkfifo /var/run/skylark_download /var/run/skylark_upload
@@ -31,10 +31,10 @@ zmq_adapter --file /var/run/skylark_upload -s >tcp://127.0.0.1:43070
 zmq_adapter --file /var/run/skylark_download -p >tcp://127.0.0.1:43071
 ```
 
-The upload and download daemons read and write from two FIFOs
-(`/var/run/skylark_download` and `/var/run/skylark_upload`) they materialize.
-The ZMQ adapter processes manage the piping and framing of SBP via these pipes.
-The dataflow here looks something like this:
+The upload and download daemons read and write from two FIFOs they materialize:
+`/var/run/skylark_download` and `/var/run/skylark_upload`.  The ZMQ adapter
+processes manage the piping and framing of SBP via these pipes.  The dataflow
+here looks something like this:
 
 ```
 skylark_download_daemon:

--- a/package/ntrip_daemon/docs/README.md
+++ b/package/ntrip_daemon/docs/README.md
@@ -1,0 +1,34 @@
+# Network diagram for translating NTRIP RTCM to SBP
+
+┌───────────────────┐                                             
+│                   │     HTTP Request      ┌────────────────────┐
+│        Piksi      │         (TCP)         │   Someone else's   │
+│    NTRIP Daemon   │──────────────────────▶│    NTRIP Server    │
+│                   │                       └────────────────────┘
+└───────────────────┘                                             
+          │                                                       
+          │                                                       
+          └─────┐                                                 
+                │  FIFO output                                    
+                ▼ (RTCM packets)    ┌──────────────────┐          
+┌───────────────────┐               │    ZMQ Router    │          
+│                   │  ┌───────────▶│  (Routes 45031   │──┐       
+│     ZMQ Adapter   │  │            │    to 45010)     │  │       
+│   (+ RTCM framer) │  │            └──────────────────┘  │       
+│                   │  │                                  │       
+└─────────┬─────────┘  │          ┌───────────────────────┘       
+          │            │          │            ZMQ Pub to 45010   
+    ZMQ Pub to 45031   │          │                               
+          │────────────┘          │  ┌────────────────────────┐   
+          │           ▲           │  │                        │   
+          ▼           │           │  │      rtcm3_bridge      │   
+                      │           │  │                        │   
+                      │           └─▶│(Bridge from RTCM to SBP│   
+                      │              │that provides correction│   
+             ┌─────────────────┐     │         data)          │   
+             │  Other things   │     │                        │   
+             │ (like TCP port  │     └────────────────────────┘   
+             │  adpaters) can  │                                  
+             │ setup a ZMQ pub │                                  
+             │    to 45031     │                                  
+             └─────────────────┘                                  


### PR DESCRIPTION
A few doc improvements for libnetwork and the ntrip_daemon, does not need to go to release 1.2.0.