### PR TITLE
Only do the "no internet" check if NTRIP/Skylark is enabled

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
@@ -1,8 +1,30 @@
 #!/bin/ash
 
+touch /var/run/skylark_enabled
+touch /var/run/ntrip_enabled
+
+skylark_enabled() {
+  if [ x`cat /var/run/skylark_enabled` != "x0" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+ntrip_enabled() {
+  if [ x`cat /var/run/ntrip_enabled` != "x0" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 should_check_inet() {
-  [ x`cat /var/run/skylark_enabled` != "x0" ] || \
-    [ x`cat /var/run/ntrip_enabled` != "x0" ]
+  if skylark_enabled || ntrip_enabled; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 while true; do
@@ -16,6 +38,9 @@ while true; do
     echo "No route to Internet" | sbp_log --warn
   fi
 done &
+
+child_pid=$!
+trap 'kill $child_pid; exit' EXIT STOP TERM
 
 while true; do
   if ! should_check_inet; then

--- a/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
@@ -9,8 +9,9 @@ while true; do
   if ! should_check_inet; then
     sleep 1
     continue
+  else
+    sleep 10
   fi
-  sleep 10
   if [ x`cat /var/run/network_available` != "x1" ]; then
     echo "No route to Internet" | sbp_log --warn
   fi

--- a/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/network_poll.sh
@@ -1,6 +1,15 @@
 #!/bin/ash
 
+should_check_inet() {
+  [ x`cat /var/run/skylark_enabled` != "x0" ] || \
+    [ x`cat /var/run/ntrip_enabled` != "x0" ]
+}
+
 while true; do
+  if ! should_check_inet; then
+    sleep 1
+    continue
+  fi
   sleep 10
   if [ x`cat /var/run/network_available` != "x1" ]; then
     echo "No route to Internet" | sbp_log --warn
@@ -8,6 +17,10 @@ while true; do
 done &
 
 while true; do
+  if ! should_check_inet; then
+    sleep 1
+    continue
+  fi
   if ping -w 5 -c 1 8.8.8.8 >/dev/null 2>&1 || \
      ping -w 5 -c 1 114.114.114.114 > /dev/null 2>&1; then
     echo 1 > /var/run/network_available

--- a/package/piksi_system_daemon/piksi_system_daemon/src/ntrip.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/ntrip.c
@@ -97,8 +97,11 @@ static int ntrip_notify(void *context)
     }
 
     if (!ntrip_enabled || strcmp(ntrip_url, "") == 0) {
+      system("echo 0 >/var/run/ntrip_enabled");
       continue;
     }
+
+    system("echo 1 >/var/run/ntrip_enabled");
 
     ntrip_argv = ntrip_debug ? ntrip_argv_debug : ntrip_argv_normal;
 

--- a/package/piksi_system_daemon/piksi_system_daemon/src/skylark.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/skylark.c
@@ -106,8 +106,11 @@ static int skylark_notify(void *context)
     }
 
     if (!skylark_enabled) {
+      system("echo 0 >/var/run/skylark_enabled");
       continue;
     }
+
+    system("echo 1 >/var/run/skylark_enabled");
 
     process->pid = fork();
     if (process->pid == 0) {


### PR DESCRIPTION
Fix for https://github.com/swift-nav/piksi_v3_bug_tracking/issues/996