### PR TITLE
Removed virtual network interfaces from USB gadget [issues 1080, 691]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S38usb_gadget
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S38usb_gadget
@@ -26,8 +26,6 @@ start() {
   # Functions
   mkdir functions/acm.GS0
   mkdir functions/acm.GS1
-  mkdir functions/rndis.usb0
-  mkdir functions/ecm.usb0
 
   # Configurations
   mkdir configs/c.1
@@ -35,13 +33,6 @@ start() {
   echo "$CONFIGURATION" > configs/c.1/strings/0x409/configuration
   ln -s functions/acm.GS0 configs/c.1
   ln -s functions/acm.GS1 configs/c.1
-  ln -s functions/rndis.usb0 configs/c.1
-  ln -s functions/ecm.usb0 configs/c.1
-
-  # RNDIS Windows hack
-  echo 0xEF > /sys/kernel/config/usb_gadget/g1/bDeviceClass
-  echo 0x02 > /sys/kernel/config/usb_gadget/g1/bDeviceSubClass
-  echo 0x01 > /sys/kernel/config/usb_gadget/g1/bDeviceProtocol
 
   # Attach
   for dev in /sys/class/udc/*; do


### PR DESCRIPTION
Since the ethernet over USB feature was pushed until a future release, this cherry-pick removes the intermediate functionality and makes master behave the same as v1.3 release and v1.4 release.  See issues: 
https://github.com/swift-nav/piksi_v3_bug_tracking/issues/1080
 and 
https://github.com/swift-nav/piksi_v3_bug_tracking/issues/691

When we pickup this feature again we should probably just revert this commit and start from there.