### PR TITLE
Lstrz/antenna short

### DIFF
--- a/package/piksi_leds/src/firmware_state.c
+++ b/package/piksi_leds/src/firmware_state.c
@@ -17,7 +17,6 @@
 #include <libsbp/navigation.h>
 #include <libsbp/system.h>
 #include <libsbp/tracking.h>
-#include <c/include/libsbp/system.h>
 
 #include "firmware_state.h"
 

--- a/package/piksi_leds/src/firmware_state.c
+++ b/package/piksi_leds/src/firmware_state.c
@@ -17,12 +17,14 @@
 #include <libsbp/navigation.h>
 #include <libsbp/system.h>
 #include <libsbp/tracking.h>
+#include <c/include/libsbp/system.h>
 
 #include "firmware_state.h"
 
 /* These really belong in libsbp */
 #define SBP_ECEF_FLAGS_MODE_MASK 0x7
-#define SBP_HEARTBEAT_FLAGS_ANTENNA_SHIFT 31
+#define SBP_HEARTBEAT_FLAGS_ANTENNA_MASK (1 << 31)
+#define SBP_HEARTBEAT_FLAGS_ANTENNA_SHORT_MASK (1 << 30)
 
 static u8 base_obs_counter;
 static struct soln_state soln_state;
@@ -61,7 +63,9 @@ static void sbp_msg_baseline_ecef_callback(u16 sender_id, u8 len, u8 msg_[], voi
 static void sbp_msg_heartbeat_callback(u16 sender_id, u8 len, u8 msg_[], void *ctx)
 {
   msg_heartbeat_t *msg = (void*)msg_;
-  soln_state.antenna = msg->flags >> SBP_HEARTBEAT_FLAGS_ANTENNA_SHIFT;
+  // Implicit conversion to bool.
+  soln_state.antenna = msg->flags & SBP_HEARTBEAT_FLAGS_ANTENNA_MASK &&
+          !(msg->flags & SBP_HEARTBEAT_FLAGS_ANTENNA_SHORT_MASK);
   heartbeat_seen = true;
 }
 


### PR DESCRIPTION
# Design Notes

Added a check in the heartbeat callback that looks for antenna fault (over-current) flag. Fixes swift-nav/firmware_team_planning#394.

# Testing

Used a shorted antenna connector. Previously, the POS LED would start blinking. It no longer does that.

With a proper antenna, signal acquisition, tracking and LED signaling works as before.