### PR TITLE
Allow settings write response to go to SBP_PORT_EXTERNAL

### DIFF
--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -111,6 +111,7 @@ ports:
       - dst_port: SBP_PORT_EXTERNAL
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
           - { action: REJECT }
       - dst_port: SBP_PORT_SETTINGS_DAEMON
         filters:


### PR DESCRIPTION
Now that we implement sending a settings write response, we need to
allow the response to be sent to SBP_PORT_EXTERNAL so it can make it's
way to the console.