### PR TITLE
Create "is duro" API in libpiksi

### DIFF
--- a/package/libpiksi/libpiksi/include/libpiksi/util.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/util.h
@@ -49,6 +49,14 @@ u64 system_uptime_ms_get(void);
 int device_uuid_get(char *str, size_t str_size);
 
 /**
+ * @brief   Determine if the current system is Duro
+ * @details Returns the true or false
+ *
+ * @return  True if the current system is a Duro
+ */
+bool device_is_duro(void);
+
+/**
  * @brief   Run a ZMQ loop ignoring signals.
  * @details Run a ZMQ loop ignoring signals until an error occurs or a handler
  *          returns -1.

--- a/package/libpiksi/libpiksi/src/util.c
+++ b/package/libpiksi/libpiksi/src/util.c
@@ -17,6 +17,10 @@
 #define SBP_SENDER_ID_FILE_PATH "/cfg/sbp_sender_id"
 #define DEVICE_UUID_FILE_PATH   "/cfg/device_uuid"
 
+#define DEVICE_DURO_EEPROM_PATH "/cfg/duro_eeprom"
+#define DEVICE_DURO_MAX_CONTENTS_SIZE (128u)
+#define DEVICE_DURO_ID_STRING "DUROV0"
+
 #define PROC_UPTIME_FILE_PATH   "/proc/uptime"
 #define UPTIME_READ_MAX_LENGTH (64u)
 
@@ -76,6 +80,23 @@ u64 system_uptime_ms_get(void)
 int device_uuid_get(char *str, size_t str_size)
 {
   return file_read_string(DEVICE_UUID_FILE_PATH, str, str_size);
+}
+
+bool device_is_duro(void)
+{
+  char duro_eeprom_sig[sizeof(DEVICE_DURO_ID_STRING)];
+
+  int fd = open(DEVICE_DURO_EEPROM_PATH, O_RDONLY);
+  if (fd < 0) {
+    piksi_log(LOG_WARNING, "Failed to open DURO eeprom path");
+    return false;
+  }
+  read(fd, duro_eeprom_sig, sizeof(DEVICE_DURO_ID_STRING));
+  close(fd);
+
+  return (memcmp(duro_eeprom_sig,
+                 DEVICE_DURO_ID_STRING,
+                 strlen(DEVICE_DURO_ID_STRING)) == 0);
 }
 
 int zmq_simple_loop(zloop_t *zloop)

--- a/package/piksi_leds/src/main.c
+++ b/package/piksi_leds/src/main.c
@@ -22,21 +22,6 @@
 #define PUB_ENDPOINT_EXTERNAL_SBP ">tcp://localhost:43031"
 #define SUB_ENDPOINT_EXTERNAL_SBP ">tcp://localhost:43030"
 
-#define DURO_EEPROM_PATH "/cfg/duro_eeprom"
-
-static bool board_is_duro(void)
-{
-  int fd = open(DURO_EEPROM_PATH, O_RDONLY);
-  if (fd < 0) {
-    piksi_log(LOG_WARNING, "failed to open DURO eeprom path");
-    return false;
-  }
-  char buf[6];
-  read(fd, buf, 6);
-  close(fd);
-  return memcmp(buf, "DUROV0", 6) == 0;
-}
-
 int main(void)
 {
   logging_init(PROGRAM_NAME);
@@ -51,7 +36,7 @@ int main(void)
   }
 
   firmware_state_init(sbp_zmq_pubsub_rx_ctx_get(ctx));
-  manage_led_setup(board_is_duro());
+  manage_led_setup(device_is_duro());
 
   zmq_simple_loop(sbp_zmq_pubsub_zloop_get(ctx));
 

--- a/package/piksi_system_daemon/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/main.c
@@ -359,6 +359,25 @@ static void img_tbl_settings_setup(settings_ctx_t *settings_ctx)
   }
 }
 
+static void hardware_variant_settings_setup(settings_ctx_t *settings_ctx)
+{
+  static char *hardware_variant = "";
+  if (device_is_duro()) {
+    hardware_variant = "Duro";
+  } else {
+    hardware_variant = "Multi";
+  }
+  if (settings_register_readonly(settings_ctx,
+                                 "system_info",
+                                 "hw_variant",
+                                 hardware_variant,
+                                 strlen(hardware_variant) + 1,
+                                 SETTINGS_TYPE_STRING)
+      != 0) {
+    piksi_log(LOG_WARNING, "Failed to register hardware_variant in system_info");
+  }
+}
+
 static void reset_callback(u16 sender_id, u8 len, u8 msg_[], void *context)
 {
   (void)sender_id; (void)context;
@@ -502,6 +521,7 @@ int main(void)
   cellmodem_init(pubsub_ctx, settings_ctx);
 
   img_tbl_settings_setup(settings_ctx);
+  hardware_variant_settings_setup(settings_ctx);
   sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(pubsub_ctx),
                                SBP_MSG_COMMAND_REQ, sbp_command, pubsub_ctx, NULL);
   sbp_zmq_rx_callback_register(sbp_zmq_pubsub_rx_ctx_get(pubsub_ctx),


### PR DESCRIPTION
Moving code from `piksi_leds` into `libpiksi` to centralize the process of checking the current system for a hardware variant.

A new setting has been added in 'system_info' that reflects this API being used to determine a read only string value for the current hardware variant, called 'hardware_variant'. It will show either "DURO" or "MULTI" at this point based on the above check.

This should not be merged prior to #546 as it relies on the newly created `/cfg/duro_eeprom` resource

Addresses DEVC-38