### PR TITLE
Add docker-exec target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ docker-run:
 	docker run $(DOCKER_RUN_ARGS) --name=$(DOCKER_TAG) \
 		--tty --interactive $(DOCKER_TAG) || :
 
+docker-exec:
+	docker exec $(DOCKER_ENV_ARGS) --interactive --tty \
+		$(DOCKER_TAG) /bin/bash -s 'export PS1="\u@\h:\w\$$"'
+
 docker-make-firmware:
 	docker run $(DOCKER_ARGS) $(DOCKER_TAG) \
 		make firmware

--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -39,9 +39,7 @@ ifeq ($(PIKSI_NON_INTERACTIVE_BUILD),)
 INTERACTIVE_ARGS := $(shell tty &>/dev/null && echo "--tty --interactive")
 endif
 
-DOCKER_SETUP_ARGS :=                                                          \
-  $(INTERACTIVE_ARGS)                                                         \
-  --rm                                                                        \
+DOCKER_ENV_ARGS :=                                                            \
   -e USER=$(USER)                                                             \
   -e GID=$(GID)                                                               \
   -e HW_CONFIG=$(HW_CONFIG)                                                   \
@@ -50,8 +48,13 @@ DOCKER_SETUP_ARGS :=                                                          \
   -e BR2_BUILD_SAMPLE_DAEMON=$(BR2_BUILD_SAMPLE_DAEMON)                       \
   -e GITHUB_TOKEN=$(GITHUB_TOKEN)                                             \
   $(AWS_VARIABLES)                                                            \
-  --hostname piksi-builder$(_DOCKER_SUFFIX)                                   \
   --user $(USER)                                                              \
+
+DOCKER_SETUP_ARGS :=                                                          \
+  $(INTERACTIVE_ARGS)                                                         \
+  $(DOCKER_ENV_ARGS)                                                          \
+  --rm                                                                        \
+  --hostname piksi-builder$(_DOCKER_SUFFIX)                                   \
   -v $(HOME):/host/home:ro                                                    \
   -v /tmp:/host/tmp:rw                                                        \
   -v $(CURDIR):/piksi_buildroot                                               \


### PR DESCRIPTION
Add a `docker-exec` target so that you can have multiple shells inside the same container.