### PR TITLE
Don't set 'chunked' for outgoing requests

### DIFF
--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -343,7 +343,6 @@ static void network_request(CURL *curl)
 static struct curl_slist *ntrip_init(CURL *curl)
 {
   struct curl_slist *chunk = NULL;
-  chunk = curl_slist_append(chunk, "Transfer-Encoding: chunked");
   chunk = curl_slist_append(chunk, "Ntrip-Version: Ntrip/2.0");
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
@@ -362,7 +361,6 @@ static struct curl_slist *skylark_init(CURL *curl)
 
   struct curl_slist *chunk = NULL;
   chunk = curl_slist_append(chunk, device_buf);
-  chunk = curl_slist_append(chunk, "Transfer-Encoding: chunked");
   chunk = curl_slist_append(chunk, "Accept: application/vnd.swiftnav.broker.v1+sbp2");
   chunk = curl_slist_append(chunk, "Content-Type: application/vnd.swiftnav.broker.v1+sbp2");
 


### PR DESCRIPTION
Setting "Transfer-Encoding: chunked" causes the some NTRIP casters to
attempt to parse the body of the GET request as chunked (even if the
body is empty).