### PR TITLE
[master:#564] Upgrade process file io validation and error codes in upgrade_tool

### DIFF
--- a/package/piksi_system_daemon/piksi_system_daemon/src/async-child.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/async-child.c
@@ -46,6 +46,9 @@ static void sigchld_handler(int signum)
   pid_t pid;
   int status;
   while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
+    if (WIFEXITED(status)) {
+      status = WEXITSTATUS(status);
+    }
     ports_sigchld_waitpid_handler(pid, status);
     async_child_waitpid_handler(pid, status);
   }


### PR DESCRIPTION
DEVC-336 #comment This is the master PR for #564

Summary:
 - Add validation of fileio write to gate response
 - Introduce differentiated failure codes in upgrade_tool
 - Remove usage of exit(3) and fix status code from async child