### PR TITLE
[DEV] Add shared context module for glo health monitors

### DIFF
--- a/package/health_daemon/src/Makefile
+++ b/package/health_daemon/src/Makefile
@@ -1,5 +1,5 @@
 TARGET=health_daemon
-SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c utils.c
+SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c utils.c glo_health_context.c
 LIBS=-lczmq -lsbp -lpiksi -lm
 CFLAGS=-std=gnu11 -Wmissing-prototypes -Wconversion -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror
 

--- a/package/health_daemon/src/glo_bias_monitor.c
+++ b/package/health_daemon/src/glo_bias_monitor.c
@@ -10,6 +10,20 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+/**
+ * \file glo_bias_monitor.c
+ * \brief GLONASS Bias Message Health Monitor
+ *
+ * When glonass acquisition is enabled, it is expected that glonass bias
+ * measurements will be received periodically. This monitor will track
+ * bias messages and alert after a specified time period if no biases are
+ * received. Will not alert when not connected to a base station (no base
+ * obs messages being received).
+ * \author Ben Altieri
+ * \version v1.4.0
+ * \date 2018-01-30
+ */
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -22,61 +36,48 @@
 #include "health_monitor.h"
 #include "utils.h"
 
+#include "glo_health_context.h"
 #include "glo_bias_monitor.h"
 
 /* these are from fw private, consider moving to libpiski */
 #define MSG_FORWARD_SENDER_ID (0u)
 
-#define GNSS_BIAS_ALERT_RATE_LIMIT (240000) /* ms */
+#define GLO_BIAS_ALERT_RATE_LIMIT (240000) /* ms */
 
+/**
+ * \brief Private context for the glo bias health monitor
+ */
 static health_monitor_t *glo_bias_monitor;
 
-static struct glo_bias_ctx_s {
-  bool glo_setting_read_resp;
-  bool glonass_enabled;
-} glo_bias_ctx = { .glo_setting_read_resp = false, .glonass_enabled = false };
-
-static void
-sbp_msg_read_resp_callback(u16 sender_id, u8 len, u8 msg_[], void *ctx)
-{
-  (void)sender_id;
-  (void)len;
-  health_monitor_t *monitor = (health_monitor_t *)ctx;
-
-  const char *section, *name, *value;
-  if (health_util_parse_setting_read_resp(msg_, len, &section, &name, &value)
-      == 0) {
-    bool last_glonass_enabled = glo_bias_ctx.glonass_enabled;
-    if (health_util_check_glonass_enabled(
-          section, name, value, &glo_bias_ctx.glonass_enabled)
-        == 0) {
-      glo_bias_ctx.glo_setting_read_resp = true;
-      if (glo_bias_ctx.glonass_enabled && !last_glonass_enabled) {
-        health_monitor_reset_timer(monitor);
-      }
-    }
-  }
-}
-
+/**
+ * \brief glo_bias_timer_callback - handler for glo_bias_monitor timeouts
+ * \param monitor: health monitor associated with this callback
+ * \param context: user context associated with the monitor
+ * \return 0 for success, otherwise error
+ */
 static int glo_bias_timer_callback(health_monitor_t *monitor, void *context)
 {
+  (void)monitor;
   (void)context;
-  if (glo_bias_ctx.glonass_enabled) {
+  if (glo_context_is_glonass_enabled() && glo_context_is_connected_to_base()) {
     sbp_log(
       LOG_WARNING,
-      "Glonass Biases Msg Timeout - no biases msg received within %d sec window",
-      GNSS_BIAS_ALERT_RATE_LIMIT / 1000);
-  }
-  if (!glo_bias_ctx.glo_setting_read_resp) {
-    health_monitor_send_setting_read_request(
-      monitor,
-      SETTING_SECTION_ACQUISITION,
-      SETTING_GLONASS_ACQUISITION_ENABLED);
+      "Reference GLONASS Biases Msg Timeout - no biases received from base station within %d sec window",
+      GLO_BIAS_ALERT_RATE_LIMIT / 1000);
   }
 
   return 0;
 }
 
+/**
+ * \brief sbp_msg_glo_biases_callback - handler for glo bias sbp messages
+ * \param monitor: health monitor associated with this callback
+ * \param sender_id: message sender id
+ * \param len: length of the message in bytes
+ * \param msg_[]: pointer to message data
+ * \param ctx: user context associated with the monitor
+ * \return 0 resets timeout, 1 skips the reset, -1 for error
+ */
 static int sbp_msg_glo_biases_callback(health_monitor_t *monitor,
                                        u16 sender_id,
                                        u8 len,
@@ -106,15 +107,9 @@ int glo_bias_timeout_health_monitor_init(health_ctx_t *health_ctx)
                           health_ctx,
                           SBP_MSG_GLO_BIASES,
                           sbp_msg_glo_biases_callback,
-                          GNSS_BIAS_ALERT_RATE_LIMIT,
+                          GLO_BIAS_ALERT_RATE_LIMIT,
                           glo_bias_timer_callback,
                           NULL)
