### PR TITLE
Allow TCP client to recover after network stalls

### DIFF
--- a/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
@@ -77,9 +77,10 @@ err:
 
 static bool configure_socket(int fd)
 {
+  int ret = 0;
 #ifdef TCP_USER_TIMEOUT
   unsigned int timeout = 5000;
-  int ret = setsockopt(fd, SOL_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout));
+  ret = setsockopt(fd, SOL_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout));
   if (ret < 0) {
     syslog(LOG_ERR, "setsockopt error %d", errno);
     return false;

--- a/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
@@ -66,7 +66,7 @@ static int socket_create(const struct sockaddr *addr, socklen_t addr_len)
 {
   int ret;
 
-  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  int fd = socket(addr->sa_family, SOCK_STREAM, 0);
   if (fd < 0) {
     return fd;
   }

--- a/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
@@ -31,6 +31,11 @@ static int addr_parse(const char *addr, struct sockaddr *s_addr, socklen_t *s_ad
     return 1;
   }
 
+  if (resolutions == NULL) {
+    syslog(LOG_ERR, "no addresses returned by name resolution");
+    return 1;
+  }
+
   memcpy(s_addr, resolutions->ai_addr, resolutions->ai_addrlen);
   freeaddrinfo(resolutions);
 
@@ -70,7 +75,7 @@ err:
   return ret;
 }
 
-bool configure_socket(int fd)
+static bool configure_socket(int fd)
 {
 #ifdef TCP_USER_TIMEOUT
   unsigned int timeout = 5000;

--- a/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
@@ -14,14 +14,16 @@
 
 #define CONNECT_RETRY_TIME_s 10
 
-static int addr_parse(const char *addr, struct sockaddr *s_addr, socklet_t *s_addr_len)
+static int addr_parse(const char *addr, struct sockaddr *s_addr, socklen_t *s_addr_len)
 {
-  char hostname[256];
+  char hostname[256] = {0};
   int port;
   if (sscanf(addr, "%255[^:]:%d", hostname, &port) != 2) {
     syslog(LOG_ERR, "error parsing address");
     return 1;
   }
+
+  debug_printf("connecting to %s\n", hostname);
 
   struct addrinfo *resolutions = NULL;
   if (getaddrinfo(hostname, NULL, NULL, &resolutions) != 0) {
@@ -32,10 +34,21 @@ static int addr_parse(const char *addr, struct sockaddr *s_addr, socklet_t *s_ad
   memcpy(s_addr, resolutions->ai_addr, resolutions->ai_addrlen);
   freeaddrinfo(resolutions);
 
+  *s_addr_len = resolutions->ai_addrlen;
+
+  if (resolutions->ai_family == AF_INET) {
+    ((struct sockaddr_in*)s_addr)->sin_port = htons(port);
+  } else if (resolutions->ai_family == AF_INET6) {
+    ((struct sockaddr_in6*)s_addr)->sin6_port = htons(port);
+  } else {
+    syslog(LOG_ERR, "unknown address family returned from solution");
+    return 1;
+  }
+
   return 0;
 }
 
-static int socket_create(const struct sockaddr *addr, socklet_t addr_len)
+static int socket_create(const struct sockaddr *addr, socklen_t addr_len)
 {
   int ret;
 
@@ -57,11 +70,49 @@ err:
   return ret;
 }
 
+bool configure_socket(int fd)
+{
+#ifdef TCP_USER_TIMEOUT
+  unsigned int timeout = 5000;
+  int ret = setsockopt(fd, SOL_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout));
+  if (ret < 0) {
+    syslog(LOG_ERR, "setsockopt error %d", errno);
+    return false;
+  }
+#endif
+  int optval = 1;
+  ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval));
+  if (ret < 0) {
+    syslog(LOG_ERR, "setsockopt (SO_KEEPALIVE) error: %d", errno);
+    return false;
+  }
+  optval = 5;
+  ret = setsockopt(fd, SOL_TCP, TCP_KEEPCNT, &optval, sizeof(optval));
+  if (ret < 0) {
+    syslog(LOG_ERR, "setsockopt (TCP_KEEPCNT) error: %d", errno);
+    return false;
+  }
+  optval = 5;
+  ret = setsockopt(fd, SOL_TCP, TCP_KEEPINTVL, &optval, sizeof(optval));
+  if (ret < 0) {
+    syslog(LOG_ERR, "setsockopt (TCP_KEEPINTVL) error: %d", errno);
+    return false;
+  }
+  optval = 20;
+  ret = setsockopt(fd, SOL_TCP, TCP_KEEPIDLE, &optval, sizeof(optval));
+  if (ret < 0) {
+    syslog(LOG_ERR, "setsockopt (TCP_KEEPIDLE) error: %d", errno);
+    return false;
+  }
+  return true;
+}
+
 int tcp_connect_loop(const char *addr)
 {
   struct sockaddr_storage s_addr;
-  socklet_t s_addr_len;
-  if (addr_parse(addr, &s_addr, &s_addr_len) != 0) {
+  socklen_t s_addr_len = 0;
+
+  if (addr_parse(addr, (struct sockaddr *) &s_addr, &s_addr_len) != 0) {
     return 1;
   }
 
@@ -72,7 +123,9 @@ int tcp_connect_loop(const char *addr)
       sleep(CONNECT_RETRY_TIME_s);
       continue;
     }
-
+    if (!configure_socket(fd)) {
+      return 1;
+    }
     int wfd = dup(fd);
     io_loop_start(fd, wfd);
     io_loop_wait_one();

--- a/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
+++ b/package/zmq_adapter/src/zmq_adapter_tcp_connect.c
@@ -41,7 +41,7 @@ static int addr_parse(const char *addr, struct sockaddr *s_addr, socklen_t *s_ad
   } else if (resolutions->ai_family == AF_INET6) {
     ((struct sockaddr_in6*)s_addr)->sin6_port = htons(port);
   } else {
-    syslog(LOG_ERR, "unknown address family returned from solution");
+    syslog(LOG_ERR, "unknown address family returned from name resolution");
     return 1;
   }
 


### PR DESCRIPTION
Fix for https://github.com/swift-nav/firmware_team_planning/issues/377.

+ Configure the TCP socket that zmq_adapter opens up with keep-alive so that it'll recover (quicker) when the network stalls.

+ Add address resolution to the `addr_parse` helper so that TCP connections can use a DNS name instead of just an IP address.