### PR TITLE
Fix baseline calculation for threshold warning

### DIFF
--- a/package/health_daemon/src/health_monitor.c
+++ b/package/health_daemon/src/health_monitor.c
@@ -67,6 +67,14 @@ void health_monitor_reset_timer(health_monitor_t* monitor)
 }
 
 /*
+ * Access shared log function
+ */
+log_fn_t health_monitor_get_log(health_monitor_t* monitor)
+{
+  return monitor->log_fn;
+}
+
+/*
  * Call Monitor Message Callback
  */
 static void health_monitor_message_callback(u16 sender_id, u8 len, u8 msg[], void *ctx)

--- a/package/health_daemon/src/health_monitor.h
+++ b/package/health_daemon/src/health_monitor.h
@@ -40,6 +40,11 @@ void health_monitor_set_timer_resolution(u32 resolution);
 void health_monitor_reset_timer(health_monitor_t* monitor);
 
 /*
+ * Access shared log function
+ */
+log_fn_t health_monitor_get_log(health_monitor_t* monitor);
+
+/*
  * Allocate Monitor
  */
 health_monitor_t* health_monitor_create(void);


### PR DESCRIPTION
Conversion from mm to m was needed for correct
evaluation of the threshold. The timer callback
was added to build in a 1Hz rate limit on alerts.

Addresses swift-nav/piksi_v3_bug_tracking#986