### PR TITLE
Refactor libpiksi settings for watchers

### DIFF
--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -147,6 +147,30 @@ int settings_register_readonly(settings_ctx_t *ctx, const char *section,
                                size_t var_len, settings_type_t type);
 
 /**
+ * @brief   Create and add a watch only setting.
+ * @details Create and add a watch only setting.
+ *
+ * @param[in] ctx           Pointer to the context to use.
+ * @param[in] section       String describing the setting section.
+ * @param[in] name          String describing the setting name.
+ * @param[in] var           Address of the setting variable. This location will
+ *                          be written directly by the settings module.
+ * @param[in] var_len       Size of the setting variable.
+ * @param[in] type          Type of the setting.
+ * @param[in] notify        Notify function to be executed when the setting is
+ *                          updated by a write response
+ * @param[in] notify_context Context passed to the notify function.
+ *
+ * @return                  The operation result.
+ * @retval 0                The setting was registered successfully.
+ * @retval -1               An error occurred.
+ */
+int settings_add_watch(settings_ctx_t *ctx, const char *section,
+                       const char *name, void *var, size_t var_len,
+                       settings_type_t type, settings_notify_fn notify,
+                       void *notify_context);
+
+/**
  * @brief   Read and process incoming data.
  * @details Read and process a single incoming ZMQ message.
  *

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -64,6 +64,26 @@ typedef int (*settings_notify_fn)(void *context);
 typedef struct settings_ctx_s settings_ctx_t;
 
 /**
+ * @brief Parse a setting message to obtain the section, name and value
+ *
+ * @param[in] msg          raw sbp message
+ * @param[in] msg_n        length of sbp message
+ *
+ * @param[out] section     reference to location of section string in message
+ * @param[out] name        reference to location of name string in message
+ * @param[out] value       reference to location of value string in message
+ *
+ * @return                 The operation result.
+ * @retval 0               Parsing operation successful
+ * @retval -1              An error occurred.
+ */
+int setting_parse_setting_text(const u8 *msg,
+                               u8 msg_n,
+                               const char **section,
+                               const char **name,
+                               const char **value);
+
+/**
  * @brief   Create a settings context.
  * @details Create and initialize a settings context.
  *

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2017 Swift Navigation Inc.
- * Contact: Jacob McNamee <jacob@swiftnav.com>
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -131,7 +131,7 @@ typedef struct setting_data_s {
 /**
  * @brief Registration Helper Struct
  *
- * This helper struct is used watch for asyc callbacks during the
+ * This helper struct is used watch for async callbacks during the
  * registration/add watch read req phases of setup to allow a
  * synchronous blocking stragety. These are for ephemeral use.
  */
@@ -796,20 +796,11 @@ static int setting_read_watched_value(settings_ctx_t *ctx, setting_data_t *setti
                                             SBP_SENDER_ID);
 }
 
-/**
- * @brief setting_parse_setting_text - parse main components of settings payload
- * @param msg: raw sbp message
- * @param msg_n: length of sbp message
- * @param section: reference to location of section string in message
- * @param name: reference to location of name string in message
- * @param value: reference to location of value string in message
- * @return zero on successful parse, -1 on parsing error
- */
-static int setting_parse_setting_text(const u8 *msg,
-                                      u8 msg_n,
-                                      const char **section,
-                                      const char **name,
-                                      const char **value)
+int setting_parse_setting_text(const u8 *msg,
+                               u8 msg_n,
+                               const char **section,
+                               const char **name,
+                               const char **value)
 {
   const char **result_holders[] = { section, name, value };
   u8 start = 0;

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -10,6 +10,10 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0xAE, 0x00] } # Settings register
           - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: REJECT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: REJECT }
       - dst_port: SBP_PORT_EXTERNAL
         filters:
           - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
@@ -115,6 +119,10 @@ ports:
       - dst_port: SBP_PORT_SETTINGS_DAEMON
         filters:
           - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: REJECT }
 
   - name: SBP_PORT_SKYLARK
     pub_addr: "@tcp://127.0.0.1:43080"


### PR DESCRIPTION
The initial implementation of settings watchers for the health daemon was a bit copy-pasta.

This refactor covers lightly refactoring libpiksi/settings to allow settings nodes to be registered to a client that do not perform registration and only response to read responses as a way to 'watch' a particular setting.

Notes:
 * Most code has merely been moved into smaller functions but the parse code has been
    taken from health_daemon
 * Much of this code is functionally similar to that in the settings_daemon, the next step would be
    to condense that code as well
 * No implementation has been performed in this PR, I will refactor health_daemon and 
    others (like the simulation check in the rtcm3 bridge) as separate pull requests.
 * The commits are intentionally discrete, all will be squashed if/when merged