### PR TITLE
[DEV] Refactor libpiksi settings for watchers

### DIFF
--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2017 Swift Navigation Inc.
- * Contact: Jacob McNamee <jacob@swiftnav.com>
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
@@ -62,6 +62,26 @@ typedef int (*settings_notify_fn)(void *context);
  * @brief   Opaque context for settings.
  */
 typedef struct settings_ctx_s settings_ctx_t;
+
+/**
+ * @brief Parse a setting message to obtain the section, name and value
+ *
+ * @param[in] msg          raw sbp message
+ * @param[in] msg_n        length of sbp message
+ *
+ * @param[out] section     reference to location of section string in message
+ * @param[out] name        reference to location of name string in message
+ * @param[out] value       reference to location of value string in message
+ *
+ * @return                 The operation result.
+ * @retval 0               Parsing operation successful
+ * @retval -1              An error occurred.
+ */
+int setting_parse_setting_text(const u8 *msg,
+                               u8 msg_n,
+                               const char **section,
+                               const char **name,
+                               const char **value);
 
 /**
  * @brief   Create a settings context.
@@ -145,6 +165,30 @@ int settings_register(settings_ctx_t *ctx, const char *section,
 int settings_register_readonly(settings_ctx_t *ctx, const char *section,
                                const char *name, const void *var,
                                size_t var_len, settings_type_t type);
+
+/**
+ * @brief   Create and add a watch only setting.
+ * @details Create and add a watch only setting.
+ *
+ * @param[in] ctx           Pointer to the context to use.
+ * @param[in] section       String describing the setting section.
+ * @param[in] name          String describing the setting name.
+ * @param[in] var           Address of the setting variable. This location will
+ *                          be written directly by the settings module.
+ * @param[in] var_len       Size of the setting variable.
+ * @param[in] type          Type of the setting.
+ * @param[in] notify        Notify function to be executed when the setting is
+ *                          updated by a write response
+ * @param[in] notify_context Context passed to the notify function.
+ *
+ * @return                  The operation result.
+ * @retval 0                The setting was registered successfully.
+ * @retval -1               An error occurred.
+ */
+int settings_add_watch(settings_ctx_t *ctx, const char *section,
+                       const char *name, void *var, size_t var_len,
+                       settings_type_t type, settings_notify_fn notify,
+                       void *notify_context);
 
 /**
  * @brief   Read and process incoming data.

--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -1,13 +1,69 @@
 /*
- * Copyright (C) 2017 Swift Navigation Inc.
- * Contact: Jacob McNamee <jacob@swiftnav.com>
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**
+ * @file settings.c
+ * @brief Implementation of Settings Client APIs
+ *
+ * The piksi settings daemon acts as the manager for onboard settings
+ * registration and read responses for read requests while individual
+ * processes are responsible for the ownership of settings values and
+ * must respond to write requests with the value of the setting as a
+ * response to the question of whether or not a write request was
+ * valid and accepted by that process.
+ *
+ * This module provides a context and APIs for client interactions
+ * with the settings manager. Where previously these APIs were intended
+ * only for settings owning processes to register settings and respond
+ * to write requests, the intention will be to allow a fully formed
+ * settings client to be built upon these APIs to include read requests
+ * and other client side queries.
+ *
+ * The high level approach to the client is to hold a list of unique
+ * settings that can be configured as owned or non-owned (watch-only)
+ * by the process running the client. Each setting which is added to
+ * the list will be kept in sync with the settings daemon and/or the
+ * owning process via asynchronous messages recieved in the zmq routed
+ * endpoint for the client.
+ *
+ * Standard usage is as follow, initialize the settings context:
+ * \code{.c}
+ * // Create the settings context
+ * settings_ctx_t *settings_ctx = settings_create();
+ * \endcode
+ * Add a reader to the main zmq context zloop (if applicable)
+ * \code{.c}
+ * // Depending on you implementation this will vary
+ * settings_reader_add(settings_ctx, zmq_pubsub_ctx_zloop);
+ * \endcode
+ * For settings owners, a setting is registered as follows:
+ * \code{.c}
+ * settings_register(settings_ctx, "sample_process", "sample_setting",
+                     &sample_setting_data, sizeof(sample_setting_data),
+                     SETTINGS_TYPE_BOOL,
+                     optional_notify_callback, optional_callback_data);
+ * \endcode
+ * For a process that is tracking a non-owned setting, the process is similar:
+ * \code{.c}
+ * settings_add_watch(settings_ctx, "sample_process", "sample_setting",
+                      &sample_setting_data, sizeof(sample_setting_data),
+                      SETTINGS_TYPE_BOOL,
+                      optional_notify_callback, optional_callback_data);
+ * \endcode
+ * The main difference here is that an owned setting will response to write
+ * requests only, while a watch-only setting is updated on write responses
+ * to stay in sync with successful updates as reported by settings owners.
+ * @version v1.4
+ * @date 2018-02-23
  */
 
 #include <libpiksi/settings.h>
@@ -21,8 +77,11 @@
 #define PUB_ENDPOINT ">tcp://127.0.0.1:43071"
 #define SUB_ENDPOINT ">tcp://127.0.0.1:43070"
 
-#define REGISTER_TIMEOUT_ms 100
+#define REGISTER_TIMEOUT_MS 100
 #define REGISTER_TRIES 5
+
+#define WATCH_INIT_TIMEOUT_MS 100
+#define WATCH_INIT_TRIES 5
 
 #define SBP_PAYLOAD_SIZE_MAX 255
 
