### PR TITLE
Update UART1 whitelist for usability.

### DIFF
--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -78,7 +78,7 @@ typedef struct {
 static port_config_t port_configs[] = {
   {
     .name = "uart0",
-    .opts = "--file /dev/ttyPS0 --nonblock --outq 4096",
+    .opts = "--file /dev/ttyPS0 --nonblock --outq 8192",
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -88,7 +88,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "uart1",
-    .opts = "--file /dev/ttyPS1 --nonblock --outq 4096",
+    .opts = "--file /dev/ttyPS1 --nonblock --outq 8192",
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -98,7 +98,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "usb0",
-    .opts = "--file /dev/ttyGS0 --nonblock --outq 4096",
+    .opts = "--file /dev/ttyGS0 --nonblock --outq 8192",
     .opts_get = NULL,
     .type = PORT_TYPE_USB,
     .mode_name_default = MODE_NAME_DEFAULT,

--- a/package/piksi_system_daemon/src/whitelists.c
+++ b/package/piksi_system_daemon/src/whitelists.c
@@ -55,7 +55,40 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UART1] = {
     .name = "uart1",
-    .wl = ""
+    .wl = "1025,520,522,524,526,23,29,257,65282,65,72,74,2304,80,528,134,136,163,165,166,167,171,181,185,187,188,2305,258,259,65280,65535"
+    /*  This filter represents the messages in use by the console.
+        It removes all ECEF nav messages as well as parts of nav msg.
+        MsgLog                   1025
+        MsgDops                   520
+        MsgPosLLH                 522
+        MsgBaselineNED            524
+        MsgVelNED                 526
+        MsgThreadState             23
+        MsgUartState               29
+        MsgExtEvent               257
+        MsgDgnssStatus          65282
+        MsgTrackingState           65
+        MsgBasePosECEF             72
+        MsgObs                     74
+        MsgImuRaw                2304
+        MsgSpecan                  80
+        MsgAgeCorrections         528
+        MsgEphemerisGPS           134
+        MsgEphemerisGlo           136
+        MsgFileioReadResp         163
+        MsgSettingsReadResp       165
+        MsgSettingsReadByIn       166
+        MsgSettingsReadByIn       167
+        MsgFileioWriteResp        171
+        MsgDeviceMonitor          181
+        MsgCommandResp            185
+        MsgNetworkStateResp       187
+        MsgCommandOutput          188
+        MsgImuAux                2305
+        MsgGPSTime                258
+        MsgUtcTime                259
+        MsgStartup              65280
+        MsgHeartbeat            65535 */
   },
   [PORT_USB0] = {
     .name = "usb0",


### PR DESCRIPTION
My task from triage meeting.

Requires console testing and SBP2RINEX testing before merging; both should work with a file recorded over UART1.

Will break HITL since HITL probably only uses the ECEF messages and is connected over UART1. @axlan 