### PR TITLE
Connect NMEA output to ntpd via pty linked at /dev/gps0

### DIFF
--- a/board/piksiv3/patches/ntp/0001-nmea-ignore-build-time.patch
+++ b/board/piksiv3/patches/ntp/0001-nmea-ignore-build-time.patch
@@ -1,0 +1,27 @@
+diff -uar a/ntpd/refclock_nmea.c b/ntpd/refclock_nmea.c
+--- a/ntpd/refclock_nmea.c	2017-03-22 02:04:20.000000000 +1300
++++ b/ntpd/refclock_nmea.c	2018-01-03 09:17:41.729766587 +1300
+@@ -366,22 +366,7 @@
+ {
+ 	struct calendar date;
+ 
+-	/* - calculate min. base value for GPS epoch & century unfolding 
+-	 * This assumes that the build system was roughly in sync with
+-	 * the world, and that really synchronising to a time before the
+-	 * program was created would be unsafe or insane. If the build
+-	 * date cannot be stablished, at least use the start of GPS
+-	 * (1980-01-06) as minimum, because GPS can surely NOT
+-	 * synchronise beyond it's own big bang. We add a little safety
+-	 * margin for the fuzziness of the build date, which is in an
+-	 * undefined time zone. */
+-	if (ntpcal_get_build_date(&date))
+-		g_gpsMinBase = ntpcal_date_to_rd(&date) - 2;
+-	else
+-		g_gpsMinBase = 0;
+-
+-	if (g_gpsMinBase < DAY_GPS_STARTS)
+-		g_gpsMinBase = DAY_GPS_STARTS;
++	g_gpsMinBase = DAY_GPS_STARTS;
+ 
+ 	ntpcal_rd_to_date(&date, g_gpsMinBase);
+ 	g_gpsMinYear  = date.year;

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S45zmq_adapter_gps0
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S45zmq_adapter_gps0
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+name="zmq_adapter_gps0"
+cmd="zmq_adapter --stdio -s '>tcp://127.0.0.1:44030' | socat pty,raw,link=/dev/gps0 fd:0"
+dir="/"
+
+ulimit -c unlimited
+
+pid_file="/var/run/$name.pid"
+stdout_log="/var/log/$name.log"
+stderr_log="/var/log/$name.err"
+
+get_pid() {
+    cat "$pid_file"
+}
+
+is_running() {
+    [ -f "$pid_file" ] && [ -d "/proc/`get_pid`" ] > /dev/null 2>&1
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+        cd "$dir"
+        sh -c "$cmd" >> "$stdout_log" 2>> "$stderr_log" &
+        echo $! > "$pid_file"
+        if ! is_running; then
+            echo "Unable to start, see $stdout_log and $stderr_log"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+        kill `get_pid`
+        for i in {1..10}
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; may still be shutting down or shutdown may have failed"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0
+
+

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf
@@ -1,3 +1,5 @@
+# Use NMEA reference clock in addition to NTP servers
+# http://support.ntp.org/bin/view/Support/ConfiguringNMEARefclocks
 server 127.127.20.0 mode 1 prefer
 server 0.pool.ntp.org iburst
 server 1.pool.ntp.org iburst

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf
@@ -1,0 +1,11 @@
+server 127.127.20.0 mode 1 prefer
+server 0.pool.ntp.org iburst
+server 1.pool.ntp.org iburst
+server 2.pool.ntp.org iburst
+server 3.pool.ntp.org iburst
+
+# Allow only time queries, at a limited rate, sending KoD when in excess.
+# Allow all local queries (IPv4, IPv6)
+restrict default nomodify nopeer noquery limited kod
+restrict 127.0.0.1
+restrict [::1]

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.gps
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.gps
@@ -1,0 +1,7 @@
+server 127.127.20.0 mode 1 true
+
+# Allow only time queries, at a limited rate, sending KoD when in excess.
+# Allow all local queries (IPv4, IPv6)
+restrict default nomodify nopeer noquery limited kod
+restrict 127.0.0.1
+restrict [::1]

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.gps
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.gps
@@ -1,3 +1,5 @@
+# Use NMEA reference clock as absolute truth
+# http://support.ntp.org/bin/view/Support/ConfiguringNMEARefclocks
 server 127.127.20.0 mode 1 true
 
 # Allow only time queries, at a limited rate, sending KoD when in excess.

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.gpsntp
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.gpsntp
@@ -1,3 +1,5 @@
+# Use NMEA reference clock in addition to NTP servers
+# http://support.ntp.org/bin/view/Support/ConfiguringNMEARefclocks
 server 127.127.20.0 mode 1 prefer
 server 0.pool.ntp.org iburst
 server 1.pool.ntp.org iburst

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.gpsntp
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.gpsntp
@@ -1,0 +1,11 @@
+server 127.127.20.0 mode 1 prefer
+server 0.pool.ntp.org iburst
+server 1.pool.ntp.org iburst
+server 2.pool.ntp.org iburst
+server 3.pool.ntp.org iburst
+
+# Allow only time queries, at a limited rate, sending KoD when in excess.
+# Allow all local queries (IPv4, IPv6)
+restrict default nomodify nopeer noquery limited kod
+restrict 127.0.0.1
+restrict [::1]

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.ntp
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.ntp
@@ -1,0 +1,10 @@
+server 0.pool.ntp.org iburst
+server 1.pool.ntp.org iburst
+server 2.pool.ntp.org iburst
+server 3.pool.ntp.org iburst
+
+# Allow only time queries, at a limited rate, sending KoD when in excess.
+# Allow all local queries (IPv4, IPv6)
+restrict default nomodify nopeer noquery limited kod
+restrict 127.0.0.1
+restrict [::1]


### PR DESCRIPTION
This provides UTC from our navigation solution as a reference clock to set the Linux system time.
- Start a new zmq_adapter to connect NMEA stream and use socat to link to pty at /dev/gps0
- Add NMEA reference clock to ntpd configuration
- Patched NTP to allow a system time older than it's build time in NMEA driver
- Add a setting to select system time source for cases when NTP and GPS time are available, but different.
  
For https://github.com/swift-nav/firmware_team_planning/issues/290