### PR TITLE
Add support for actually stopping the usb gadget

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S38usb_gadget
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S38usb_gadget
@@ -50,7 +50,23 @@ start() {
 }
 
 stop() {
-  :
+  cd /sys/kernel/config/usb_gadget/g1
+  for dev in /sys/class/udc/*; do
+    echo "" > UDC
+  done
+  rm configs/c.1/acm.GS0
+  rm configs/c.1/acm.GS1
+  rm configs/c.1/rndis.usb0
+  rm configs/c.1/ecm.usb0
+  rmdir configs/c.1/strings/0x409
+  rmdir configs/c.1
+  rmdir functions/acm.GS0
+  rmdir functions/acm.GS1
+  rmdir functions/rndis.usb0
+  rmdir functions/ecm.usb0
+  rmdir strings/0x409
+  cd ..
+  rmdir g1
 }
 
 source /etc/init.d/template_command.inc.sh


### PR DESCRIPTION
Not a fix for anything, but useful if you're testing the usb gadget support.

From the documentation here:
https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt