### PR TITLE
Docker usability improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get -y --force-yes install \
   mercurial \
   libc6-i386 \
   lib32stdc++6 \
-  lib32z1
+  lib32z1 \
+  vim \
+  silversearcher-ag
 RUN apt-get -y --force-yes -t jessie-backports install \
   cmake
 


### PR DESCRIPTION
+ Use `--rm` so that a new container isn't created every time we run a make command.

+ Add a few helpful tools to the build image: ag, and vim.

+ Add `docker-pkg-%` family of commands for rebuilding individual packages.

+ Name the docker image that's used in the `docker-run` target so that files can be easily copied out of the volume using `docker cp`.