### PR TITLE
Rename sdk build output, don't push build comment to GH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,6 @@ matrix:
         - set -o pipefail && make docker-make-image 2>&1 | tee -a sdk_build.out | grep --line-buffered '^>>>'
       after_success:
         - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh sdk_build.out
-        - SLACK_CHANNEL=github ./comment.sh
       after_failure:
         - tail -n 500 build.out
         - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh sdk_build.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,11 @@ matrix:
         - bash -c "while true; do sleep 1m; echo ...; done" &
         - set -o pipefail && make docker-make-image 2>&1 | tee -a build.out | grep --line-buffered '^>>>'
       after_success:
-        - ./publish.sh build.out buildroot/output/images/piksiv3_prod/*
+        - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh build.out buildroot/output/images/piksiv3_prod/*
         - SLACK_CHANNEL=github ./comment.sh
       after_failure:
         - tail -n 500 build.out
-        - ./publish.sh build.out
+        - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh build.out
 
     # Host image build to run tests
     - env:
@@ -60,34 +60,29 @@ matrix:
         - set -o pipefail && make docker-make-host-image 2>&1 | tee -a host_build.out | grep --line-buffered '^>>>'
       after_success:
         - git fetch --tags --unshallow
-        - ./publish.sh host_build.out
+        - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh host_build.out
       after_failure:
         - tail -n 500 host_build.out
-        - ./publish.sh build.out
+        - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh host_build.out
 
     # Normal build + SDK sample app
     - env:
         - TRAVIS_TARGET=docker-make-image
         - BR2_BUILD_SAMPLE_DAEMON=y
-        - PRODUCT_REV=sdk_sample
       script:
         - make docker-setup
         - make docker-make-firmware
         - bash -c "while true; do sleep 1m; echo ...; done" &
-        - set -o pipefail && make docker-make-image 2>&1 | tee -a build.out | grep --line-buffered '^>>>'
+        - set -o pipefail && make docker-make-image 2>&1 | tee -a sdk_build.out | grep --line-buffered '^>>>'
       after_success:
-        - ./publish.sh build.out
+        - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh sdk_build.out
         - SLACK_CHANNEL=github ./comment.sh
       after_failure:
         - tail -n 500 build.out
-        - ./publish.sh build.out
-
-
+        - PRODUCT_VERSION=v3 PRODUCT_REV=prod ./publish.sh sdk_build.out
 
 env:
   global:
-    - PRODUCT_VERSION=v3
-    - PRODUCT_REV=prod
     # Secure keys below are encrypted with travis encrypt gem
     # Example encryption: travis encrypt AWS_SECRET_ACCESS_KEY=foo
     # See https://docs.travis-ci.com/user/encryption-keys/


### PR DESCRIPTION
+ Change the naming of what's uploaded for the SDK build so that it can
be put into the same folder as the other build logs

+ Add back PRODUCT_VERSION/PRODUCT_REV so it's obvious that they're
arguments to the publish.sh script

+ Remove the comment.sh script from the SDK example build

cc: @mfine 