### PR TITLE
 Poll for network state with ping

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S85network_poll
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S85network_poll
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+name="network_poll"
+cmd="/etc/init.d/network_poll.sh"
+dir="/"
+user=""
+
+source /etc/init.d/template_process.inc.sh

--- a/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
@@ -1,0 +1,12 @@
+#!/bin/ash
+
+while true; do
+  if ping -w 5 -c 1 8.8.8.8 >/dev/null 2>&1 || \
+     ping -w 5 -c 1 114.114.114.114 > /dev/null 2>&1; then
+    echo 1 > /var/run/network_available
+    sleep 10
+  else
+    echo 0 > /var/run/network_available
+    sleep 1
+  fi
+done

--- a/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
@@ -1,6 +1,13 @@
 #!/bin/ash
 
 while true; do
+  sleep 10
+  if [ x`cat /var/run/network_available` != "x1" ]; then
+    echo "No route to Internet" | sbp_log --warn
+  fi
+done &
+
+while true; do
   if ping -w 5 -c 1 8.8.8.8 >/dev/null 2>&1 || \
      ping -w 5 -c 1 114.114.114.114 > /dev/null 2>&1; then
     echo 1 > /var/run/network_available


### PR DESCRIPTION
Periodically check for Internet connectivity by pinging public DNS servers.
Network status is written to `/var/run/network_available` for use by other processes.
While network is down, an SBP warning will be logged periodically with the text "No route to Internet"

For Duro Cell Modem solution S1 & S2, task https://github.com/swift-nav/firmware_team_planning/issues/429

Works with https://github.com/swift-nav/piksi_buildroot/pull/452 for LED changes.