### PR TITLE
Allow empty string in settings write and route read resp to client

### DIFF
--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -810,7 +810,8 @@ int setting_parse_setting_text(const u8 *msg,
     *(result_holders[i]) = NULL;
     while (end < msg_n) {
       if (msg[end] == '\0') {
-        if (end == start) {
+        // don't allow empty strings before the third term
+        if (end == start && i < 2) {
           return -1;
         } else {
           *(result_holders[i]) = (const char *)msg + start;

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -53,6 +53,7 @@ ports:
       - dst_port: SBP_PORT_SETTINGS_CLIENT
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: REJECT }
 
   - name: SBP_PORT_EXTERNAL


### PR DESCRIPTION
Small behavioral fixes to the settings refactor #521 

 * Allow a string value field to be "" (refactored parsing was treating this as an error)
 * Route read responses from settings daemon to settings client to allow the initial update read request to complete successfully