### PR TITLE
Request errors -> warnings

### DIFF
--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -529,8 +529,8 @@ static void network_request(network_context_t* ctx, CURL *curl)
       continue;
 
     if (code != CURLE_OK) {
-      sbp_log(LOG_ERR, "Network Request Error - \"%s\"", error_buf);
-      piksi_log(LOG_ERR, "curl request (error: %d) \"%s\"", code, error_buf);
+      sbp_log(LOG_WARNING, "Network Request Error - \"%s\"", error_buf);
+      piksi_log(LOG_WARNING, "curl request (error: %d) \"%s\"", code, error_buf);
     } else {
       long response = 0;
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);


### PR DESCRIPTION
Networking issues should in general be warning, not errors. Most of the other networking related problems get captured as warnings. I'm seeing errors in logs from expected behavior (server hangups) - these should be warnings. See https://github.com/swift-nav/piksi_v3_bug_tracking/issues/1023.

/cc @silverjam @benjaminaltieri 