### PR TITLE
Add awscli to nix-shell environement for building

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
 let fhs = pkgs.buildFHSUserEnv {
   name = "piksi-env";
   targetPkgs = pkgs: with pkgs; [
+    awscli
     bash
     bc
     bison

--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -15,6 +15,11 @@
 
 set -xe
 
+if [[ $(uname -a) == *NixOS* ]]; then
+  # Remove buildroot from LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=/lib:/usr/lib
+fi
+
 FW_VERSION=${1:-v1.3.0-develop-2018030818}
 NAP_VERSION=${2:-v1.3.0-develop-2018030818}
 


### PR DESCRIPTION
This makes `make firmware` function as expected, some tricks need to be played with `LD_LIBRARY_PATH` so that the system Python doesn't attempt to load libraries from the "host" Python that buildroot builds.