### PR TITLE
ntpd: Use ZDA for time, and trust GPS date. [master]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf
@@ -1,6 +1,8 @@
 # Use NMEA reference clock in addition to NTP servers
 # http://support.ntp.org/bin/view/Support/ConfiguringNMEARefclocks
-server 127.127.20.0 mode 1 prefer
+# Mode bit 3 - Use ZDA sentence as time source
+# Mode bit 25 - Trust receiver's handling of week rollover
+server 127.127.20.0 mode 0x02000008 prefer
 server 0.pool.ntp.org iburst
 server 1.pool.ntp.org iburst
 server 2.pool.ntp.org iburst

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.gps
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.gps
@@ -1,6 +1,8 @@
 # Use NMEA reference clock as absolute truth
 # http://support.ntp.org/bin/view/Support/ConfiguringNMEARefclocks
-server 127.127.20.0 mode 1 true
+# Mode bit 3 - Use ZDA sentence as time source
+# Mode bit 25 - Trust receiver's handling of week rollover
+server 127.127.20.0 mode 0x02000008 true
 
 # Allow only time queries, at a limited rate, sending KoD when in excess.
 # Allow all local queries (IPv4, IPv6)

--- a/board/piksiv3/rootfs-overlay/etc/ntp.conf.gpsntp
+++ b/board/piksiv3/rootfs-overlay/etc/ntp.conf.gpsntp
@@ -1,6 +1,8 @@
 # Use NMEA reference clock in addition to NTP servers
 # http://support.ntp.org/bin/view/Support/ConfiguringNMEARefclocks
-server 127.127.20.0 mode 1 prefer
+# Mode bit 3 - Use ZDA sentence as time source
+# Mode bit 25 - Trust receiver's handling of week rollover
+server 127.127.20.0 mode 0x02000008 prefer
 server 0.pool.ntp.org iburst
 server 1.pool.ntp.org iburst
 server 2.pool.ntp.org iburst


### PR DESCRIPTION
Master version of #491

Update the mode for ntpd's NMEA refclock.
Bit 3 indicates that the ZDA message should be used for the time,
since this has complete date information.
Bit 25 is undocumented, but configured ntpd to trust the date
supplied by the receiver.  Without this ntpd assumes the
receiver doesn't handle week rollover correctly, and will select
the GPS epoch based on the system time (which is initially 1970).