### PR TITLE
Ignore SIGIO

### DIFF
--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -169,7 +169,7 @@ static void adapter_kill(port_config_t *port_config)
   sigchld_mask(&saved_mask);
   {
     if (port_config->adapter_pid > 0) {
-      int ret = kill(port_config->adapter_pid, SIGTERM);
+      int ret = kill(port_config->adapter_pid, SIGKILL);
       piksi_log(LOG_DEBUG,
                 "Killing zmq_adapter with PID: %d (kill returned %d, errno %d)",
                 port_config->adapter_pid, ret, errno);

--- a/package/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/src/ports.c
@@ -169,7 +169,7 @@ static void adapter_kill(port_config_t *port_config)
   sigchld_mask(&saved_mask);
   {
     if (port_config->adapter_pid > 0) {
-      int ret = kill(port_config->adapter_pid, SIGKILL);
+      int ret = kill(port_config->adapter_pid, SIGTERM);
       piksi_log(LOG_DEBUG,
                 "Killing zmq_adapter with PID: %d (kill returned %d, errno %d)",
                 port_config->adapter_pid, ret, errno);

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -1107,6 +1107,7 @@ int main(int argc, char *argv[])
   zsys_handler_set(NULL);
 
   signal(SIGPIPE, SIG_IGN); /* Allow write to return an error */
+  signal(SIGIO, SIG_IGN);
 
   /* Set up handler for signals which should terminate the program */
   struct sigaction terminate_sa;


### PR DESCRIPTION
I have witnessed a situation where several adapters on UART0 were running.
Some of them were running as SBP, others as RTCM.

It appears that the proble is that the zmq_adapter exits when receiving SIGIO, which is unhandled.