### PR TITLE
Add shared context module for glo health monitors

### DIFF
--- a/package/health_daemon/src/Makefile
+++ b/package/health_daemon/src/Makefile
@@ -1,5 +1,5 @@
 TARGET=health_daemon
-SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c utils.c
+SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c utils.c glo_health_context.c
 LIBS=-lczmq -lsbp -lpiksi -lm
 CFLAGS=-std=gnu11 -Wmissing-prototypes -Wconversion -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror
 

--- a/package/health_daemon/src/glo_bias_monitor.h
+++ b/package/health_daemon/src/glo_bias_monitor.h
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef __HEALTH_MONITOR_GNSS_BIAS_H
-#define __HEALTH_MONITOR_GNSS_BIAS_H
+#ifndef __HEALTH_MONITOR_GLO_BIAS_H
+#define __HEALTH_MONITOR_GLO_BIAS_H
 
 int glo_bias_timeout_health_monitor_init(health_ctx_t *health_ctx);
 void glo_bias_timeout_health_monitor_deinit(void);
 
-#endif /* __HEALTH_MONITOR_GNSS_BIAS_H */
+#endif /* __HEALTH_MONITOR_GLO_BIAS_H */

--- a/package/health_daemon/src/glo_health_context.c
+++ b/package/health_daemon/src/glo_health_context.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ *  be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+
+#include <stdlib.h>
+#include <libsbp/sbp.h>
+
+#include "glo_health_context.h"
+
+static struct glo_health_ctx_s {
+  bool glonass_enabled;
+  bool connected_to_base;
+} glo_health_ctx = { .glonass_enabled = false, .connected_to_base = false };
+
+
+void glo_context_receive_base_obs(void)
+{
+  glo_health_ctx.connected_to_base = true;
+}
+
+void glo_context_reset_connected_to_base(void)
+{
+  glo_health_ctx.connected_to_base = false;
+}
+
+bool glo_context_is_connected_to_base(void)
+{
+  return glo_health_ctx.connected_to_base;
+}
+
+void glo_context_set_glonass_enabled(bool enabled)
+{
+  glo_health_ctx.glonass_enabled = enabled;
+}
+
+bool glo_context_is_glonass_enabled(void)
+{
+  return glo_health_ctx.glonass_enabled;
+}

--- a/package/health_daemon/src/glo_health_context.c
+++ b/package/health_daemon/src/glo_health_context.c
@@ -16,6 +16,9 @@
 
 #include "glo_health_context.h"
 
+/**
+ * \brief private context for glo health state
+ */
 static struct glo_health_ctx_s {
   bool glonass_enabled;
   bool connected_to_base;

--- a/package/health_daemon/src/glo_health_context.h
+++ b/package/health_daemon/src/glo_health_context.h
@@ -13,10 +13,32 @@
 #ifndef __HEALTH_MONITOR_GLO_CONTEXT_H
 #define __HEALTH_MONITOR_GLO_CONTEXT_H
 
+/**
+ * \brief glo_context_receive_base_obs - indicate base obs received
+ */
 void glo_context_receive_base_obs(void);
+
+/**
+ * \brief glo_context_reset_connected_to_base - indicate base is disconnected
+ */
 void glo_context_reset_connected_to_base(void);
+
+/**
+ * \brief glo_context_is_connected_to_base - evaluate base connection state
+ * \return true if base is currently connected and receiving obs, otherwise false
+ */
 bool glo_context_is_connected_to_base(void);
+
+/**
+ * \brief glo_context_set_glonass_enabled - set the current glonass enable state
+ * \param enabled: bool indicating if glonass enable is set to true or false
+ */
 void glo_context_set_glonass_enabled(bool enabled);
+
+/**
+ * \brief glo_context_is_glonass_enabled - evaluate glonass enabled state
+ * \return true if glonass_aquisition_enabled is true, otherwise false
+ */
 bool glo_context_is_glonass_enabled(void);
 
 #endif /* __HEALTH_MONITOR_GLO_CONTEXT_H */

--- a/package/health_daemon/src/glo_health_context.h
+++ b/package/health_daemon/src/glo_health_context.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ *  be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef __HEALTH_MONITOR_GLO_CONTEXT_H
+#define __HEALTH_MONITOR_GLO_CONTEXT_H
+
+void glo_context_receive_base_obs(void);
+void glo_context_reset_connected_to_base(void);
+bool glo_context_is_connected_to_base(void);
+void glo_context_set_glonass_enabled(bool enabled);
+bool glo_context_is_glonass_enabled(void);
+
+#endif /* __HEALTH_MONITOR_GLO_CONTEXT_H */

--- a/package/health_daemon/src/glo_obs_monitor.h
+++ b/package/health_daemon/src/glo_obs_monitor.h
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef __HEALTH_MONITOR_GNSS_OBS_H
-#define __HEALTH_MONITOR_GNSS_OBS_H
+#ifndef __HEALTH_MONITOR_GLO_OBS_H
+#define __HEALTH_MONITOR_GLO_OBS_H
 
 int glo_obs_timeout_health_monitor_init(health_ctx_t *health_ctx);
 void glo_obs_timeout_health_monitor_deinit(void);
 
-#endif /* __HEALTH_MONITOR_GNSS_OBS_H */
+#endif /* __HEALTH_MONITOR_GLO_OBS_H */


### PR DESCRIPTION
The same parameters are used for both glo obs and
bias monitoring so they have been merged into
a global context with access/modifier methods.
Effectively this makes the bias monitor slave
to the more 'active' obs monitor - relying on
its shorter timeout to keep current the base
station connection parameter and handle the
glonass enabled setting query/updates

swift-nav/firmware_team_planning#453

Related to:  swift-nav/piksi_v3_bug_tracking#999 