### PR TITLE
Refactor rtcm3 bridge simulator watcher

### DIFF
--- a/package/sbp_rtcm3_bridge/src/sbp.c
+++ b/package/sbp_rtcm3_bridge/src/sbp.c
@@ -18,9 +18,11 @@
 static struct {
   sbp_zmq_rx_ctx_t *rx_ctx;
   sbp_zmq_tx_ctx_t *tx_ctx;
+  bool simulator_enabled;
 } ctx = {
   .rx_ctx = NULL,
-  .tx_ctx = NULL
+  .tx_ctx = NULL,
+  .simulator_enabled = false
 };
 
 int sbp_init(sbp_zmq_rx_ctx_t *rx_ctx, sbp_zmq_tx_ctx_t *tx_ctx)
@@ -51,85 +53,14 @@ int sbp_callback_register(u16 msg_type, sbp_msg_callback_t cb, void *context)
   return sbp_zmq_rx_callback_register(ctx.rx_ctx, msg_type, cb, context, NULL);
 }
 
-/* this is a short term solution - settings refactor to remove */
-static int parse_setting_read_resp(const u8 *msg,
-                                   u8 msg_n,
-                                   const char **section,
-                                   const char **name,
-                                   const char **value)
+void sbp_simulator_enabled_set(bool enabled)
 {
-  const char **result_holders[] = { section, name, value };
-  u8 start = 0;
-  u8 end = 0;
-  for (u8 i = 0; i < sizeof(result_holders) / sizeof(*result_holders); i++) {
-    bool found = false;
-    *(result_holders[i]) = NULL;
-    while (end < msg_n) {
-      if (msg[end] == '\0') {
-        if (end == start) {
-          return -1;
-        } else {
-          *(result_holders[i]) = (const char *)msg + start;
-          start = (u8)(end + 1);
-          found = true;
-        }
-      }
-      end++;
-      if (found) {
-        break;
-      }
-    }
-  }
-  return 0;
-}
-
-static const char *const bool_names[] = { "False", "True" };
-static const char *const section_simulator = "simulator";
-static const char *const name_enabled = "enabled";
-
-static int check_simulator_enabled(const char *section,
-                                   const char *name,
-                                   const char *value,
-                                   bool *result)
-{
-  if (section == NULL || name == NULL || value == NULL) {
-    return -1;
-  }
-
-  if (strcmp(section, section_simulator ) != 0
-      || strcmp(name, name_enabled) != 0) {
-    return -1;
-  }
-
-  if (strcmp(value, bool_names[(u8) true]) == 0) {
-    *result = true;
-  } else if (strcmp(value, bool_names[(u8) false]) == 0) {
-    *result = false;
-  } else {
-    return -1;
-  }
-
-  return 0;
-}
-
-static bool simulator_enabled = false;
-void sbp_read_resp_callback(u16 sender_id, u8 len, u8 msg_[], void *context)
-{
-  (void)sender_id;
-  (void)context;
-
-  const char *section, *name, *value;
-  if (parse_setting_read_resp(msg_, len, &section, &name, &value) == 0) {
-    if(check_simulator_enabled(section, name, value, &simulator_enabled) == 0) {
-      piksi_log(LOG_DEBUG, "Parsed simulator enable: %d", (u8)simulator_enabled);
-    }
-  }
+  ctx.simulator_enabled = enabled;
 }
 
 void sbp_base_obs_invalid(double timediff)
 {
-  if (simulator_enabled) {
-    piksi_log(LOG_DEBUG, "Skipping obs invalid");
+  if (ctx.simulator_enabled) {
     return;
   }
 

--- a/package/sbp_rtcm3_bridge/src/sbp.h
+++ b/package/sbp_rtcm3_bridge/src/sbp.h
@@ -23,7 +23,7 @@
 int sbp_init(sbp_zmq_rx_ctx_t *rx_ctx, sbp_zmq_tx_ctx_t *tx_ctx);
 void sbp_message_send(u16 msg_type, u8 len, u8 *payload, u16 sender_id);
 int sbp_callback_register(u16 msg_type, sbp_msg_callback_t cb, void *context);
-void sbp_read_resp_callback(u16 sender_id, u8 len, u8 msg_[], void *context);
+void sbp_simulator_enabled_set(bool enabled);
 void sbp_base_obs_invalid(double timediff);
 
 #endif /* SWIFTNAV_SBP_H */

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -15,6 +15,7 @@
 #include <getopt.h>
 #include <libpiksi/sbp_zmq_pubsub.h>
 #include <libpiksi/sbp_zmq_rx.h>
+#include <libpiksi/settings.h>
 #include <libpiksi/util.h>
 #include <libpiksi/logging.h>
 #include <libsbp/navigation.h>
@@ -35,6 +36,8 @@
 bool rtcm3_debug = false;
 
 struct rtcm3_sbp_state state;
+
+bool simulator_enabled_watch = false;
 
 static int rtcm3_reader_handler(zloop_t *zloop, zsock_t *zsock, void *arg)
 {
@@ -152,14 +155,26 @@ static void utc_time_callback(u16 sender_id, u8 len, u8 msg[], void *context)
   rtcm2sbp_set_leap_second(leap_second,&state);
 }
 
+static int notify_simulator_enable_changed(void *context)
+{
+  (void)context;
+  sbp_simulator_enabled_set(simulator_enabled_watch);
+  return 0;
+}
+
 int main(int argc, char *argv[])
 {
+  int status = EXIT_SUCCESS;
+  settings_ctx_t *settings_ctx = NULL;
+  sbp_zmq_pubsub_ctx_t *ctx = NULL;
+
   logging_init(PROGRAM_NAME);
 
   if (parse_options(argc, argv) != 0) {
     piksi_log(LOG_ERR, "invalid arguments");
     usage(argv[0]);
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
   /* Need to init state variable before we get SBP in */
@@ -168,46 +183,71 @@ int main(int argc, char *argv[])
   /* Prevent czmq from catching signals */
   zsys_handler_set(NULL);
 
-  sbp_zmq_pubsub_ctx_t *ctx = sbp_zmq_pubsub_create(SBP_PUB_ENDPOINT,
-                                                    SBP_SUB_ENDPOINT);
+  ctx = sbp_zmq_pubsub_create(SBP_PUB_ENDPOINT, SBP_SUB_ENDPOINT);
   if (ctx == NULL) {
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
   zsock_t *rtcm3_sub = zsock_new_sub(RTCM3_SUB_ENDPOINT, "");
   if (rtcm3_sub == NULL) {
     piksi_log(LOG_ERR, "error creating SUB socket");
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
   if (zloop_reader(sbp_zmq_pubsub_zloop_get(ctx), rtcm3_sub,
                    rtcm3_reader_handler, NULL) != 0) {
     piksi_log(LOG_ERR, "error adding reader");
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
   if (sbp_init(sbp_zmq_pubsub_rx_ctx_get(ctx),
                sbp_zmq_pubsub_tx_ctx_get(ctx)) != 0) {
     piksi_log(LOG_ERR, "error initializing SBP");
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
   if (sbp_callback_register(SBP_MSG_GPS_TIME, gps_time_callback, NULL) != 0) {
     piksi_log(LOG_ERR, "error setting GPS TIME callback");
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
   if (sbp_callback_register(SBP_MSG_UTC_TIME, utc_time_callback, NULL) != 0) {
     piksi_log(LOG_ERR, "error setting UTC TIME callback");
-    exit(EXIT_FAILURE);
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
 
-  if (sbp_callback_register(SBP_MSG_SETTINGS_READ_RESP, sbp_read_resp_callback, NULL) != 0) {
-    piksi_log(LOG_ERR, "error setting SBP READ RESP callback");
-    exit(EXIT_FAILURE);
+  settings_ctx = settings_create();
+
+  if (settings_ctx == NULL) {
+    sbp_log(LOG_ERR, "Error registering for settings!");
+    status = EXIT_FAILURE;
+    goto cleanup;
   }
+
+  if (settings_reader_add(settings_ctx,
+                          sbp_zmq_pubsub_zloop_get(ctx)) != 0) {
+    sbp_log(LOG_ERR, "Error registering for settings read!");
+    status = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  settings_add_watch(settings_ctx, "simulator", "enabled",
+                     &simulator_enabled_watch , sizeof(simulator_enabled_watch),
+                     SETTINGS_TYPE_BOOL,
+                     notify_simulator_enable_changed, NULL);
 
   zmq_simple_loop(sbp_zmq_pubsub_zloop_get(ctx));
 
-  exit(EXIT_SUCCESS);
+cleanup:
+  sbp_zmq_pubsub_destroy(&ctx);
+  settings_destroy(&settings_ctx);
+  logging_deinit();
+
+  return status;
 }


### PR DESCRIPTION
This incorporates #506 to remove all settings callbacks and parsing logic since that now exists in libpiksi