### PR TITLE
[Release 1.3.x] don't pre-populate the buildroot dir, fix publish.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BR2_EXTERNAL:=$(shell pwd)
+BR2_EXTERNAL:=$(CURDIR)
 
 ifeq ($(HW_CONFIG),)
   HW_CONFIG=prod
@@ -7,15 +7,18 @@ endif
 DOCKER_BUILD_VOLUME = piksi_buildroot-buildroot$(DOCKER_SUFFIX)
 DOCKER_TAG = piksi_buildroot$(DOCKER_SUFFIX)
 
-DOCKER_RUN_ARGS :=                                                            \
+DOCKER_SETUP_ARGS :=                                                          \
   --rm                                                                        \
   -e HW_CONFIG=$(HW_CONFIG)                                                   \
   -e BR2_EXTERNAL=/piksi_buildroot                                            \
   -e BR2_BUILD_SAMPLE_DAEMON=$(BR2_BUILD_SAMPLE_DAEMON)                       \
-  -v `pwd`:/piksi_buildroot                                                   \
-  -v `pwd`/buildroot/output/images:/piksi_buildroot/buildroot/output/images   \
+  -v $(CURDIR):/piksi_buildroot                                               \
   -v $(HOME)/.aws:/root/.aws:ro                                               \
   -v $(DOCKER_BUILD_VOLUME):/piksi_buildroot/buildroot                        \
+
+DOCKER_RUN_ARGS :=                                                          \
+	$(DOCKER_SETUP_ARGS)                                                      \
+  -v $(CURDIR)/buildroot/output/images:/piksi_buildroot/buildroot/output/images \
 
 DOCKER_ARGS := --sig-proxy=false $(DOCKER_RUN_ARGS)
 
@@ -76,7 +79,7 @@ docker-build-image:
 	docker build --no-cache --force-rm --tag $(DOCKER_TAG) .
 
 docker-populate-volume:
-	docker run $(DOCKER_ARGS) $(DOCKER_TAG) \
+	docker run $(DOCKER_SETUP_ARGS) $(DOCKER_TAG) \
 		git submodule update --init --recursive
 
 docker-setup: docker-build-image docker-populate-volume

--- a/README.md
+++ b/README.md
@@ -14,36 +14,6 @@
   - Board-specific files (rootfs overlay, device trees, scripts, etc.) in `board/piksiv3`
 
 
-## Fetching firmware binaries
-
-To build a production system image, the build process expects the following
-firmware and FPGA binaries to be present:
-
-```
-firmware/prod/piksi_firmware.elf
-firmware/prod/piksi_fpga.bit
-firmware/microzed/piksi_firmware.elf
-firmware/microzed/piksi_fpga.bit
-```
-
-You can use the following command to download these binaries from S3. Note that
-this requires `awscli` to be installed and AWS credentials to be properly
-configured.
-
-```
-# Docker
-make docker-make-firmware # (Requires 'make docker-setup` to be run first)
-
-# Linux native
-make firmware
-```
-
-Check `fetch-firmware.sh` to see which image versions are being used.
-
-Note that these binaries are only used by the production system image. In the
-development system image they are instead read from the network or SD
-card.
-
 ## Building
 
 ### Docker
@@ -129,3 +99,33 @@ make docker-make-image
 # or, Linux native
 make image
 ```
+
+## Fetching firmware binaries
+
+To build a production system image, the build process expects the following
+firmware and FPGA binaries to be present:
+
+```
+firmware/prod/piksi_firmware.elf
+firmware/prod/piksi_fpga.bit
+firmware/microzed/piksi_firmware.elf
+firmware/microzed/piksi_fpga.bit
+```
+
+You can use the following command to download these binaries from S3. Note that
+this requires `awscli` to be installed and AWS credentials to be properly
+configured if you are not building from a release branch.
+
+```
+# Docker
+make docker-make-firmware # (Requires 'make docker-setup` to be run first)
+
+# Linux native
+make firmware
+```
+
+Check `fetch-firmware.sh` to see which image versions are being used.
+
+Note that these binaries are only used by the production system image. In the
+development system image they are instead read from the network or SD
+card.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,35 @@
   - Custom packages in `package`
   - Board-specific files (rootfs overlay, device trees, scripts, etc.) in `board/piksiv3`
 
+## Fetching firmware binaries
+
+To build a production system image, the build process expects the following
+firmware and FPGA binaries to be present:
+
+```
+firmware/prod/piksi_firmware.elf
+firmware/prod/piksi_fpga.bit
+firmware/microzed/piksi_firmware.elf
+firmware/microzed/piksi_fpga.bit
+```
+
+You can use the following command to download these binaries from S3. Note that
+this requires `awscli` to be installed and AWS credentials to be properly
+configured.
+
+```
+# Docker
+make docker-make-firmware # (Requires 'make docker-setup` to be run first)
+
+# Linux native
+make firmware
+```
+
+Check `fetch-firmware.sh` to see which image versions are being used.
+
+Note that these binaries are only used by the production system image. In the
+development system image they are instead read from the network or SD
+card.
 
 ## Building
 
@@ -99,33 +128,3 @@ make docker-make-image
 # or, Linux native
 make image
 ```
-
-## Fetching firmware binaries
-
-To build a production system image, the build process expects the following
-firmware and FPGA binaries to be present:
-
-```
-firmware/prod/piksi_firmware.elf
-firmware/prod/piksi_fpga.bit
-firmware/microzed/piksi_firmware.elf
-firmware/microzed/piksi_fpga.bit
-```
-
-You can use the following command to download these binaries from S3. Note that
-this requires `awscli` to be installed and AWS credentials to be properly
-configured if you are not building from a release branch.
-
-```
-# Docker
-make docker-make-firmware # (Requires 'make docker-setup` to be run first)
-
-# Linux native
-make firmware
-```
-
-Check `fetch-firmware.sh` to see which image versions are being used.
-
-Note that these binaries are only used by the production system image. In the
-development system image they are instead read from the network or SD
-card.

--- a/publish.sh
+++ b/publish.sh
@@ -41,12 +41,12 @@ echo "Publish TAG ($TRAVIS_TAG)"
 
 for file in "$@"; do
     KEY="$BUILD_PATH/$(basename $file)"
+    OBJECT="s3://$BUCKET/$KEY"
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         if [[ "$TRAVIS_BRANCH" == master || "$TRAVIS_TAG" == v* || "$TRAVIS_BRANCH" == v*-release ]]; then
-            OBJECT="s3://$BUCKET/$KEY"
             aws s3 cp "$file" "$OBJECT"
         fi
     else
-        aws s3api put-object --no-sign-request --bucket "$PRS_BUCKET" --key "$KEY" --body "$file" --acl public-read
+        aws s3 cp "$file" "$OBJECT"
     fi
 done


### PR DESCRIPTION
+ Addresses https://github.com/swift-nav/firmware_team_planning/issues/412

+ Don't accidentally pre-populate buildroot dir.  This will cause the `git submodule update` command to fail.

+ Fix fetch_firmware.sh to not try to use a public-read puts.