### PR TITLE
llvm_obfuscator: update to v12, check linking of czmq [v1.4]

### DIFF
--- a/package/llvm_obfuscator/llvm_obfuscator.hash
+++ b/package/llvm_obfuscator/llvm_obfuscator.hash
@@ -1,1 +1,1 @@
-sha256 470d5d75b437e5afd94f2fb5744fb8be7546a7ac3cb041de7d2f619988fa1f80  llvm-obfuscator-arm-x86.txz
+sha256 92dc973bd2657c594a8bf2076bafbeb51dfc437889002cacb2517c17255b6663 llvm-obfuscator-arm-x86.txz

--- a/package/llvm_obfuscator/llvm_obfuscator.mk
+++ b/package/llvm_obfuscator/llvm_obfuscator.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HOST_LLVM_OBFUSCATOR_VERSION = v11
+HOST_LLVM_OBFUSCATOR_VERSION = v12
 HOST_LLVM_OBFUSCATOR_SOURCE = $(HOST_LLVM_OBFUSCATOR_VERSION)/llvm-obfuscator-arm-x86.txz
 HOST_LLVM_OBFUSCATOR_SITE = https://github.com/swift-nav/llvm-obfuscator-arm/releases/download/
 HOST_LLVM_OBFUSCATOR_ACTUAL_SOURCE_TARBALL = llvm-obfuscator-$(HOST_LLVM_OBFUSCATOR_VERSION).tar.xz
@@ -21,6 +21,8 @@ SYSROOT = $(shell find $(HOST_DIR)/usr -name 'sysroot')
 define HOST_LLVM_OBFUSCATOR_INSTALL_CMDS
 	mkdir -p $(HOST_DIR)/opt/llvm-obfuscator
 	rsync -az $(@D)/opt/llvm-obfuscator/ $(HOST_DIR)/opt/llvm-obfuscator/
+	rsync -az --ignore-existing \
+		$(SYSROOT)/lib/ $(HOST_DIR)/opt/llvm-obfuscator/sysroot/lib/
 	rsync -az --ignore-existing \
 		$(SYSROOT)/usr/lib/ $(HOST_DIR)/opt/llvm-obfuscator/sysroot/usr/lib/
 	rsync -az --ignore-existing \

--- a/package/piksi_ins_ref/piksi_ins_ref.mk
+++ b/package/piksi_ins_ref/piksi_ins_ref.mk
@@ -6,10 +6,10 @@
 
 ifeq    ($(BR2_HAS_PIKSI_INS_REF),y)
 
-PIKSI_INS_REF_VERSION = v6
+PIKSI_INS_REF_VERSION = v9
 PIKSI_INS_REF_SITE = ssh://git@github.com/swift-nav/piksi_inertial_ipsec_crl.git
 PIKSI_INS_REF_SITE_METHOD = git
-PIKSI_INS_REF_DEPENDENCIES = host-llvm_obfuscator
+PIKSI_INS_REF_DEPENDENCIES = host-llvm_obfuscator czmq
 
 ifeq    ($(BR2_BUILD_TESTS),y)
 ifeq    ($(BR2_RUN_TESTS),y)
@@ -35,10 +35,12 @@ define PIKSI_INS_REF_BUILD_FOR_TARGET
 	$(MAKE) CC=$(LLVM_OBF_CC) CXX=$(LLVM_OBF_CXX) AR=$(LLVM_OBF_AR) \
 				  STRIP=$(LLVM_OBF_STRIP) HOSTCC=$(LLVM_OBF_HOSTCC) \
 					HOSTCXX=$(LLVM_OBF_HOSTCXX) OBJCOPY=$(LLVM_OBF_OBJCOPY) \
+					TEST_CZMQ_LINK=y \
 					-C $(@D) all || :
 	$(MAKE) CC=$(LLVM_OBF_CC) CXX=$(LLVM_OBF_CXX) AR=$(LLVM_OBF_AR) \
 				  STRIP=$(LLVM_OBF_STRIP) HOSTCC=$(LLVM_OBF_HOSTCC) \
 					HOSTCXX=$(LLVM_OBF_HOSTCXX) OBJCOPY=$(LLVM_OBF_OBJCOPY) \
+					TEST_CZMQ_LINK=y \
 					-C $(@D) all
 endef
 endif # ($(BR2_BUILD_TESTS),y)


### PR DESCRIPTION
Fix for https://github.com/swift-nav/firmware_team_planning/issues/432

+ Bring in v12 of llvm-obfuscator-arm which fixes compatibility issues with the default buildroot toolchain

+ Sync /lib from the default toolchain's sysroot dir (this pulls in libuuid.so needed for linking against czmq)

+ Bring v9 of piksi_ins_ref, which adds a test checking that linking against czmq works