### PR TITLE
Make ntrip network diagram readable on github.com

### DIFF
--- a/package/ntrip_daemon/docs/README.md
+++ b/package/ntrip_daemon/docs/README.md
@@ -1,5 +1,5 @@
 # Network diagram for translating NTRIP RTCM to SBP
-
+```
 ┌───────────────────┐                                             
 │                   │     HTTP Request      ┌────────────────────┐
 │        Piksi      │         (TCP)         │   Someone else's   │
@@ -32,3 +32,4 @@
              │ setup a ZMQ pub │                                  
              │    to 45031     │                                  
              └─────────────────┘                                  
+```


### PR DESCRIPTION
Need to enclose the diagram in a code block so it renders correctly.