### PR TITLE
 Dump serial output buffer when it's full [v1.4] 

### DIFF
--- a/package/piksi_system_daemon/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/ports.c
@@ -97,10 +97,14 @@ typedef struct {
   restart_type_t restart;
 } port_config_t;
 
+// This is the default for most serial devices, we need to drop and flush
+//   data when we get to this point to avoid sending partial SBP packets.
+#define SERIAL_XMIT_SIZE "4096"
+
 static port_config_t port_configs[] = {
   {
     .name = "uart0",
-    .opts = "--file /dev/ttyPS0 --nonblock --outq 8192",
+    .opts = "--file /dev/ttyPS0 --nonblock --outq " SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -110,7 +114,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "uart1",
-    .opts = "--file /dev/ttyPS1 --nonblock --outq 8192",
+    .opts = "--file /dev/ttyPS1 --debug --nonblock --outq " SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -120,7 +124,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "usb0",
-    .opts = "--file /dev/ttyGS0 --nonblock --outq 8192",
+    .opts = "--file /dev/ttyGS0 --nonblock --outq " SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_USB,
     .mode_name_default = MODE_NAME_DEFAULT,

--- a/package/piksi_system_daemon/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/ports.c
@@ -99,12 +99,16 @@ typedef struct {
 
 // This is the default for most serial devices, we need to drop and flush
 //   data when we get to this point to avoid sending partial SBP packets.
+//   See https://elixir.bootlin.com/linux/v4.6/source/include/linux/serial.h#L29
 #define SERIAL_XMIT_SIZE "4096"
+
+// See https://elixir.bootlin.com/linux/v4.6/source/drivers/usb/gadget/function/u_serial.c#L83
+#define USB_SERIAL_XMIT_SIZE "8192"
 
 static port_config_t port_configs[] = {
   {
     .name = "uart0",
-    .opts = "--file /dev/ttyPS0 --nonblock --outq " SERIAL_XMIT_SIZE,
+    .opts = "--name uart0 --file /dev/ttyPS0 --nonblock --outq " SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -114,7 +118,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "uart1",
-    .opts = "--file /dev/ttyPS1 --debug --nonblock --outq " SERIAL_XMIT_SIZE,
+    .opts = "--name uart1 --file /dev/ttyPS1 --debug --nonblock --outq " SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
@@ -124,7 +128,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "usb0",
-    .opts = "--file /dev/ttyGS0 --nonblock --outq " SERIAL_XMIT_SIZE,
+    .opts = "--name usb0 --file /dev/ttyGS0 --nonblock --outq " USB_SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_USB,
     .mode_name_default = MODE_NAME_DEFAULT,

--- a/package/piksi_system_daemon/piksi_system_daemon/src/ports.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/ports.c
@@ -118,7 +118,7 @@ static port_config_t port_configs[] = {
   },
   {
     .name = "uart1",
-    .opts = "--name uart1 --file /dev/ttyPS1 --debug --nonblock --outq " SERIAL_XMIT_SIZE,
+    .opts = "--name uart1 --file /dev/ttyPS1 --nonblock --outq " SERIAL_XMIT_SIZE,
     .opts_get = NULL,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,

--- a/package/zmq_adapter/src/Makefile
+++ b/package/zmq_adapter/src/Makefile
@@ -12,7 +12,7 @@ SOURCES= \
 	filter.c \
 	filter_none.c \
 	protocols.c
-LIBS=-lczmq -lzmq -lsbp -ldl
+LIBS=-lczmq -lzmq -lsbp -lpiksi -ldl
 CFLAGS=-std=gnu11 -Wall
 
 CROSS=

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -576,7 +576,7 @@ static ssize_t fd_write(int fd, const void *buffer, size_t count)
     if (qlen + count > outq) {
       /* Flush the output buffer, otherwise we'll get behind and start
        * transmitting partial SBP packets, we must drop some data here, so we
-       * choose to drop old data rather than new data here.
+       * choose to drop old data rather than new data.
        */
       tcflush(fd, TCOFLUSH);
       piksi_log(LOG_ERR, MSG_ERROR_SERIAL_FLUSH);

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -591,10 +591,11 @@ static ssize_t fd_write(int fd, const void *buffer, size_t count)
         if (strstr(port_name, "usb") != port_name) {
           piksi_log(LOG_WARNING, "Cloud not completely flush tty: %d bytes remaining.", qlen);
         } else {
-          // USB gadget serial can't flush properly for some reason, ignore...
-          //   (This is ignored ad infinitum because this condition occurs on
-          //   start-up before the interface is read from, after the interface
-          //   is read from, it never occurs again.)
+          /* USB gadget serial can't flush properly for some reason, ignore...
+           *   (This is ignored ad infinitum because this condition occurs on
+           *   start-up before the interface is read from, after the interface
+           *   is read from, it never occurs again.)
+           */
           return count;
         }
       }

--- a/package/zmq_adapter/src/zmq_adapter.c
+++ b/package/zmq_adapter/src/zmq_adapter.c
@@ -587,7 +587,7 @@ static ssize_t fd_write(int fd, const void *buffer, size_t count)
        */
       tcflush(fd, TCOFLUSH);
       ioctl(fd, TIOCOUTQ, &qlen);
-      if (qlen != 0 ) {
+      if (qlen != 0) {
         if (strstr(port_name, "usb") != port_name) {
           piksi_log(LOG_WARNING, "Cloud not completely flush tty: %d bytes remaining.", qlen);
         } else {

--- a/package/zmq_adapter/src/zmq_adapter_file.c
+++ b/package/zmq_adapter/src/zmq_adapter_file.c
@@ -64,6 +64,7 @@ int file_loop(const char *file_path, int need_read, int need_write)
 
   io_loop_start(fd_read, fd_write);
   io_loop_wait();
+  io_loop_terminate();
 
   if (need_read) {
     close(fd_read);

--- a/package/zmq_adapter/zmq_adapter.mk
+++ b/package/zmq_adapter/zmq_adapter.mk
@@ -8,7 +8,7 @@ ZMQ_ADAPTER_VERSION = 0.1
 ZMQ_ADAPTER_SITE = \
   "${BR2_EXTERNAL_piksi_buildroot_PATH}/package/zmq_adapter/src"
 ZMQ_ADAPTER_SITE_METHOD = local
-ZMQ_ADAPTER_DEPENDENCIES = czmq libsbp
+ZMQ_ADAPTER_DEPENDENCIES = czmq libsbp libpiksi
 
 define ZMQ_ADAPTER_BUILD_CMDS
     $(MAKE) CC=$(TARGET_CC) LD=$(TARGET_LD) -C $(@D) all


### PR DESCRIPTION
Fix for swift-nav/piksi_v3_bug_tracking#1069
Release 1.4.x version of #514 

---

At 57600 baud with a 20Hz solution frequency, Piksi produces a stream of
data that's about 5-7 KiB/s -- near the limit that the output queue can be
emptied at 57600 baud.

This causing settings reads (which are lots of small packets) to be lost
or arrive in between lots of solution messages.  The best thing we can
do here (short of implementing priority queuing and smart rate limiting)
is to issue a warning that we're getting behind, and dump the old data
that's stuck in the queue.

Note that [this change from the 1.2.x release][1] to bump the "output queue"
limit to 8192 effectively disabled the feature because the queue would never
grow beyond 4096 for a serial device (whose internal buffer is also 4096).

[1]: https://github.com/swift-nav/piksi_buildroot/commit/89efd8b5aaf1687ed7fe0a053397affbed62bfa2 

However dropping random bits of data when the queue got full would cause
continuous CRC errors since we apparently don't submit whole SBP packets
to the underlying FD in zmq_adapter.