### PR TITLE
[DEVC-336] Add ramdisk for update fileio and redirect current upgrades

### DIFF
--- a/board/piksiv3/device_table.txt
+++ b/board/piksiv3/device_table.txt
@@ -10,6 +10,7 @@
 /tmp					d	1777	0	0	-	-	-	-	-
 /etc					d	755	0	0	-	-	-	-	-
 /persistent				d	755	0	0	-	-	-	-	-
+/data					d	755	0	0	-	-	-	-	-
 /root					d	700	0	0	-	-	-	-	-
 /var/www				d	755	33	33	-	-	-	-	-
 /etc/shadow				f	600	0	0	-	-	-	-	-

--- a/board/piksiv3/rootfs-overlay/etc/fstab
+++ b/board/piksiv3/rootfs-overlay/etc/fstab
@@ -5,5 +5,6 @@ devpts		/dev/pts	devpts	defaults,gid=5,mode=620	0	0
 tmpfs		/dev/shm	tmpfs	mode=0777	0	0
 tmpfs		/tmp		tmpfs	mode=1777	0	0
 tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
+tmpfs		/data		tmpfs	mode=0755,nodev,size=40M	0	0
 sysfs		/sys		sysfs	defaults	0	0
 configfs	/sys/kernel/config	configfs	defaults	0	0

--- a/package/piksi_system_daemon/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/main.c
@@ -262,7 +262,7 @@ static void sbp_command(u16 sender_id, u8 len, u8 msg_[], void* context)
   struct shell_cmd_ctx *ctx = calloc(1, sizeof(*ctx));
   ctx->sequence = msg->sequence;
   ctx->pubsub_ctx = pubsub_ctx;
-  char *argv[] = {"upgrade_tool", "--debug", "upgrade.image_set.bin", NULL};
+  char *argv[] = {"upgrade_tool", "--debug", "/data/upgrade.image_set.bin", NULL};
   async_spawn(sbp_zmq_pubsub_zloop_get(ctx->pubsub_ctx),
               argv, command_output_cb, command_exit_cb, ctx, NULL);
 }


### PR DESCRIPTION
This addresses DEVC-336 by adding a tmpfs partition mounted as /data

Fileio daemon will inspect incoming fileio write requests and prefix the filepath with /data/ if the upgrade filepath is found ("upgrade.image_set.bin")