### PR TITLE
Interim NTRIP connectivity logging improvements

### DIFF
--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -332,9 +332,9 @@ static void network_request(CURL *curl)
       sbp_log(LOG_ERR, "Network Request Error - \"%s\"", error_buf);
       piksi_log(LOG_ERR, "curl request (error: %d) \"%s\"", code, error_buf);
     } else {
-      long response;
+      long response = 0;
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
-      if (response) {
+      if (response != 0) {
         sbp_log(LOG_INFO, "Network Request Response Code - (%d)", response);
         piksi_log(LOG_INFO, "curl request code %d", response);
       }

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -329,11 +329,15 @@ static void network_request(CURL *curl)
       continue;
 
     if (code != CURLE_OK) {
+      sbp_log(LOG_ERR, "Network Request Error - \"%s\"", error_buf);
       piksi_log(LOG_ERR, "curl request (error: %d) \"%s\"", code, error_buf);
     } else {
       long response;
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
-      piksi_log(LOG_INFO, "curl request code %d", response);
+      if (response) {
+        sbp_log(LOG_INFO, "Network Request Response Code - (%d)", response);
+        piksi_log(LOG_INFO, "curl request code %d", response);
+      }
     }
 
     usleep(1000000);


### PR DESCRIPTION
This is a first pass addressing https://github.com/swift-nav/piksi_v3_bug_tracking/issues/921 along with some input from @mfine and @LanceAndre as summarized below:

This PR covers:
* Curl reported error and http repsonse codes (failed connections, bad creds or url)
* Exposing this activity to the user via Swift Console via `sbp_log`

This PR does NOT cover:
* NTRIP protocol level issues that may arise (No NTRIP caster found, NMEA GGA not set - possibly related to https://github.com/swift-nav/piksi_buildroot/pull/444, RTCM message type 16/36/1029 reporting)

*Details*
This is not much more than adding curl error string reporting as well as http response code info logging via `sbp_log`, where previously these were only sent to `piksi_log` (`vsyslog`). Nevertheless this covers a variety of cases and is relatively verbose when dealing with connection issues that don't touch the protocol level.

E.G.
ERROR ntrip_daemon: Network Request Error - "Resolving timed out after 15004 milliseconds"
ERROR ntrip_daemon: Network Request Error - "Could not resolve: rtgpsout.unavco.org (Could not contact DNS servers)"
INFO ntrip_daemon: Network Request Response Code - (401)
etc..

If necessary I can create a routine to inspect these codes and print coherent 'user friendly' text ( `401` => `"Unauthorized"`) from a whitelist that is maintained manually but I am leaving that out for now.

In reference to https://github.com/swift-nav/firmware_team_planning/issues/411 - much of the current logging in libnetwork is very curl specific and likely useful only to developers. It seems like the bulk of the interest in logging lies in `sbp_rtcm3_bridge` based on the above feedback. Feel free to correct or comment, I am still coming up to speed on all the working parts.