-      != 0) {
-    return -1;
-  }
-
-  if (health_monitor_register_setting_handler(glo_bias_monitor,
-                                              sbp_msg_read_resp_callback)
       != 0) {
     return -1;
   }

--- a/package/health_daemon/src/glo_bias_monitor.h
+++ b/package/health_daemon/src/glo_bias_monitor.h
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef __HEALTH_MONITOR_GNSS_BIAS_H
-#define __HEALTH_MONITOR_GNSS_BIAS_H
+#ifndef __HEALTH_MONITOR_GLO_BIAS_H
+#define __HEALTH_MONITOR_GLO_BIAS_H
 
 int glo_bias_timeout_health_monitor_init(health_ctx_t *health_ctx);
 void glo_bias_timeout_health_monitor_deinit(void);
 
-#endif /* __HEALTH_MONITOR_GNSS_BIAS_H */
+#endif /* __HEALTH_MONITOR_GLO_BIAS_H */

--- a/package/health_daemon/src/glo_health_context.c
+++ b/package/health_daemon/src/glo_health_context.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ *  be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+
+#include <stdlib.h>
+#include <libsbp/sbp.h>
+
+#include "glo_health_context.h"
+
+/**
+ * \brief private context for glo health state
+ */
+static struct glo_health_ctx_s {
+  bool glonass_enabled;
+  bool connected_to_base;
+} glo_health_ctx = { .glonass_enabled = false, .connected_to_base = false };
+
+
+void glo_context_receive_base_obs(void)
+{
+  glo_health_ctx.connected_to_base = true;
+}
+
+void glo_context_reset_connected_to_base(void)
+{
+  glo_health_ctx.connected_to_base = false;
+}
+
+bool glo_context_is_connected_to_base(void)
+{
+  return glo_health_ctx.connected_to_base;
+}
+
+void glo_context_set_glonass_enabled(bool enabled)
+{
+  glo_health_ctx.glonass_enabled = enabled;
+}
+
+bool glo_context_is_glonass_enabled(void)
+{
+  return glo_health_ctx.glonass_enabled;
+}

--- a/package/health_daemon/src/glo_health_context.h
+++ b/package/health_daemon/src/glo_health_context.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ *  be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef __HEALTH_MONITOR_GLO_CONTEXT_H
+#define __HEALTH_MONITOR_GLO_CONTEXT_H
+
+/**
+ * \brief glo_context_receive_base_obs - indicate base obs received
+ */
+void glo_context_receive_base_obs(void);
+
+/**
+ * \brief glo_context_reset_connected_to_base - indicate base is disconnected
+ */
+void glo_context_reset_connected_to_base(void);
+
+/**
+ * \brief glo_context_is_connected_to_base - evaluate base connection state
+ * \return true if base is currently connected and receiving obs, otherwise false
+ */
+bool glo_context_is_connected_to_base(void);
+
+/**
+ * \brief glo_context_set_glonass_enabled - set the current glonass enable state
+ * \param enabled: bool indicating if glonass enable is set to true or false
+ */
+void glo_context_set_glonass_enabled(bool enabled);
+
+/**
+ * \brief glo_context_is_glonass_enabled - evaluate glonass enabled state
+ * \return true if glonass_aquisition_enabled is true, otherwise false
+ */
+bool glo_context_is_glonass_enabled(void);
+
+#endif /* __HEALTH_MONITOR_GLO_CONTEXT_H */

--- a/package/health_daemon/src/glo_obs_monitor.h
+++ b/package/health_daemon/src/glo_obs_monitor.h
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef __HEALTH_MONITOR_GNSS_OBS_H
-#define __HEALTH_MONITOR_GNSS_OBS_H
+#ifndef __HEALTH_MONITOR_GLO_OBS_H
+#define __HEALTH_MONITOR_GLO_OBS_H
 
 int glo_obs_timeout_health_monitor_init(health_ctx_t *health_ctx);
 void glo_obs_timeout_health_monitor_deinit(void);
 
-#endif /* __HEALTH_MONITOR_GNSS_OBS_H */
+#endif /* __HEALTH_MONITOR_GLO_OBS_H */


### PR DESCRIPTION
The same parameters are used for both glo obs and
bias monitoring so they have been merged into
a global context with access/modifier methods.
Effectively this makes the bias monitor slave
to the more 'active' obs monitor - relying on
its shorter timeout to keep current the base
station connection parameter and handle the
glonass enabled setting query/updates

swift-nav/firmware_team_planning#453

Dev commit of swift-nav/piksi_buildroot#479