### PR TITLE
zmq_router init: use sbp_router_smoothpose.yml if Smoothpose enabled

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S80zmq_router_sbp
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S80zmq_router_sbp
@@ -1,9 +1,15 @@
 #!/bin/sh
 
 name="zmq_router_sbp"
-cmd="zmq_router -f /etc/zmq_router/sbp_router.yml"
 dir="/"
 user=""
 
-source /etc/init.d/template_process.inc.sh
+if grep -q "smoothpose_enable=True" /persistent/config.ini; then
+  router_config="/etc/zmq_router/sbp_router_smoothpose.yml"
+else
+  router_config="/etc/zmq_router/sbp_router.yml"
+fi
 
+cmd="zmq_router -f $router_config"
+
+source /etc/init.d/template_process.inc.sh

--- a/package/sbp_protocol/sbp_protocol.mk
+++ b/package/sbp_protocol/sbp_protocol.mk
@@ -26,6 +26,7 @@ define SBP_PROTOCOL_INSTALL_TARGET_CMDS
                           $(TARGET_DIR)/usr/lib/zmq_protocols
     $(INSTALL) -d -m 0755 $(TARGET_DIR)/etc/zmq_router
     $(INSTALL) -D -m 0755 $(@D)/sbp_router.yml $(TARGET_DIR)/etc/zmq_router
+    $(INSTALL) -D -m 0755 $(@D)/sbp_router_smoothpose.yml $(TARGET_DIR)/etc/zmq_router
 endef
 
 $(eval $(generic-package))

--- a/package/sbp_protocol/src/sbp_router_smoothpose.yml
+++ b/package/sbp_protocol/src/sbp_router_smoothpose.yml
@@ -1,0 +1,184 @@
+# This file is a variant the stock sbp_router.yml 
+# With it, the router sends the "best position" and "best velcity" estimates
+# through a new nav_daemon port before going to the external interfaces.
+# It can be used to allow a process like a loosely coupled INS filter
+# to intercept and transform the best GNSS position and velocity estimates 
+# they go on the wire
+# The key changes to the stock config are highlihged with the string **Smoothpose Change**
+
+name: SBP_ROUTER
+ports:
+  - name: SBP_PORT_FIRMWARE
+    pub_addr: "@tcp://127.0.0.1:43010"
+    sub_addr: "@tcp://127.0.0.1:43011"
+    forwarding_rules:
+      - dst_port: SBP_PORT_SETTINGS_DAEMON
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  **Smoothpose Change**
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_FILEIO_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: ACCEPT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: ACCEPT, prefix: [0x55, 0xAC, 0x00] } # File reamove
+          - { action: ACCEPT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_INTERNAL
+        filters:
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SKYLARK
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # Publish: SBP MSG_POS_LLH
+          - { action: ACCEPT, prefix: [0x55, 0xFF, 0xFF] } # Publish: SBP MSG_HEARTBEAT
+          - { action: REJECT }
+      - dst_port: SBP_PORT_NAV_DAEMON # This list sends only what Smoothpose needs at present.
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x00, 0x09] } # MSG_IMU_RAW  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x09] } # MSG_IMU_AUX  **Smoothpose Change**
+          - { action: REJECT }
+
+  - name: SBP_PORT_SETTINGS_DAEMON
+    pub_addr: "@tcp://127.0.0.1:43020"
+    sub_addr: "@tcp://127.0.0.1:43021"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: REJECT }
+
+  - name: SBP_PORT_EXTERNAL
+    pub_addr: "@tcp://127.0.0.1:43030"
+    sub_addr: "@tcp://127.0.0.1:43031"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_DAEMON
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_FILEIO_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: ACCEPT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: ACCEPT, prefix: [0x55, 0xAC, 0x00] } # File reamove
+          - { action: ACCEPT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_INTERNAL
+        filters:
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: REJECT }
+
+  - name: SBP_PORT_FILEIO_FIRMWARE
+    pub_addr: "@tcp://127.0.0.1:43040"
+    sub_addr: "@tcp://127.0.0.1:43041"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_FILEIO_EXTERNAL
+    pub_addr: "@tcp://127.0.0.1:43050"
+    sub_addr: "@tcp://127.0.0.1:43051"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_INTERNAL
+    pub_addr: "@tcp://127.0.0.1:43060"
+    sub_addr: "@tcp://127.0.0.1:43061"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_SETTINGS_CLIENT
+    pub_addr: "@tcp://127.0.0.1:43070"
+    sub_addr: "@tcp://127.0.0.1:43071"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_SETTINGS_DAEMON
+        filters:
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+
+  - name: SBP_PORT_SKYLARK
+    pub_addr: "@tcp://127.0.0.1:43080"
+    sub_addr: "@tcp://127.0.0.1:43081"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x44, 0x00] } # SBP_MSG_BASE_POS_LLH
+          - { action: ACCEPT, prefix: [0x55, 0x48, 0x00] } # SBP_MSG_BASE_POS_ECEF
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: ACCEPT, prefix: [0x55, 0x86, 0x00] } # SBP_MSG_EPHEMERIS_GPS
+          - { action: ACCEPT, prefix: [0x55, 0x88, 0x00] } # SBP_MSG_EPHEMERIS_GLO
+          - { action: ACCEPT, prefix: [0x55, 0x84, 0x00] } # SBP_MSG_EPHEMERIS_SBAS
+          - { action: ACCEPT, prefix: [0x55, 0x75, 0x00] } # SBP_MSG_GLO_BIASES
+          - { action: REJECT }
+
+  - name: SBP_PORT_NAV_DAEMON  # Entire Section Smoothpose Change**
+    pub_addr: "@tcp://127.0.0.1:43090"
+    sub_addr: "@tcp://127.0.0.1:43091"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x13, 0x02] } # MSG_VEL_BODY      **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x20, 0x02] } # MSG_ORIENT_QUAT   **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x21, 0x02] } # MSG_ORIENT_EULER  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x22, 0x02] } # MSG_ANGULAR_RATE  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           **Smoothpose Change**
+          - { action: REJECT }


### PR DESCRIPTION
I'd like to get feedback on this PR.

It adjust the zmq_router init script to use a different router yaml file in the case that smoothpose is enabled. It does this hackily, but I think that is okay since we plan to eventually do this with a better API.

It has been tested on the hardware extensively by hand (in the PR with the nav_daemon).  It requires the board to be restarted when smoothpose is disabled or enabled.
/cc @nicolekelley 