### PR TITLE
[DEV] Fix caching of led brightness

### DIFF
--- a/package/piksi_leds/src/led_adp8866.c
+++ b/package/piksi_leds/src/led_adp8866.c
@@ -19,15 +19,19 @@
 #include <libpiksi/logging.h>
 
 #include <string.h>
+#include <errno.h>
 
 #define LED_I2C_ADDR 0x27
 #define LED_I2C_TIMEOUT 1
+#define LED_I2C_WRITE_RETRY_COUNT 3
 
 #define LED_LEVEL_SET_VALUE 0x20
 
 static int led_i2c;
 
-static u8 brightness_cache[LED_ADP8866_LED_COUNT] = {0};
+#define LED_I2C_CACHE_INITIAL_BRIGHTNESS (0u)
+static led_adp8866_led_state_t led_state_cache[LED_ADP8866_LED_COUNT];
+static bool flush_led_state_cache = false;
 
 /*
  * Duro connected different outputs of the adp8866 driver to the RGB
@@ -206,26 +210,62 @@ static bool configure(void) {
  * \return true if the operation succeeded, false otherwise.
  */
 static bool leds_set(const led_adp8866_led_state_t *led_states,
-                     u32 led_states_count) {
+                     u32 led_states_count)
+{
   bool ret = true;
 
   {
     for (u32 i = 0; i < led_states_count; i++) {
       const led_adp8866_led_state_t *led_state = &led_states[i];
 
+      led_state_cache[led_state->led].brightness = led_state->brightness;
       /* Write ISCn */
-      if (i2c_write(isc_route[led_state->led],
-                    (led_state->brightness << LED_ADP8866_ISCn_SCDn_Pos)) !=
-          0) {
-        ret = false;
-      } else {
-        /* Update cache */
-        brightness_cache[led_state->led] = led_state->brightness;
+      bool success = false;
+      u8 retries = LED_I2C_WRITE_RETRY_COUNT;
+      while (retries--) {
+        if (i2c_write(isc_route[led_state->led],
+                      (led_state->brightness << LED_ADP8866_ISCn_SCDn_Pos))
+            != 0) {
+          if (errno == ETIMEDOUT) {
+            piksi_log(LOG_WARNING, "LED I2C Write Timeout. Retries left: %d", retries);
+          } else {
+            piksi_log(LOG_ERR, "LED I2C Write Failure. ERRNO = %d", errno);
+            ret = false;
+            break;
+          }
+        } else {
+          success = true;
+          break;
+        }
+      }
+
+      if (!success) {
+        flush_led_state_cache = true;
       }
     }
   }
 
   return ret;
+}
+
+/** Initialize LED state cache
+ *
+ */
+static void led_cache_init(void)
+{
+  for (u32 i = 0; i < LED_ADP8866_LED_COUNT; i++) {
+    led_state_cache[i].led = i;
+    led_state_cache[i].brightness = LED_I2C_CACHE_INITIAL_BRIGHTNESS;
+  }
+}
+
+/** Flush LED state cache
+ *
+ * \return true if the operation succeeded, false otherwise.
+ */
+static bool led_cache_flush(void)
+{
+  return leds_set(led_state_cache, LED_ADP8866_LED_COUNT);
 }
 
 /** Get an array of modified LED states.
@@ -246,7 +286,7 @@ static u32 modified_states_get(const led_adp8866_led_state_t *input_states,
     led_adp8866_led_state_t *output_state = &output_states[output_states_count];
 
     /* Compare brightness */
-    if (input_state->brightness == brightness_cache[input_state->led]) {
+    if (input_state->brightness == led_state_cache[input_state->led].brightness) {
       continue;
     }
 
@@ -282,14 +322,8 @@ void led_adp8866_init(bool is_duro) {
     exit(3);
   }
 
-  led_adp8866_led_state_t led_states[LED_ADP8866_LED_COUNT];
-  for (u32 i = 0; i < LED_ADP8866_LED_COUNT; i++) {
-    led_adp8866_led_state_t *led_state = &led_states[i];
-    led_state->led = i;
-    led_state->brightness = 0;
-  }
-
-  if (!leds_set(led_states, LED_ADP8866_LED_COUNT)) {
+  led_cache_init();
+  if (!led_cache_flush()) {
     piksi_log(LOG_WARNING, "Failed to initialize LED states");
     exit(4);
   }
@@ -317,6 +351,11 @@ bool led_adp8866_leds_set(const led_adp8866_led_state_t *led_states,
   led_adp8866_led_state_t modified_states[LED_ADP8866_LED_COUNT];
   u32 modified_states_count =
       modified_states_get(led_states, led_states_count, modified_states);
+
+  if (flush_led_state_cache) {
+    led_cache_flush();
+    flush_led_state_cache = false;
+  }
 
   if (modified_states_count == 0) {
     return true;


### PR DESCRIPTION
Replaces cache with fully formed state structs so
the cache itself can be passed to leds_set in order
to 'flush' the values out to the driver. leds_set
has retry looping with logging on error or timeout.
Flush logic is to set flush flag if any single write
is not successful, and flush occurs before any call
to update leds when flag is set, then resets the
flag.

swift-nav/piksi_v3_bug_tracking#997

#478 