@@ -32,6 +91,13 @@ typedef bool (*from_string_fn)(const void *priv, void *blob, int blen,
                                const char *str);
 typedef int (*format_type_fn)(const void *priv, char *str, int slen);
 
+/**
+ * @brief Type Data
+ *
+ * This structure encapsulates the codec for values of a given type
+ * which the settings context uses to build a list of known types
+ * that it can support when settings are added to the settings list.
+ */
 typedef struct type_data_s {
   to_string_fn to_string;
   from_string_fn from_string;
@@ -40,6 +106,14 @@ typedef struct type_data_s {
   struct type_data_s *next;
 } type_data_t;
 
+/**
+ * @brief Setting Data
+ *
+ * This structure holds the information use to serialize settings
+ * information into sbp messages, as well as internal flags used
+ * to evaluate sbp settings callback behavior managed within the
+ * settings context.
+ */
 typedef struct setting_data_s {
   char *section;
   char *name;
@@ -50,9 +124,17 @@ typedef struct setting_data_s {
   settings_notify_fn notify;
   void *notify_context;
   bool readonly;
+  bool watchonly;
   struct setting_data_s *next;
 } setting_data_t;
 
+/**
+ * @brief Registration Helper Struct
+ *
+ * This helper struct is used watch for async callbacks during the
+ * registration/add watch read req phases of setup to allow a
+ * synchronous blocking stragety. These are for ephemeral use.
+ */
 typedef struct {
   bool pending;
   bool match;
@@ -60,11 +142,23 @@ typedef struct {
   u8 compare_data_len;
 } registration_state_t;
 
+/**
+ * @brief Settings Context
+ *
+ * This is the main context for managing client interactions with
+ * the settings manager. It implements the client messaging context
+ * as well as the list of types and settings necessary to perform
+ * the registration, watching and callback functionality of the client.
+ */
 struct settings_ctx_s {
   sbp_zmq_pubsub_ctx_t *pubsub_ctx;
   type_data_t *type_data_list;
   setting_data_t *setting_data_list;
   registration_state_t registration_state;
+  bool write_callback_registered;
+  bool write_resp_callback_registered;
+  bool read_resp_callback_registered;
+  sbp_msg_callbacks_node_t *read_resp_cb_node;
 };
 
 enum {
@@ -74,6 +168,10 @@ enum {
 };
 
 static const char * const bool_enum_names[] = {"False", "True", NULL};
+
+/* Forward Declarations */
+static int settings_register_read_resp_callback(settings_ctx_t *ctx);
+static int settings_deregister_read_resp_callback(settings_ctx_t *ctx);
 
 static int float_to_string(const void *priv, char *str, int slen,
                            const void *blob, int blen)
@@ -229,6 +327,13 @@ static int enum_format_type(const void *priv, char *str, int slen)
   return n;
 }
 
+/**
+ * @brief message_header_get - to allow formatting of identity only
+ * @param setting_data: the setting to format
+ * @param buf: buffer to hold formatted header string
+ * @param blen: length of the destination buffer
+ * @return bytes written to the buffer, -1 in case of failure
+ */
 static int message_header_get(setting_data_t *setting_data, char *buf, int blen)
 {
   int n = 0;
@@ -251,6 +356,13 @@ static int message_header_get(setting_data_t *setting_data, char *buf, int blen)
   return n;
 }
 
+/**
+ * @brief message_data_get - formatting of value and type
+ * @param setting_data: the setting to format
+ * @param buf: buffer to hold formatted data string
+ * @param blen: length of the destination buffer
+ * @return bytes written to the buffer, -1 in case of failure
+ */
 static int message_data_get(setting_data_t *setting_data, char *buf, int blen)
 {
   int n = 0;
@@ -278,6 +390,12 @@ static int message_data_get(setting_data_t *setting_data, char *buf, int blen)
   return n;
 }
 
+/**
+ * @brief type_data_lookup - retrieves type node from settings context
+ * @param ctx: settings context
+ * @param type: type struct to be matched
+ * @return the setting type entry if a match is found, otherwise NULL
+ */
 static type_data_t * type_data_lookup(settings_ctx_t *ctx, settings_type_t type)
 {
   type_data_t *type_data = ctx->type_data_list;
@@ -287,6 +405,13 @@ static type_data_t * type_data_lookup(settings_ctx_t *ctx, settings_type_t type)
   return type_data;
 }
 
+/**
+ * @brief setting_data_lookup - retrieves setting node from settings context
+ * @param ctx: settings context
+ * @param section: setting section string to match
+ * @param name: setting name string to match
+ * @return the setting type entry if a match is found, otherwise NULL
+ */
 static setting_data_t * setting_data_lookup(settings_ctx_t *ctx,
                                             const char *section,
                                             const char *name)
@@ -321,6 +446,12 @@ static void setting_data_list_insert(settings_ctx_t *ctx,
   }
 }
 
+/**
+ * @brief compare_init - set up compare structure for synchronous req/reply
+ * @param ctx: settings context
+ * @param data: formatted settings header string to match with incoming messages
+ * @param data_len: length of match string
+ */
 static void compare_init(settings_ctx_t *ctx, const u8 *data, u8 data_len)
 {
   registration_state_t *r = &ctx->registration_state;
@@ -333,6 +464,12 @@ static void compare_init(settings_ctx_t *ctx, const u8 *data, u8 data_len)
   r->pending = true;
 }
 
+/**
+ * @brief compare_check - used by message callbacks to perform comparison
+ * @param ctx: settings context
+ * @param data: settings message payload string to match with header string
+ * @param data_len: length of payload string
+ */
 static void compare_check(settings_ctx_t *ctx, const u8 *data, u8 data_len)
 {
   registration_state_t *r = &ctx->registration_state;
@@ -349,18 +486,40 @@ static void compare_check(settings_ctx_t *ctx, const u8 *data, u8 data_len)
   }
 }
 
+/**
+ * @brief compare_deinit - clean up compare structure after transaction
+ * @param ctx: settings context
+ */
 static void compare_deinit(settings_ctx_t *ctx)
 {
   registration_state_t *r = &ctx->registration_state;
   r->pending = false;
 }
 
+/**
+ * @brief compare_match - returns status of current comparison
+ * This is used as the value to block on until the comparison has been matched
+ * successfully or until (based on implementation) a number of retries or a
+ * timeout has expired.
+ * @param ctx: settings context
+ * @return true if response was matched, false if not response has been received
+ */
 static bool compare_match(settings_ctx_t *ctx)
 {
   registration_state_t *r = &ctx->registration_state;
   return r->match;
 }
 
+/**
+ * @brief type_register - register type data for reference when adding settings
+ * @param ctx: settings context
+ * @param to_string: serialization method
+ * @param from_string: deserialization method
+ * @param format_type: ?
+ * @param priv: private data used in ser/des methods
+ * @param type: type enum that is used to identify this type
+ * @return
+ */
 static int type_register(settings_ctx_t *ctx, to_string_fn to_string,
                          from_string_fn from_string, format_type_fn format_type,
                          const void *priv, settings_type_t *type)
@@ -392,6 +551,10 @@ static int type_register(settings_ctx_t *ctx, to_string_fn to_string,
   return 0;
 }
 
+/**
+ * @brief setting_data_members_destroy - deinit for settings data
+ * @param setting_data: setting to deinit
+ */
 static void setting_data_members_destroy(setting_data_t *setting_data)
 {
   if (setting_data->section) {
@@ -410,16 +573,52 @@ static void setting_data_members_destroy(setting_data_t *setting_data)
   }
 }
 
-static int setting_register(settings_ctx_t *ctx, const char *section,
-                            const char *name, void *var, size_t var_len,
-                            settings_type_t type, settings_notify_fn notify,
-                            void *notify_context, bool readonly)
+/**
+ * @brief setting_data_list_remove - remove a setting from the settings context
+ * @param ctx: settings context
+ * @param setting_data: setting to remove
+ */
+static void setting_data_list_remove(settings_ctx_t *ctx,
+                                     setting_data_t **setting_data)
+{
+  if (ctx->setting_data_list != NULL) {
+    setting_data_t *s;
+    /* Find element before the one to remove */
+    for (s = ctx->setting_data_list; s->next != NULL; s = s->next) {
+      if (s->next == *setting_data) {
+        setting_data_members_destroy(s->next);
+        free(s->next);
+        *setting_data = NULL;
+        s->next = s->next->next;
+      }
+    }
+  }
+}
+
+/**
+ * @brief setting_create_setting - factory for new settings
+ * @param ctx: settings context
+ * @param section: section identifier
+ * @param name: setting name
+ * @param var: non-owning reference to location the data is stored
+ * @param var_len: length of data storage
+ * @param type: type identifier
+ * @param notify: optional notification callback
+ * @param notify_context: optional data reference to pass during notification
+ * @param readonly: set to true to disable value updates
+ * @param watchonly: set to true to indicate a non-owned setting watch
+ * @return the newly created setting, NULL if failed
+ */
+static setting_data_t * setting_create_setting(settings_ctx_t *ctx, const char *section,
+                                               const char *name, void *var, size_t var_len,
+                                               settings_type_t type, settings_notify_fn notify,
+                                               void *notify_context, bool readonly, bool watchonly)
 {
   /* Look up type data */
   type_data_t *type_data = type_data_lookup(ctx, type);
   if (type_data == NULL) {
     piksi_log(LOG_ERR, "invalid type");
-    return -1;
+    return NULL;
   }
 
   /* Set up setting data */
@@ -427,7 +626,7 @@ static int setting_register(settings_ctx_t *ctx, const char *section,
                                      malloc(sizeof(*setting_data));
   if (setting_data == NULL) {
     piksi_log(LOG_ERR, "error allocating setting data");
-    return -1;
+    return NULL;
   }
 
   *setting_data = (setting_data_t) {
@@ -440,6 +639,7 @@ static int setting_register(settings_ctx_t *ctx, const char *section,
     .notify = notify,
     .notify_context = notify_context,
     .readonly = readonly,
+    .watchonly = watchonly,
     .next = NULL
   };
 
@@ -450,12 +650,99 @@ static int setting_register(settings_ctx_t *ctx, const char *section,
     setting_data_members_destroy(setting_data);
     free(setting_data);
     setting_data = NULL;
+  }
+
+  return setting_data;
+}
+
+/**
+ * @brief setting_perform_request_reply_from
+ * Performs a synchronous req/reply transation for the provided
+ * message using the compare structure to match the header in callbacks.
+ * Uses an explicit sender_id to allow for settings interactions with manager.
+ * @param ctx: settings context
+ * @param message_type: sbp message to use when sending the message
+ * @param message: sbp message payload
+ * @param message_length: length of payload
+ * @param header_length: length of the substring to match during compare
+ * @param timeout_ms: timeout between retries
+ * @param retries: number of times to retry the transaction
+ * @param sender_id: sender_id to use for outgoing message
+ * @return zero on success, -1 the transaction failed to complete
+ */
+static int setting_perform_request_reply_from(settings_ctx_t *ctx,
+                                              u16 message_type,
+                                              u8 *message,
+                                              u8 message_length,
+                                              u8 header_length,
+                                              u32 timeout_ms,
+                                              u8 retries,
+                                              u16 sender_id)
+{
+  /* Register with daemon */
+  compare_init(ctx, message, header_length);
+
+  u8 tries = 0;
+  bool success = false;
+  do {
+    sbp_zmq_tx_send_from(sbp_zmq_pubsub_tx_ctx_get(ctx->pubsub_ctx),
+                         message_type,
+                         message_length,
+                         message,
+                         sender_id);
+    zmq_simple_loop_timeout(sbp_zmq_pubsub_zloop_get(ctx->pubsub_ctx),
+                            timeout_ms);
+    success = compare_match(ctx);
+  } while (!success && (++tries < retries));
+
+  compare_deinit(ctx);
+
+  if (!success) {
+    piksi_log(LOG_ERR, "setting req/reply failed");
     return -1;
   }
 
-  /* Add to list */
-  setting_data_list_insert(ctx, setting_data);
+  return 0;
+}
 
+/**
+ * @brief setting_perform_request_reply - same as above but with implicit sender_id
+ * @param ctx: settings context
+ * @param message_type: sbp message to use when sending the message
+ * @param message: sbp message payload
+ * @param message_length: length of payload
+ * @param header_length: length of the substring to match during compare
+ * @param timeout_ms: timeout between retries
+ * @param retries: number of times to retry the transaction
+ * @return zero on success, -1 the transaction failed to complete
+ */
+static int setting_perform_request_reply(settings_ctx_t *ctx,
+                                         u16 message_type,
+                                         u8 *message,
+                                         u8 message_length,
+                                         u8 header_length,
+                                         u16 timeout_ms,
+                                         u8 retries)
+{
+  u16 sender_id = sbp_sender_id_get();
+  return setting_perform_request_reply_from(ctx,
+                                            message_type,
+                                            message,
+                                            message_length,
+                                            header_length,
+                                            timeout_ms,
+                                            retries,
+                                            sender_id);
+}
+
+/**
+ * @brief setting_register - perform SBP_MSG_SETTINGS_REGISTER req/reply
+ * @param ctx: settings context
+ * @param setting_data: setting to register with settings daemon
+ * @return zero on success, -1 the transaction failed to complete
+ */
+static int setting_register(settings_ctx_t *ctx, setting_data_t *setting_data)
+{
   /* Build message */
   u8 msg[SBP_PAYLOAD_SIZE_MAX];
   u8 msg_len = 0;
@@ -477,30 +764,192 @@ static int setting_register(settings_ctx_t *ctx, const char *section,
   }
   msg_len += l;
 
-  /* Register with daemon */
-  compare_init(ctx, msg, msg_header_len);
+  return setting_perform_request_reply(ctx,
+                                       SBP_MSG_SETTINGS_REGISTER,
+                                       msg,
+                                       msg_len,
+                                       msg_header_len,
+                                       REGISTER_TIMEOUT_MS,
+                                       REGISTER_TRIES);
+}
 
-  u8 tries = 0;
-  bool success = false;
-  do {
-    sbp_zmq_tx_send(sbp_zmq_pubsub_tx_ctx_get(ctx->pubsub_ctx),
-                    SBP_MSG_SETTINGS_REGISTER, msg_len, msg);
-    zmq_simple_loop_timeout(sbp_zmq_pubsub_zloop_get(ctx->pubsub_ctx),
-                            REGISTER_TIMEOUT_ms);
-    success = compare_match(ctx);
+/**
+ * @brief setting_read_watched_value - perform SBP_MSG_SETTINGS_READ_REQ req/reply
+ * @param ctx: setting context
+ * @param setting_data: setting to read from settings daemon
+ * @return zero on success, -1 the transaction failed to complete
+ */
+static int setting_read_watched_value(settings_ctx_t *ctx, setting_data_t *setting_data)
+{
+  int result = 0;
+  /* Build message */
+  u8 msg[SBP_PAYLOAD_SIZE_MAX];
+  u8 msg_len = 0;
+  int l;
 
-  } while (!success && (++tries < REGISTER_TRIES));
-
-  compare_deinit(ctx);
-
-  if (!success) {
-    piksi_log(LOG_ERR, "setting registration failed");
+  if (!setting_data->watchonly) {
+    piksi_log(LOG_ERR, "cannot update non-watchonly setting manually");
     return -1;
   }
 
+  l = message_header_get(setting_data, &msg[msg_len], sizeof(msg) - msg_len);
+  if (l < 0) {
+    piksi_log(LOG_ERR, "error building settings read req message");
+    return -1;
+  }
+  msg_len += l;
+
+  if (settings_register_read_resp_callback(ctx) != 0) {
+    piksi_log(LOG_ERR, "error registering settings read callback");
+    return -1;
+  }
+
+  result =  setting_perform_request_reply_from(ctx,
+                                               SBP_MSG_SETTINGS_READ_REQ,
+                                               msg,
+                                               msg_len,
+                                               msg_len,
+                                               WATCH_INIT_TIMEOUT_MS,
+                                               WATCH_INIT_TRIES,
+                                               SBP_SENDER_ID);
+
+  settings_deregister_read_resp_callback(ctx);
+  return result;
+}
+
+int setting_parse_setting_text(const u8 *msg,
+                               u8 msg_n,
+                               const char **section,
+                               const char **name,
+                               const char **value)
+{
+  const char **result_holders[] = { section, name, value };
+  u8 start = 0;
+  u8 end = 0;
+  for (u8 i = 0; i < sizeof(result_holders) / sizeof(*result_holders); i++) {
+    bool found = false;
+    *(result_holders[i]) = NULL;
+    while (end < msg_n) {
+      if (msg[end] == '\0') {
+        if (end == start) {
+          return -1;
+        } else {
+          *(result_holders[i]) = (const char *)msg + start;
+          start = (u8)(end + 1);
+          found = true;
+        }
+      }
+      end++;
+      if (found) {
+        break;
+      }
+    }
+  }
   return 0;
 }
 
+/**
+ * @brief setting_format_setting - formats a fully formed setting message payload
+ * @param setting_data: the setting to format
+ * @param buf: buffer to hold formatted setting string
+ * @param len: length of the destination buffer
+ * @return bytes written to the buffer, -1 in case of failure
+ */
+static int setting_format_setting(setting_data_t *setting_data, char *buf, int len)
+{
+  int result = 0;
+  int written = 0;
+
+  result = message_header_get(setting_data, buf, len - written);
+  if (result < 0) {
+    return result;
+  }
+  written += result;
+
+  result = message_data_get(setting_data, buf + written, len - written);
+  if (result < 0) {
+    return result;
+  }
+  written += result;
+
+  return written;
+}
+
+/**
+ * @brief setting_update_value - process value string and update internal data on success
+ * @param setting_data: setting to update
+ * @param value: value string to evaluate
+ * @param write_result: result to pass to write response
+ */
+static void setting_update_value(setting_data_t *setting_data, const char *value, u8 *write_result)
+{
+  if (setting_data->readonly) {
+    *write_result = SBP_WRITE_STATUS_VALUE_REJECTED;
+  } else {
+    *write_result = SBP_WRITE_STATUS_OK;
+    /* Store copy and update value */
+    memcpy(setting_data->var_copy, setting_data->var, setting_data->var_len);
+    if (!setting_data->type_data->from_string(setting_data->type_data->priv,
+          setting_data->var,
+          setting_data->var_len,
+          value)) {
+      /* Revert value if conversion fails */
+      memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
+      *write_result = SBP_WRITE_STATUS_VALUE_REJECTED;
+    } else if (setting_data->notify != NULL) {
+      /* Call notify function */
+      if (setting_data->notify(setting_data->notify_context) != 0) {
+        if (!setting_data->watchonly) {
+          /* Revert value if notify returns error */
+          memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
+          *write_result = SBP_WRITE_STATUS_VALUE_REJECTED;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief setting_send_write_response
+ * @param ctx: settings context
+ * @param write_response: pre-formatted read response sbp message
+ * @param len: length of the message
+ * @return zero on success, -1 if message failed to send
+ */
+static int setting_send_write_response(settings_ctx_t *ctx,
+                                       msg_settings_write_resp_t *write_response,
+                                       u8 len)
+{
+  if (sbp_zmq_tx_send(sbp_zmq_pubsub_tx_ctx_get(ctx->pubsub_ctx),
+        SBP_MSG_SETTINGS_WRITE_RESP, len, (u8 *)write_response) != 0) {
+    piksi_log(LOG_ERR, "error sending settings write response");
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * @brief setting_send_read_response
+ * @param ctx: settings context
+ * @param read_response: pre-formatted read response sbp message
+ * @param len: length of the message
+ * @return zero on success, -1 if message failed to send
+ */
+static int setting_send_read_response(settings_ctx_t *ctx,
+                                      msg_settings_read_resp_t *read_response,
+                                      u8 len)
+{
+  if (sbp_zmq_tx_send(sbp_zmq_pubsub_tx_ctx_get(ctx->pubsub_ctx),
+        SBP_MSG_SETTINGS_READ_RESP, len, (u8 *)read_response) != 0) {
+    piksi_log(LOG_ERR, "error sending settings read response");
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * @brief settings_write_callback - callback for SBP_MSG_SETTINGS_WRITE
+ */
 static void settings_write_callback(u16 sender_id, u8 len, u8 msg[],
                                     void* context)
 {
@@ -514,41 +963,13 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[],
   /* Check for a response to a pending registration request */
   compare_check(ctx, msg, len);
 
-  if ((len == 0) ||
-      (msg[len-1] != '\0')) {
-    piksi_log(LOG_WARNING, "error in settings write message");
-    return;
-  }
-
   /* Extract parameters from message:
    * 3 null terminated strings: section, setting and value
    */
   const char *section = NULL;
   const char *name = NULL;
   const char *value = NULL;
-  section = (const char *)msg;
-  for (int i = 0, tok = 0; i < len; i++) {
-    if (msg[i] == '\0') {
-      tok++;
-      switch (tok) {
-      case 1:
-        name = (const char *)&msg[i+1];
-        break;
-      case 2:
-        if (i + 1 < len)
-          value = (const char *)&msg[i+1];
-        break;
-      case 3:
-        if (i == len-1)
-          break;
-      default:
-        piksi_log(LOG_WARNING, "error in settings write message");
-        return;
-      }
-    }
-  }
-
-  if (value == NULL) {
+  if (setting_parse_setting_text(msg, len, &section, &name, &value) != 0) {
     piksi_log(LOG_WARNING, "error in settings write message");
     return;
   }
@@ -559,55 +980,183 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[],
     return;
   }
 
-  u8 status = SBP_WRITE_STATUS_OK;
-  if (!setting_data->readonly) {
-    /* Store copy and update value */
-    memcpy(setting_data->var_copy, setting_data->var, setting_data->var_len);
-    if (!setting_data->type_data->from_string(setting_data->type_data->priv,
-                                             setting_data->var,
-                                             setting_data->var_len,
-                                             value)) {
-      /* Revert value if conversion fails */
-      memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
-      status = SBP_WRITE_STATUS_VALUE_REJECTED;
-    } else if (setting_data->notify != NULL) {
-      /* Call notify function */
-      if (setting_data->notify(setting_data->notify_context) != 0) {
-        /* Revert value if notify returns error */
-        memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
-        status = SBP_WRITE_STATUS_VALUE_REJECTED;
-      }
-    }
-  } else {
-    status = SBP_WRITE_STATUS_VALUE_REJECTED;
+  if (setting_data->watchonly) {
+    return;
   }
 
-  /* Build message */
-  u8 resp[SBP_PAYLOAD_SIZE_MAX] = {status};
-  u8 resp_len = 1;
-  int l;
+  u8 write_result = SBP_WRITE_STATUS_OK;
+  setting_update_value(setting_data, value, &write_result);
 
-  l = message_header_get(setting_data, &resp[resp_len], sizeof(resp) - resp_len);
+  u8 resp[SBP_PAYLOAD_SIZE_MAX];
+  u8 resp_len = 0;
+  msg_settings_write_resp_t *write_response = (msg_settings_write_resp_t *)resp;
+  write_response->status = write_result;
+  resp_len += sizeof(write_response->status);
+  int l = setting_format_setting(setting_data,
+                                 write_response->setting,
+                                 SBP_PAYLOAD_SIZE_MAX - resp_len);
   if (l < 0) {
-    piksi_log(LOG_ERR, "error building settings message");
     return;
   }
   resp_len += l;
 
-  l = message_data_get(setting_data, &resp[resp_len], sizeof(resp) - resp_len);
-  if (l < 0) {
-    piksi_log(LOG_ERR, "error building settings message");
-    return;
-  }
-  resp_len += l;
+  setting_send_write_response(ctx, write_response, resp_len);
+}
 
-  if (sbp_zmq_tx_send(sbp_zmq_pubsub_tx_ctx_get(ctx->pubsub_ctx),
-                      SBP_MSG_SETTINGS_WRITE_RESP, resp_len, resp) != 0) {
-    piksi_log(LOG_ERR, "error sending settings read response");
-    return;
+static int settings_update_watch_only(settings_ctx_t *ctx,
+                                       u8 *msg,
+                                       u8 len)
+{
+  /* Extract parameters from message:
+   * 3 null terminated strings: section, setting and value
+   */
+  const char *section = NULL;
+  const char *name = NULL;
+  const char *value = NULL;
+  if (setting_parse_setting_text(msg, len, &section, &name, &value) != 0) {
+    piksi_log(LOG_WARNING, "error parsing setting");
+    return -1;
+  }
+
+  /* Look up setting data */
+  setting_data_t *setting_data = setting_data_lookup(ctx, section, name);
+  if (setting_data == NULL) {
+    return 0;
+  }
+
+  if (!setting_data->watchonly) {
+    return 0;
+  }
+
+  u8 write_result = SBP_WRITE_STATUS_OK;
+  setting_update_value(setting_data, value, &write_result);
+  if (write_result != SBP_WRITE_STATUS_OK) {
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * @brief settings_read_resp_callback - callback for SBP_MSG_SETTINGS_READ_RESP
+ */
+static void settings_read_resp_callback(u16 sender_id, u8 len, u8 msg[],
+                                         void* context)
+{
+  settings_ctx_t *ctx = (settings_ctx_t *)context;
+  msg_settings_read_resp_t *read_response = (msg_settings_read_resp_t *)msg;
+
+  /* Check for a response to a pending request */
+  compare_check(ctx, read_response->setting, len);
+
+  if (settings_update_watch_only(ctx,
+                                 read_response->setting,
+                                 len) != 0) {
+    piksi_log(LOG_WARNING, "error in settings read response message");
   }
 }
 
+/**
+ * @brief settings_write_resp_callback - callback for SBP_MSG_SETTINGS_WRITE_RESP
+ */
+static void settings_write_resp_callback(u16 sender_id, u8 len, u8 msg[],
+                                         void* context)
+{
+  settings_ctx_t *ctx = (settings_ctx_t *)context;
+  msg_settings_write_resp_t *write_response = (msg_settings_write_resp_t *)msg;
+
+  /* Check for a response to a pending request */
+  compare_check(ctx, write_response->setting, len - sizeof(write_response->status));
+
+  if (settings_update_watch_only(ctx,
+                                 write_response->setting,
+                                 len - sizeof(write_response->status)) != 0) {
+    piksi_log(LOG_WARNING, "error in settings read response message");
+  }
+}
+
+/**
+ * @brief settings_register_write_callback - register callback for SBP_MSG_SETTINGS_WRITE
+ * @param ctx: settings context
+ * @return zero on success, -1 if registration failed
+ */
+static int settings_register_write_callback(settings_ctx_t *ctx)
+{
+  if (!ctx->write_callback_registered) {
+    if (sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(ctx->pubsub_ctx),
+                                     SBP_MSG_SETTINGS_WRITE,
+                                     settings_write_callback, ctx, NULL) != 0) {
+      piksi_log(LOG_ERR, "error registering settings write callback");
+      return -1;
+    } else {
+      ctx->write_callback_registered = true;
+    }
+  }
+  return 0;
+}
+
+/**
+ * @brief settings_register_read_resp_callback - register callback for SBP_MSG_SETTINGS_READ_RESP
+ * @param ctx: settings context
+ * @return zero on success, -1 if registration failed
+ */
+static int settings_register_read_resp_callback(settings_ctx_t *ctx)
+{
+  if (!ctx->read_resp_callback_registered) {
+    if (sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(ctx->pubsub_ctx),
+                                     SBP_MSG_SETTINGS_READ_RESP,
+                                     settings_read_resp_callback, ctx, &ctx->read_resp_cb_node) != 0) {
+      piksi_log(LOG_ERR, "error registering settings read resp callback");
+      return -1;
+    } else {
+      ctx->read_resp_callback_registered = true;
+    }
+  }
+  return 0;
+}
+
+/**
+ * @brief settings_deregister_read_resp_callback - deregister callback for SBP_MSG_SETTINGS_READ_RESP
+ * @param ctx: settings context
+ * @return zero on success, -1 if deregistration failed
+ */
+static int settings_deregister_read_resp_callback(settings_ctx_t *ctx)
+{
+  if (ctx->read_resp_callback_registered) {
+    if (sbp_zmq_rx_callback_remove(sbp_zmq_pubsub_rx_ctx_get(ctx->pubsub_ctx),
+                                   &ctx->read_resp_cb_node) != 0) {
+      piksi_log(LOG_ERR, "error deregistering settings read resp callback");
+      return -1;
+    } else {
+      ctx->read_resp_callback_registered = false;
+    }
+  }
+  return 0;
+}
+
+/**
+ * @brief settings_register_write_resp_callback - register callback for SBP_MSG_SETTINGS_READ_RESP
+ * @param ctx: settings context
+ * @return zero on success, -1 if registration failed
+ */
+static int settings_register_write_resp_callback(settings_ctx_t *ctx)
+{
+  if (!ctx->write_resp_callback_registered) {
+    if (sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(ctx->pubsub_ctx),
+                                     SBP_MSG_SETTINGS_WRITE_RESP,
+                                     settings_write_resp_callback, ctx, NULL) != 0) {
+      piksi_log(LOG_ERR, "error registering settings write resp callback");
+      return -1;
+    } else {
+      ctx->write_resp_callback_registered = true;
+    }
+  }
+  return 0;
+}
+
+/**
+ * @brief members_destroy - deinit for settings context members
+ * @param ctx: settings context to deinit
+ */
 static void members_destroy(settings_ctx_t *ctx)
 {
   if (ctx->pubsub_ctx != NULL) {
@@ -630,6 +1179,10 @@ static void members_destroy(settings_ctx_t *ctx)
   }
 }
 
+/**
+ * @brief destroy - deinit for settings context
+ * @param ctx: settings context to deinit
+ */
 static void destroy(settings_ctx_t **ctx)
 {
   members_destroy(*ctx);
@@ -655,6 +1208,9 @@ settings_ctx_t * settings_create(void)
   ctx->type_data_list = NULL;
   ctx->setting_data_list = NULL;
   ctx->registration_state.pending = false;
+  ctx->write_callback_registered = false;
+  ctx->write_resp_callback_registered = false;
+  ctx->read_resp_callback_registered = false;
 
   /* Register standard types */
   settings_type_t type;
@@ -687,14 +1243,6 @@ settings_ctx_t * settings_create(void)
   }
   assert(type == SETTINGS_TYPE_BOOL);
 
-  if (sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(ctx->pubsub_ctx),
-                                   SBP_MSG_SETTINGS_WRITE,
-                                   settings_write_callback, ctx, NULL) != 0) {
-    piksi_log(LOG_ERR, "error registering settings write callback");
-    destroy(&ctx);
-    return ctx;
-  }
-
   return ctx;
 }
 
@@ -718,31 +1266,96 @@ int settings_type_register_enum(settings_ctx_t *ctx,
                        enum_names, type);
 }
 
-int settings_register(settings_ctx_t *ctx, const char *section,
-                      const char *name, void *var, size_t var_len,
-                      settings_type_t type, settings_notify_fn notify,
-                      void *notify_context)
+/**
+ * @brief settings_add_setting - internal subroutine for handling new settings
+ * This method forwards all parameters to the setting factory to create a new
+ * settings but also performs the addition of the setting to the settings context
+ * internal list and performs either registration of the setting (if owned) or
+ * a value update (if watch only) to fully initialize the new setting.
+ * @param ctx: settings context
+ * @param section: section identifier
+ * @param name: setting name
+ * @param var: non-owning reference to location the data is stored
+ * @param var_len: length of data storage
+ * @param type: type identifier
+ * @param notify: optional notification callback
+ * @param notify_context: optional data reference to pass during notification
+ * @param readonly: set to true to disable value updates
+ * @param watchonly: set to true to indicate a non-owned setting watch
+ * @return zero on success, -1 if the addition of the setting has failed
+ */
+static int settings_add_setting(settings_ctx_t *ctx,
+                                const char *section, const char *name,
+                                void *var, size_t var_len, settings_type_t type,
+                                settings_notify_fn notify, void *notify_context,
+                                bool readonly, bool watchonly)
 {
   assert(ctx != NULL);
   assert(section != NULL);
   assert(name != NULL);
   assert(var != NULL);
 
-  return setting_register(ctx, section, name, var, var_len, type,
-                          notify, notify_context, false);
+  if (setting_data_lookup(ctx, section, name) != NULL) {
+    piksi_log(LOG_ERR, "setting add failed - duplicate setting");
+    return -1;
+  }
+
+  setting_data_t *setting_data = setting_create_setting(ctx, section, name,
+                                                        var, var_len, type,
+                                                        notify, notify_context,
+                                                        readonly, watchonly);
+  if (setting_data == NULL) {
+    piksi_log(LOG_ERR, "error creating setting data");
+    return -1;
+  }
+
+  /* Add to list */
+  setting_data_list_insert(ctx, setting_data);
+
+  if (watchonly) {
+    if (settings_register_write_resp_callback(ctx) != 0) {
+      piksi_log(LOG_ERR, "error registering settings write resp callback");
+    }
+    if (setting_read_watched_value(ctx, setting_data) != 0) {
+      piksi_log(LOG_ERR, "error reading watched setting to initial value");
+    }
+  } else {
+    if (settings_register_write_callback(ctx) != 0) {
+      piksi_log(LOG_ERR, "error registering settings write callback");
+    }
+    if (setting_register(ctx, setting_data) != 0) {
+      piksi_log(LOG_ERR, "error registering setting with settings manager");
+      setting_data_list_remove(ctx, &setting_data);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int settings_register(settings_ctx_t *ctx, const char *section,
+                      const char *name, void *var, size_t var_len,
+                      settings_type_t type, settings_notify_fn notify,
+                      void *notify_context)
+{
+  return settings_add_setting(ctx, section, name, var, var_len, type,
+                              notify, notify_context, false, false);
 }
 
 int settings_register_readonly(settings_ctx_t *ctx, const char *section,
                                const char *name, const void *var,
                                size_t var_len, settings_type_t type)
 {
-  assert(ctx != NULL);
-  assert(section != NULL);
-  assert(name != NULL);
-  assert(var != NULL);
+  return settings_add_setting(ctx, section, name, (void *)var, var_len, type,
+                             NULL, NULL, true, false);
+}
 
-  return setting_register(ctx, section, name, (void *)var, var_len, type,
-                          NULL, NULL, true);
+int settings_add_watch(settings_ctx_t *ctx, const char *section,
+                       const char *name, void *var, size_t var_len,
+                       settings_type_t type, settings_notify_fn notify,
+                       void *notify_context)
+{
+  return settings_add_setting(ctx, section, name, var, var_len, type,
+                              notify, notify_context, false, true);
 }
 
 int settings_read(settings_ctx_t *ctx)

--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -831,7 +831,8 @@ int setting_parse_setting_text(const u8 *msg,
     *(result_holders[i]) = NULL;
     while (end < msg_n) {
       if (msg[end] == '\0') {
-        if (end == start) {
+        // don't allow empty strings before the third term
+        if (end == start && i < 2) {
           return -1;
         } else {
           *(result_holders[i]) = (const char *)msg + start;

--- a/package/sample_daemon/src/sample_daemon.c
+++ b/package/sample_daemon/src/sample_daemon.c
@@ -46,6 +46,7 @@ static double offset = 0;
 static bool enable_broadcast = false;
 static int broadcast_port = 56666;
 static char broadcast_hostname[256] = "255.255.255.255";
+static bool ntrip_enable = false;
 
 static udp_broadcast_context udp_context;
 
@@ -133,6 +134,7 @@ static int notify_settings_changed(void *context)
   (void)context;
 
   sbp_log(LOG_DEBUG, "Settings changed: enable_broadcast = %d, broadcast port = %d, offset = %04.04f", enable_broadcast, broadcast_port, offset);
+  sbp_log(LOG_DEBUG, "Settings watched: ntrip_enable= %d", ntrip_enable);
 
   close_udp_broadcast_socket(&udp_context);
 
@@ -221,6 +223,11 @@ int main(int argc, char *argv[])
                     &broadcast_hostname, sizeof(broadcast_hostname),
                     SETTINGS_TYPE_STRING,
                     notify_settings_changed, NULL);
+
+  settings_add_watch(settings_ctx, "ntrip", "enable",
+                     &ntrip_enable, sizeof(ntrip_enable),
+                     SETTINGS_TYPE_BOOL,
+                     notify_settings_changed, NULL);
 
   sbp_log(LOG_INFO, "Ready!");
   zmq_simple_loop(sbp_zmq_pubsub_zloop_get(ctx));

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -10,6 +10,10 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0xAE, 0x00] } # Settings register
           - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: REJECT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
       - dst_port: SBP_PORT_EXTERNAL
         filters:
           - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
@@ -49,6 +53,7 @@ ports:
       - dst_port: SBP_PORT_SETTINGS_CLIENT
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: REJECT }
 
   - name: SBP_PORT_EXTERNAL
@@ -110,12 +115,15 @@ ports:
     forwarding_rules:
       - dst_port: SBP_PORT_EXTERNAL
         filters:
-          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
           - { action: REJECT }
       - dst_port: SBP_PORT_SETTINGS_DAEMON
         filters:
           - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
 
   - name: SBP_PORT_SKYLARK
     pub_addr: "@tcp://127.0.0.1:43080"


### PR DESCRIPTION
This is the dev PR for #506 with modifications to implement the write response changes from #397 which wasn't included in the v1.4.0-release

From the dev PR:

The initial implementation of settings watchers for the health daemon was a bit copy-pasta.

This refactor covers lightly refactoring libpiksi/settings to allow settings nodes to be registered to a client that do not perform registration and only response to read responses as a way to 'watch' a particular setting.

Notes:

 * Most code has merely been moved into smaller functions but the parse code has been
taken from health_daemon
 * Much of this code is functionally similar to that in the settings_daemon, the next step would be
to condense that code as well
 * No implementation has been performed in this PR, I will refactor health_daemon and
others (like the simulation check in the rtcm3 bridge) as separate pull requests.
 * The commits are intentionally discrete, all will be squashed if/when merged