### PR TITLE
[DEVC-336] Add ramdisk for update fileio and redirect current upgrades [master]

### DIFF
--- a/board/piksiv3/device_table.txt
+++ b/board/piksiv3/device_table.txt
@@ -10,6 +10,7 @@
 /tmp					d	1777	0	0	-	-	-	-	-
 /etc					d	755	0	0	-	-	-	-	-
 /persistent				d	755	0	0	-	-	-	-	-
+/data					d	755	0	0	-	-	-	-	-
 /root					d	700	0	0	-	-	-	-	-
 /var/www				d	755	33	33	-	-	-	-	-
 /etc/shadow				f	600	0	0	-	-	-	-	-

--- a/board/piksiv3/rootfs-overlay/etc/fstab
+++ b/board/piksiv3/rootfs-overlay/etc/fstab
@@ -5,5 +5,6 @@ devpts		/dev/pts	devpts	defaults,gid=5,mode=620	0	0
 tmpfs		/dev/shm	tmpfs	mode=0777	0	0
 tmpfs		/tmp		tmpfs	mode=1777	0	0
 tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
+tmpfs		/data		tmpfs	mode=0755,nodev,size=40M	0	0
 sysfs		/sys		sysfs	defaults	0	0
 configfs	/sys/kernel/config	configfs	defaults	0	0


### PR DESCRIPTION
Add tmpfs located at /data to store upgrade image files without risk of running out of room

master PR for #573 

This should merge after #549 and remove any explicit creation of a /data directory