### PR TITLE
Rename interval to gga_out_interval

### DIFF
--- a/package/piksi_system_daemon/piksi_system_daemon/src/ntrip.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/ntrip.c
@@ -172,7 +172,7 @@ void ntrip_init(settings_ctx_t *settings_ctx)
                     SETTINGS_TYPE_STRING,
                     ntrip_notify, NULL);
 
-  settings_register(settings_ctx, "ntrip", "interval",
+  settings_register(settings_ctx, "ntrip", "gga_out_interval",
                     &ntrip_interval, sizeof(ntrip_interval),
                     SETTINGS_TYPE_INT,
                     ntrip_notify, NULL);


### PR DESCRIPTION
Per request: https://github.com/swift-nav/piksi_v3_bug_tracking/issues/1079#issuecomment-369485482