### PR TITLE
Add rate limiting to libnetwork errors [DEVC-381]

### DIFF
--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -50,6 +50,9 @@ const double PIPE_WARN_THRESHOLD = 0.90;
 /** Min amount time between "pipe full" warning messages. */
 const double PIPE_WARN_SECS = 5;
 
+/** How often CURL errors should be reported */
+const time_t ERROR_REPORTING_INTERVAL = 10;
+
 typedef struct context_node context_node_t;
 
 struct network_context_s {
@@ -60,7 +63,7 @@ struct network_context_s {
   bool debug;                  /**< Set if we are emitted debug information */
   double gga_xfer_secs;        /**< The number of seconds between GGA upload times */
 
-  time_t last_xfer_time;       /**< The last type GGA was uploaded (for NTRIP only) */
+  time_t last_xfer_time;       /**< Time of the last GGA sentence uploaded (for NTRIP only) */
   curl_socket_t socket_fd;     /**< The socket we're read/writing from/to */
 
   CURL *curl;                  /**< The current cURL handle */
@@ -75,6 +78,8 @@ struct network_context_s {
   volatile bool cycle_connection_signaled;
 
   context_node_t* node;
+
+  time_t last_curl_error_time; /**< Time at which we last issued a curl require error/warning message */
 
   char username[LIBNETWORK_USERNAME_MAX_LENGTH];
   char password[LIBNETWORK_PASSWORD_MAX_LENGTH];
@@ -105,6 +110,7 @@ static network_context_t empty_context = {
   .response_code = 0,
   .response_code_check = NULL,
   .node = NULL,
+  .last_curl_error_time = 0,
   .username = "",
   .password = "",
   .url = "",
@@ -565,20 +571,23 @@ static void network_request(network_context_t* ctx, CURL *curl)
       continue;
 
     if (code != CURLE_OK) {
-      sbp_log(LOG_WARNING, "Network Request Error - \"%s\"", error_buf);
-      piksi_log(LOG_WARNING, "curl request (error: %d) \"%s\"", code, error_buf);
+      time_t current_time = time(NULL);
+      time_t last_error_delta = current_time - ctx->last_curl_error_time;
+      if (last_error_delta >= ERROR_REPORTING_INTERVAL) {
+        piksi_log(LOG_SBP|LOG_WARNING, "curl request (error: %d) \"%s\"", code, error_buf);
+        ctx->last_curl_error_time = current_time;
+      }
     } else {
       long response = 0;
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
       if (response != 0) {
-        sbp_log(LOG_INFO, "Network Request Response Code - (%d)", response);
-        piksi_log(LOG_INFO, "curl request code %d", response);
+        piksi_log(LOG_SBP|LOG_INFO, "curl request code %d", response);
         ctx->response_code = response;
         network_response_code_check(ctx);
       }
     }
 
-    usleep(1000000);
+    sleep(1);
   }
 }
 

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -80,7 +80,7 @@ struct network_context_s {
   context_node_t* node;
 
   bool report_errors;          /**< Should this instance of libnetwork report errors? */
-  time_t last_curl_error_time; /**< Time at which we last issued a cURL error/warning message */
+  time_t last_curl_error_time; /**< Time at which we last issued a cURL error message */
 
   char username[LIBNETWORK_USERNAME_MAX_LENGTH];
   char password[LIBNETWORK_PASSWORD_MAX_LENGTH];

--- a/package/libnetwork/src/libnetwork.h
+++ b/package/libnetwork/src/libnetwork.h
@@ -165,4 +165,9 @@ void libnetwork_shutdown(void);
  */
 void libnetwork_cycle_connection(void);
 
+/**
+ * @brief Configures whether libnetwork should report errors (defaults to true).
+ */
+void libnetwork_report_errors(network_context_t *ctx, bool yesno);
+
 #endif /* SWIFTNAV_LIBNETWORK_H */

--- a/package/libpiksi/libpiksi/include/libpiksi/logging.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/logging.h
@@ -26,6 +26,18 @@
 #include <syslog.h>
 
 /**
+ * Add to piksi_log to send the log message to SBP as well as
+ *   the system log (syslog).
+ *
+ *  E.g. `piksi_log(LOG_SBP|LOG_ERROR, "Some message");`
+ */
+#define LOG_SBP LOG_LOCAL1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
  * @brief   Initialize logging.
  * @details Initialize the global logging state for the process.
  * @note    This function should be called before using other API functions
@@ -67,6 +79,19 @@ void piksi_vlog(int priority, const char *format, va_list ap);
  * @param[in] msg_text      The log message text to send.
  */
 void sbp_log(int priority, const char *msg_text, ...);
+
+/**
+  * @brief   Send a log message over SBP
+  *
+  * @param[in] priority      Priority level as defined in <syslog.h>.
+  * @param[in] msg_text      The log message text to send.
+  * @param[in] ap            variable argument list for printf().
+  */
+void sbp_vlog(int priority, const char *msg_text, va_list ap);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* LIBPIKSI_LOGGING_H */
 

--- a/package/libpiksi/libpiksi/src/logging.c
+++ b/package/libpiksi/libpiksi/src/logging.c
@@ -35,7 +35,7 @@ void piksi_log(int priority, const char *format, ...)
 {
   va_list ap;
   va_start(ap, format);
-  vsyslog(priority, format, ap);
+  piksi_vlog(priority, format, ap);
   va_end(ap);
 }
 

--- a/package/skylark_daemon/src/skylark_daemon.c
+++ b/package/skylark_daemon/src/skylark_daemon.c
@@ -29,6 +29,7 @@
 static bool debug = false;
 static const char *fifo_file_path = NULL;
 static const char *url = NULL;
+static bool no_error_reporting = false;
 
 typedef enum {
   OP_MODE_NONE,
@@ -68,16 +69,18 @@ static int parse_options(int argc, char *argv[])
     OPT_ID_DOWNLOAD,
     OPT_ID_SETTINGS,
     OPT_ID_RECONNECT_DL,
+    OPT_ID_NO_ERROR_REPORTING,
   };
 
   const struct option long_opts[] = {
-    {"upload",       no_argument,       0, OPT_ID_UPLOAD},
-    {"download",     no_argument,       0, OPT_ID_DOWNLOAD},
-    {"settings",     no_argument,       0, OPT_ID_SETTINGS},
-    {"reconnect-dl", no_argument,       0, OPT_ID_RECONNECT_DL},
-    {"file",         required_argument, 0, OPT_ID_FILE},
-    {"url  ",        required_argument, 0, OPT_ID_URL},
-    {"debug",        no_argument,       0, OPT_ID_DEBUG},
+    {"upload",             no_argument,       0, OPT_ID_UPLOAD},
+    {"download",           no_argument,       0, OPT_ID_DOWNLOAD},
+    {"settings",           no_argument,       0, OPT_ID_SETTINGS},
+    {"reconnect-dl",       no_argument,       0, OPT_ID_RECONNECT_DL},
+    {"no-error-reporting", no_argument,       0, OPT_ID_NO_ERROR_REPORTING},
+    {"file",               required_argument, 0, OPT_ID_FILE},
+    {"url  ",              required_argument, 0, OPT_ID_URL},
+    {"debug",              no_argument,       0, OPT_ID_DEBUG},
     {0, 0, 0, 0},
   };
 
@@ -117,6 +120,11 @@ static int parse_options(int argc, char *argv[])
 
       case OPT_ID_DEBUG: {
         debug = true;
+      }
+      break;
+
+      case OPT_ID_NO_ERROR_REPORTING: {
+        no_error_reporting = true;
       }
       break;
 
@@ -164,6 +172,10 @@ static bool configure_libnetwork(network_context_t* ctx, int fd)
     goto exit_error;
   if ((status = libnetwork_set_debug(ctx, debug)) != NETWORK_STATUS_SUCCESS)
     goto exit_error;
+
+  if (no_error_reporting) {
+    libnetwork_report_errors(ctx, false);
+  }
 
   return true;
 

--- a/package/skylark_daemon/src/skylark_settings.c
+++ b/package/skylark_daemon/src/skylark_settings.c
@@ -35,6 +35,7 @@ static int skylark_upload_daemon_execfn(void) {
   char *argv[] = {
     "skylark_daemon",
     "--upload",
+    "--no-error-reporting",
     "--file", UPLOAD_FIFO_FILE_PATH,
     "--url", url,
     NULL,


### PR DESCRIPTION
Fix for https://swift-nav.atlassian.net/browse/DEVC-381 (Slow down skylark download/upload daemon warning message rate)

Rate limit error messages coming from the skylark/ntrip daemons (over SBP) to once every 10s, all errors are still sent to syslog.

DEVC-381 #comment PR ready for review: https://github.com/swift-nav/piksi_buildroot/pull/569.