### PR TITLE
Override the upstream site for LZO library

### DIFF
--- a/package/lzo_override/lzo_override.mk
+++ b/package/lzo_override/lzo_override.mk
@@ -1,0 +1,1 @@
+LZO_SITE = https://ftp.osuosl.org/pub/blfs/conglomeration/lzo


### PR DESCRIPTION
Temp fix since www.oberhumer.com/opensource/lzo/download is down.