### PR TITLE
piksi_leds: Exit on init failures.

### DIFF
--- a/package/piksi_leds/src/led_adp8866.c
+++ b/package/piksi_leds/src/led_adp8866.c
@@ -273,11 +273,13 @@ void led_adp8866_init(bool is_duro) {
   init_reg_isc(is_duro);
 
   if (!id_check()) {
+    exit(2);
     return;
   }
 
   if (!configure()) {
     piksi_log(LOG_WARNING, "Failed to configure LED driver");
+    exit(3);
   }
 
   led_adp8866_led_state_t led_states[LED_ADP8866_LED_COUNT];
@@ -289,6 +291,7 @@ void led_adp8866_init(bool is_duro) {
 
   if (!leds_set(led_states, LED_ADP8866_LED_COUNT)) {
     piksi_log(LOG_WARNING, "Failed to initialize LED states");
+    exit(4);
   }
 }
 

--- a/package/piksi_leds/src/manage_led.c
+++ b/package/piksi_leds/src/manage_led.c
@@ -258,6 +258,9 @@ static void handle_mode(rgb_led_state_t *s, device_state_t dev_state) {
 static void * manage_led_thread(void *arg) {
   bool is_duro = (bool)arg;
 
+  while (!firmware_state_heartbeat_seen())
+    usleep(MANAGE_LED_THREAD_PERIOD_MS * 1000);
+
   led_adp8866_init(is_duro);
   {
     led_adp8866_led_state_t init_states[LED_ADP8866_LED_COUNT];
@@ -269,9 +272,6 @@ static void * manage_led_thread(void *arg) {
                          sizeof(init_states) / sizeof(init_states[0]));
     sleep(2);
   }
-
-  while (!firmware_state_heartbeat_seen())
-    usleep(MANAGE_LED_THREAD_PERIOD_MS * 1000);
 
   while (true) {
     device_state_t dev_state = get_device_state();


### PR DESCRIPTION
Also wait for firmware to boot before configuring LED controllers.  LED reset signal is driven by firmware on a GPIO.  Moving this to Linux is inconvenient, as the firmware needs the GPIO controller for other purposes.