### PR TITLE
Pre-flight change for ndb permissions fix

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S81sbp_fileio_daemon_firmware
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S81sbp_fileio_daemon_firmware
@@ -5,5 +5,6 @@ cmd="sbp_fileio_daemon -p >tcp://localhost:43041 -s >tcp://localhost:43040"
 dir="/"
 user=""
 
-source /etc/init.d/template_process.inc.sh
+mkdir -p /persistent/ndb
 
+source /etc/init.d/template_process.inc.sh


### PR DESCRIPTION
To support the NDB permission change we need to create a /persistent/ndb directory for ndb files so that firmware will be creating files in the correct location prior to restricting permissions.