### PR TITLE
Add a read_only host board eeprom id setting and temp file

### DIFF
--- a/package/piksi_leds/src/main.c
+++ b/package/piksi_leds/src/main.c
@@ -13,6 +13,8 @@
 #include <libpiksi/sbp_zmq_pubsub.h>
 #include <libpiksi/logging.h>
 #include <libpiksi/util.h>
+#include <libpiksi/settings.h>
+
 
 #include "firmware_state.h"
 #include "manage_led.h"
@@ -23,22 +25,41 @@
 #define SUB_ENDPOINT_EXTERNAL_SBP ">tcp://localhost:43030"
 
 #define DURO_EEPROM_PATH "/sys/devices/soc0/amba/e0005000.i2c/i2c-1/1-0050/eeprom"
+#define DURO_EEPROM_TEMPFS_PATH "/config/host_board_eeprom"
 
-static bool board_is_duro(void)
+/* eeprom_id has 6 chars but leave room for null terminator */
+static char eeprom_id[7] = "UNK_ID"; 
+
+static bool read_eeprom(void)
 {
   int fd = open(DURO_EEPROM_PATH, O_RDONLY);
   if (fd < 0)
     return false;
-  char buf[6];
-  read(fd, buf, 6);
+  read(fd, eeprom_id, 6); 
   close(fd);
-  return memcmp(buf, "DUROV0", 6) == 0;
+}
+static bool write_eeprom(void)
+{
+  int fd = open(DURO_EEPROM_TEMPFS_PATH, O_WRONLY);
+  if (fd < 0)
+    return false;
+  write(fd, eeprom_id, 7); 
+  close(fd);
+}
+
+static bool board_is_duro(void)
+{
+  return memcmp(eeprom_id, "DUROV0", 6) == 0;
 }
 
 int main(void)
 {
   logging_init(PROGRAM_NAME);
 
+  settings_ctx_t *settings_ctx = settings_create();
+  if (settings_ctx == NULL) {
+    exit(EXIT_FAILURE);
+  }
   /* Prevent czmq from catching signals */
   zsys_handler_set(NULL);
 
@@ -49,6 +70,13 @@ int main(void)
   }
 
   firmware_state_init(sbp_zmq_pubsub_rx_ctx_get(ctx));
+  read_eeprom();
+  write_eeprom();
+  
+  settings_register_readonly(settings_ctx, "system_info", "host_board_eeprom",
+                             eeprom_id, sizeof(eeprom_id),
+                             SETTINGS_TYPE_STRING);
+  
   manage_led_setup(board_is_duro());
 
   zmq_simple_loop(sbp_zmq_pubsub_zloop_get(ctx));


### PR DESCRIPTION
depends on: https://github.com/swift-nav/piksi_firmware_private/pull/1525

Uses a file in config to share info with real time firmware.  I could read a setting owned by another module, but I don't think that is a good pattern right now.