### PR TITLE
 Issue warning if skylark unhealthy and there's no fix [DEVC-369] [v1.5] 

### DIFF
--- a/package/health_daemon/health_daemon.mk
+++ b/package/health_daemon/health_daemon.mk
@@ -8,7 +8,7 @@ HEALTH_DAEMON_VERSION = 0.1
 HEALTH_DAEMON_SITE = \
   "${BR2_EXTERNAL_piksi_buildroot_PATH}/package/health_daemon/src"
 HEALTH_DAEMON_SITE_METHOD = local
-HEALTH_DAEMON_DEPENDENCIES = czmq libsbp libpiksi
+HEALTH_DAEMON_DEPENDENCIES = czmq libsbp libpiksi libnetwork libcurl
 
 define HEALTH_DAEMON_BUILD_CMDS
 	$(MAKE) CC=$(TARGET_CC) LD=$(TARGET_LD) -C $(@D) all

--- a/package/health_daemon/src/Makefile
+++ b/package/health_daemon/src/Makefile
@@ -1,6 +1,6 @@
 TARGET=health_daemon
-SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c glo_health_context.c
-LIBS=-lczmq -lsbp -lpiksi -lm
+SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c glo_health_context.c skylark_monitor.c
+LIBS=-lczmq -lsbp -lpiksi -lm -lnetwork -lcurl
 CFLAGS=-std=gnu11 -Wmissing-prototypes -Wconversion -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror
 
 CROSS=

--- a/package/health_daemon/src/health_daemon.c
+++ b/package/health_daemon/src/health_daemon.c
@@ -38,6 +38,7 @@
 #include "baseline_monitor.h"
 #include "glo_obs_monitor.h"
 #include "glo_bias_monitor.h"
+#include "skylark_monitor.h"
 
 #define PROGRAM_NAME "health_daemon"
 
@@ -73,7 +74,9 @@ static health_monitor_init_fn_pair_t health_monitor_init_pairs[] = {
   { glo_obs_timeout_health_monitor_init,
     glo_obs_timeout_health_monitor_deinit },
   { glo_bias_timeout_health_monitor_init,
-    glo_bias_timeout_health_monitor_deinit }
+    glo_bias_timeout_health_monitor_deinit },
+  { skylark_monitor_init,
+    skylark_monitor_deinit },
 };
 static size_t health_monitor_init_pairs_n =
   (sizeof(health_monitor_init_pairs) / sizeof(health_monitor_init_fn_pair_t));

--- a/package/health_daemon/src/skylark_monitor.c
+++ b/package/health_daemon/src/skylark_monitor.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**
+ * \file skylark_health_monitor.c
+ * \brief GLONASS Observations Health Monitor
+ *
+ * When glonass acquisition is enabled, it is expected that glonass obs
+ * measurements will be received periodically. This monitor will track
+ * base obs messages and inspect them for glonass observations, and
+ * subsequently alert after a specified time period if none are
+ * received. Will not alert when not connected to a base station (no base
+ * obs messages being received).
+ * \author Ben Altieri
+ * \version v1.4.0
+ * \date 2018-01-30
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libnetwork.h>
+
+#include <libpiksi/logging.h>
+#include <libpiksi/sbp_zmq_pubsub.h>
+
+#include <libsbp/sbp.h>
+#include <libsbp/navigation.h>
+
+#include "health_monitor.h"
+#include "skylark_monitor.h"
+
+#define SKYLARK_ALERT_RATE_LIMIT (5000u) /*ms*/
+#define NO_FIX (0)
+
+static health_monitor_t* skylark_monitor;
+static bool no_fix = true;
+
+static bool skylark_enabled() {
+
+  FILE* fp = fopen("/var/run/skylark/enabled", "r");
+  char buf[1] = {0};
+
+  (void) fread(buf, sizeof(buf), 1, fp);
+
+  if (buf[0] != '1')
+    return false;
+
+  return true;
+}
+
+static int sbp_msg_pos_llh_callback(health_monitor_t *monitor,
+                                    u16 sender_id,
+                                    u8 len,
+                                    u8 msg_[],
+                                    void *ctx)
+{
+  (void)monitor;
+  (void)sender_id;
+  (void)len;
+  (void)ctx;
+
+  msg_pos_llh_t *pos = (msg_pos_llh_t*)msg_;
+  if (pos->flags != NO_FIX) {
+    no_fix = false;
+    return 0;
+  }
+
+  no_fix = true;
+  return 1;
+}
+
+static int skylark_timer_callback(health_monitor_t *monitor, void *context)
+{
+  (void)monitor;
+  (void)context;
+
+  if (!no_fix) {
+    return 0;
+  }
+
+  if (!skylark_enabled()) {
+    piksi_log(LOG_DEBUG, "%s: skylark is not enabled", __FUNCTION__);
+    return 0;
+  }
+
+  int status = 0;
+  network_status_t req_status = libnetwork_request_health(SKYLARK_CONTROL_PAIR, &status);
+
+  if(NETWORK_STATUS_SUCCESS != req_status) {
+    piksi_log(LOG_WARNING, "%s: error requesting skylark health status: %d", __FUNCTION__, status);
+    return 0;
+  }
+
+  piksi_log(LOG_DEBUG, "%s: skylark health status code: %d", __FUNCTION__, status);
+
+  if (status != 404 && status != 504)
+    return 0;
+
+  sbp_log(LOG_WARNING, "Skylark Correction Service - the service cannot function without position fix");
+
+  return 0;
+}
+
+int skylark_monitor_init(health_ctx_t *health_ctx)
+{
+  skylark_monitor = health_monitor_create();
+  if (skylark_monitor == NULL) {
+    piksi_log(LOG_DEBUG, "%s: failed to create health monitor context", __FUNCTION__);
+    return -1;
+  }
+
+  if (health_monitor_init(skylark_monitor,
+                          health_ctx,
+                          SBP_MSG_POS_LLH,
+                          sbp_msg_pos_llh_callback,
+                          SKYLARK_ALERT_RATE_LIMIT,
+                          skylark_timer_callback,
+                          NULL)
+      != 0) {
+    piksi_log(LOG_DEBUG, "%s: failed to initialize health monitor", __FUNCTION__);
+    return -1;
+  }
+
+  return 0;
+}
+
+void skylark_monitor_deinit(void)
+{
+  if (skylark_monitor != NULL) {
+    health_monitor_destroy(&skylark_monitor);
+  }
+}

--- a/package/health_daemon/src/skylark_monitor.c
+++ b/package/health_daemon/src/skylark_monitor.c
@@ -39,8 +39,10 @@
 #include "health_monitor.h"
 #include "skylark_monitor.h"
 
-#define SKYLARK_ALERT_RATE_LIMIT (5000u) /*ms*/
+#define SKYLARK_ALERT_RATE_LIMIT (10000u) /*ms*/
 #define NO_FIX (0)
+
+//#define DEBUG_SKYLARK_MONITOR
 
 static health_monitor_t* skylark_monitor;
 static bool no_fix = true;
@@ -89,7 +91,9 @@ static int skylark_timer_callback(health_monitor_t *monitor, void *context)
   }
 
   if (!skylark_enabled()) {
+#ifdef DEBUG_SKYLARK_MONITOR
     piksi_log(LOG_DEBUG, "%s: skylark is not enabled", __FUNCTION__);
+#endif
     return 0;
   }
 
@@ -97,11 +101,15 @@ static int skylark_timer_callback(health_monitor_t *monitor, void *context)
   network_status_t req_status = libnetwork_request_health(SKYLARK_CONTROL_PAIR, &status);
 
   if(NETWORK_STATUS_SUCCESS != req_status) {
+#ifdef DEBUG_SKYLARK_MONITOR
     piksi_log(LOG_WARNING, "%s: error requesting skylark health status: %d", __FUNCTION__, status);
+#endif
     return 0;
   }
 
+#ifdef DEBUG_SKYLARK_MONITOR
   piksi_log(LOG_DEBUG, "%s: skylark health status code: %d", __FUNCTION__, status);
+#endif
 
   if (status != 404 && status != 504)
     return 0;
@@ -115,7 +123,7 @@ int skylark_monitor_init(health_ctx_t *health_ctx)
 {
   skylark_monitor = health_monitor_create();
   if (skylark_monitor == NULL) {
-    piksi_log(LOG_DEBUG, "%s: failed to create health monitor context", __FUNCTION__);
+    piksi_log(LOG_WARING, "%s: failed to create health monitor context", __FUNCTION__);
     return -1;
   }
 
@@ -127,7 +135,7 @@ int skylark_monitor_init(health_ctx_t *health_ctx)
                           skylark_timer_callback,
                           NULL)
       != 0) {
-    piksi_log(LOG_DEBUG, "%s: failed to initialize health monitor", __FUNCTION__);
+    piksi_log(LOG_WARNING, "%s: failed to initialize health monitor", __FUNCTION__);
     return -1;
   }
 

--- a/package/health_daemon/src/skylark_monitor.c
+++ b/package/health_daemon/src/skylark_monitor.c
@@ -10,21 +10,6 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-/**
- * \file skylark_health_monitor.c
- * \brief GLONASS Observations Health Monitor
- *
- * When glonass acquisition is enabled, it is expected that glonass obs
- * measurements will be received periodically. This monitor will track
- * base obs messages and inspect them for glonass observations, and
- * subsequently alert after a specified time period if none are
- * received. Will not alert when not connected to a base station (no base
- * obs messages being received).
- * \author Ben Altieri
- * \version v1.4.0
- * \date 2018-01-30
- */
-
 #include <stdlib.h>
 #include <string.h>
 
@@ -49,7 +34,7 @@ static bool no_fix = true;
 
 static bool skylark_enabled() {
 
-  FILE* fp = fopen("/var/run/skylark/enabled", "r");
+  FILE* fp = fopen("/var/run/skylark_enabled", "r");
   char buf[1] = {0};
 
   (void) fread(buf, sizeof(buf), 1, fp);
@@ -123,7 +108,7 @@ int skylark_monitor_init(health_ctx_t *health_ctx)
 {
   skylark_monitor = health_monitor_create();
   if (skylark_monitor == NULL) {
-    piksi_log(LOG_WARING, "%s: failed to create health monitor context", __FUNCTION__);
+    piksi_log(LOG_WARNING, "%s: failed to create health monitor context", __FUNCTION__);
     return -1;
   }
 

--- a/package/health_daemon/src/skylark_monitor.h
+++ b/package/health_daemon/src/skylark_monitor.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef __HEALTH_MONITOR_SKYLARK_H
+#define __HEALTH_MONITOR_SKYLARK_H
+
+int skylark_monitor_init(health_ctx_t *health_ctx);
+void skylark_monitor_deinit(void);
+
+#endif /* __HEALTH_MONITOR_SKYLARK_H */

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -31,13 +31,14 @@
 
 #include "libnetwork.h"
 
+#define DEBUG_LIBNETWORK
+
 /** Maximum length of username string */
 #define LIBNETWORK_USERNAME_MAX_LENGTH (512L)
 /** Maximum length of password string */
 #define LIBNETWORK_PASSWORD_MAX_LENGTH (512L)
 /** Maximum length of url string */
 #define LIBNETWORK_URL_MAX_LENGTH (4096L)
-
 
 /** How large to configure the recv buffer to avoid excessive buffering. */
 const long RECV_BUFFER_SIZE = 4096L;
@@ -54,6 +55,21 @@ const double PIPE_WARN_SECS = 5;
 const time_t ERROR_REPORTING_INTERVAL = 10;
 
 typedef struct context_node context_node_t;
+
+typedef struct {
+
+  bool configured;
+
+  int req_fd;
+  int rep_fd;
+
+  int req_read_fd;
+  int rep_write_fd;
+
+  char req_path[PATH_MAX];
+  char rep_path[PATH_MAX];
+
+} fifo_info_t;
 
 struct network_context_s {
 
@@ -79,12 +95,14 @@ struct network_context_s {
 
   context_node_t* node;
 
-  bool report_errors;          /**< Should this instance of libnetwork report errors? */
-  time_t last_curl_error_time; /**< Time at which we last issued a cURL error message */
+  bool report_errors;           /**< Should this instance of libnetwork report errors? */
+  time_t last_curl_error_time;  /**< Time at which we last issued a cURL error message */
 
   char username[LIBNETWORK_USERNAME_MAX_LENGTH];
   char password[LIBNETWORK_PASSWORD_MAX_LENGTH];
   char url[LIBNETWORK_URL_MAX_LENGTH];
+
+  fifo_info_t control_fifo_info;
 };
 
 struct context_node {
@@ -116,6 +134,15 @@ static network_context_t empty_context = {
   .username = "",
   .password = "",
   .url = "",
+  .control_fifo_info = {
+    .configured = false,
+    .req_fd = -1,
+    .rep_fd = -1,
+    .req_read_fd = -1,
+    .rep_write_fd = -1,
+    .req_path = "",
+    .rep_path = "",
+  },
 };
 
 #define NMEA_GGA_FILE "/var/run/nmea_GGA"
@@ -144,6 +171,94 @@ void libnetwork_report_errors(network_context_t *ctx, bool yesno)
   ctx->report_errors = yesno;
 }
 
+network_status_t libnetwork_configure_control(network_context_t *ctx, control_pair_t control_pair)
+{
+  unlink(control_pair.req_fifo_name);
+  unlink(control_pair.rep_fifo_name);
+
+  mode_t umask_previous = umask(0);
+  int req_fd = mkfifo(control_pair.req_fifo_name, 0777);
+  if (req_fd < 0) {
+    piksi_log(LOG_ERR, "error opening request FIFO (%s) (error: %d) \"%s\"", control_pair.req_fifo_name, errno, strerror(errno));
+    umask(umask_previous);
+    return NETWORK_STATUS_FIFO_ERROR;
+  }
+
+  int rep_fd = mkfifo(control_pair.rep_fifo_name, 0777);
+  if (rep_fd < 0) {
+    piksi_log(LOG_ERR, "error opening response FIFO (%s) (error: %d) \"%s\"", control_pair.rep_fifo_name, errno, strerror(errno));
+    close(req_fd);
+    umask(umask_previous);
+    return NETWORK_STATUS_FIFO_ERROR;
+  }
+
+  umask(umask_previous);
+
+  ctx->control_fifo_info.configured = true;
+
+  ctx->control_fifo_info.req_fd = req_fd;
+  ctx->control_fifo_info.rep_fd = rep_fd;
+
+  strncpy(ctx->control_fifo_info.req_path, control_pair.req_fifo_name, sizeof(ctx->control_fifo_info.req_path));
+  strncpy(ctx->control_fifo_info.rep_path, control_pair.rep_fifo_name, sizeof(ctx->control_fifo_info.rep_path));
+
+  return NETWORK_STATUS_SUCCESS;
+}
+
+network_status_t libnetwork_request_health(control_pair_t control_pair, int *status)
+{
+  int req_fd = -1;
+  int rep_fd = -1;
+
+  network_status_t return_status = NETWORK_STATUS_SUCCESS;
+
+  req_fd = open(control_pair.req_fifo_name, O_WRONLY);
+  if (req_fd < 0) {
+    piksi_log(LOG_ERR, "request fifo error (%d) \"%s\"", errno, strerror(errno));
+    return_status = NETWORK_STATUS_FIFO_ERROR;
+    goto libnetwork_request_health_exit;
+  }
+
+  int wc = write(req_fd, CONTROL_COMMAND_STATUS, 1);
+  if (wc <= 0) {
+    return_status = NETWORK_STATUS_WRITE_ERROR;
+    goto libnetwork_request_health_exit;
+  }
+
+  close(req_fd);
+
+  rep_fd = open(control_pair.rep_fifo_name, O_RDONLY);
+  if (rep_fd < 0) {
+    piksi_log(LOG_ERR, "response fifo error (%d) \"%s\"", errno, strerror(errno));
+    return_status = NETWORK_STATUS_FIFO_ERROR;
+    goto libnetwork_request_health_exit;
+  }
+
+  char response_buf[4] = { 0 };
+  int rc = read(rep_fd, response_buf, sizeof(response_buf) - 1);
+  if (rc <= 0) {
+    return_status = NETWORK_STATUS_READ_ERROR;
+    goto libnetwork_request_health_exit;
+  }
+
+  close(rep_fd);
+
+  long response = strtol(response_buf, NULL, 10);
+  if (response < 0) {
+    piksi_log(LOG_WARNING, "%s: error requesting skylark HTTP response code: %d", __FUNCTION__, response);
+  }
+
+  if (status != NULL) {
+    *status = (int) response;
+  }
+
+ libnetwork_request_health_exit:
+  close(rep_fd);
+  close(req_fd);
+
+  return return_status;
+}
+
 network_context_t* libnetwork_create(network_type_t type)
 {
   context_node_t* node = malloc(sizeof(context_node_t));
@@ -163,8 +278,22 @@ network_context_t* libnetwork_create(network_type_t type)
 void libnetwork_destroy(network_context_t **ctx)
 {
   LIST_REMOVE((*ctx)->node, entries);
-  free(*ctx);
 
+  int* fd_list[] = {
+    &(*ctx)->control_fifo_info.req_fd,
+    &(*ctx)->control_fifo_info.req_read_fd,
+    &(*ctx)->control_fifo_info.rep_fd,
+    &(*ctx)->control_fifo_info.rep_write_fd,
+  };
+
+  for (size_t x = 0; x < COUNT_OF(fd_list); x++) {
+    if (*fd_list[x] < 0)
+      continue;
+    close(*fd_list[x]);
+    *fd_list[x] = -1;
+  }
+
+  free(*ctx);
   *ctx = NULL;
 }
 
@@ -389,11 +518,77 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
   return obj_count*size;
 }
 
+static void service_control_fifo(network_context_t *ctx)
+{
+  if (!ctx->control_fifo_info.configured) {
+    return;
+  }
+
+  long response_code = 0;
+  curl_easy_getinfo(ctx->curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+  if (response_code == 0) {
+    if (ctx->response_code != 0) {
+      // Return the most recent response code
+      response_code = ctx->response_code;
+    }
+  }
+
+  if (ctx->control_fifo_info.req_read_fd < 0) {
+    ctx->control_fifo_info.req_read_fd = open(ctx->control_fifo_info.req_path, O_RDONLY|O_NONBLOCK);
+    if (ctx->control_fifo_info.req_read_fd < 0) {
+      piksi_log(LOG_WARNING, "%s: error opening request FIFO: %s (%d)", __FUNCTION__, strerror(errno), errno);
+      return;
+    }
+  }
+
+  char cmd[1] = { 0 };
+  ssize_t rc = read(ctx->control_fifo_info.req_read_fd, cmd, sizeof(cmd));
+  if (rc <= 0) {
+    if (rc < 0 && errno != EAGAIN) {
+      piksi_log(LOG_WARNING, "%s: error reading from FIFO: %s (%d)", __FUNCTION__, strerror(errno), errno);
+    }
+    return;
+  }
+
+#ifdef DEBUG_LIBNETWORK
+  piksi_log(LOG_DEBUG, "%s: got command '%c'", __FUNCTION__, cmd[0]);
+#endif
+
+  char status_buf[4] = " -1";
+
+  if (cmd[0] != CONTROL_COMMAND_STATUS[0]) {
+    piksi_log(LOG_WARNING, "%s: received invalid command '%c'", __FUNCTION__, cmd[0]);
+  }
+
+  if (ctx->control_fifo_info.rep_write_fd < 0) {
+    ctx->control_fifo_info.rep_write_fd = open(ctx->control_fifo_info.rep_path, O_WRONLY);
+    if (ctx->control_fifo_info.rep_write_fd < 0) {
+      piksi_log(LOG_WARNING, "%s: error opening response FIFO: %s (%d)", __FUNCTION__, strerror(errno), errno);
+      return;
+    }
+  }
+
+  size_t c = snprintf(status_buf, sizeof(status_buf), "%03ld", response_code);
+#ifdef DEBUG_LIBNETWORK
+  piksi_log(LOG_DEBUG, "%s: HTTP response code: %d", __FUNCTION__, response_code);
+#endif
+  if (c >= sizeof(status_buf)) {
+    piksi_log(LOG_WARNING, "%s: HTTP response code too large: %d", __FUNCTION__, response_code);
+  }
+  ssize_t wc = write(ctx->control_fifo_info.rep_write_fd, status_buf, sizeof(status_buf) - 1);
+  if (wc < 0) {
+    piksi_log(LOG_WARNING, "%s: error writing to FIFO: %d", __FUNCTION__, strerror(errno));
+  }
+}
+
 /**
  * Abort the connection if we make no progress for the last 30 intervals
  */
 static int network_progress_check(network_context_t *ctx, curl_off_t bytes)
 {
+  service_control_fifo(ctx);
+
   if (ctx->shutdown_signaled) {
     ctx->stall_count = 0;
     return -1;
@@ -574,8 +769,16 @@ static void network_request(network_context_t* ctx, CURL *curl)
     if (ctx->shutdown_signaled)
       return;
 
-    if (code == CURLE_ABORTED_BY_CALLBACK)
+    if (code == CURLE_ABORTED_BY_CALLBACK) {
+#ifdef LIBNETWORK_DEBUG
+      piksi_log(LOG_DEBUG, "cURL aborted by callback");
+#endif
       continue;
+    }
+
+    long response = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
+    ctx->response_code = response;
 
     if (code != CURLE_OK) {
       time_t current_time = time(NULL);
@@ -587,11 +790,8 @@ static void network_request(network_context_t* ctx, CURL *curl)
       }
       piksi_log(facpri, "curl request (error: %d) \"%s\"", code, error_buf);
     } else {
-      long response = 0;
-      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
       if (response != 0) {
         piksi_log(LOG_SBP|LOG_INFO, "curl request code %d", response);
-        ctx->response_code = response;
         network_response_code_check(ctx);
       }
     }

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -31,7 +31,7 @@
 
 #include "libnetwork.h"
 
-#define DEBUG_LIBNETWORK
+//#define DEBUG_LIBNETWORK
 
 /** Maximum length of username string */
 #define LIBNETWORK_USERNAME_MAX_LENGTH (512L)

--- a/package/libnetwork/src/libnetwork.h
+++ b/package/libnetwork/src/libnetwork.h
@@ -24,8 +24,8 @@
 
 #include <stdbool.h>
 
-#define SKYLARK_REQ_FIFO_NAME "/var/run/skylark/control/dl.req"
-#define SKYLARK_REP_FIFO_NAME "/var/run/skylark/control/dl.resp"
+#define SKYLARK_REQ_FIFO_NAME "/var/run/skylark_dl.req"
+#define SKYLARK_REP_FIFO_NAME "/var/run/skylark_dl.resp"
 
 typedef struct {
   const char* req_fifo_name;

--- a/package/libnetwork/src/libnetwork.h
+++ b/package/libnetwork/src/libnetwork.h
@@ -24,6 +24,18 @@
 
 #include <stdbool.h>
 
+#define SKYLARK_REQ_FIFO_NAME "/var/run/skylark/control/dl.req"
+#define SKYLARK_REP_FIFO_NAME "/var/run/skylark/control/dl.resp"
+
+typedef struct {
+  const char* req_fifo_name;
+  const char* rep_fifo_name;
+} control_pair_t;
+
+#define SKYLARK_CONTROL_PAIR (control_pair_t){ SKYLARK_REQ_FIFO_NAME, SKYLARK_REP_FIFO_NAME }
+
+#define CONTROL_COMMAND_STATUS "s"
+
 typedef struct network_context_s network_context_t;
 
 /**
@@ -40,11 +52,14 @@ typedef enum {
  * @brief   Error type
  */
 typedef enum {
-  NETWORK_STATUS_INVALID_SETTING    = -1, /** < The setting is invalid for this type */
-  NETWORK_STATUS_URL_TOO_LARGE      = -2, /** < The URL specified is too large       */
-  NETWORK_STATUS_USERNAME_TOO_LARGE = -3, /** < The username specified is too large  */
-  NETWORK_STATUS_PASSWORD_TOO_LARGE = -4, /** < The password specified is too large  */
-  NETWORK_STATUS_SUCCESS            = 0,  /** < The operation was successful         */
+  NETWORK_STATUS_INVALID_SETTING    = -1, /** < The setting is invalid for this type   */
+  NETWORK_STATUS_URL_TOO_LARGE      = -2, /** < The URL specified is too large         */
+  NETWORK_STATUS_USERNAME_TOO_LARGE = -3, /** < The username specified is too large    */
+  NETWORK_STATUS_PASSWORD_TOO_LARGE = -4, /** < The password specified is too large    */
+  NETWORK_STATUS_FIFO_ERROR         = -5, /** < There was an error creating a FIFO     */
+  NETWORK_STATUS_WRITE_ERROR        = -6, /** < There was an error writing to a FIFO   */
+  NETWORK_STATUS_READ_ERROR         = -7, /** < There was an error reading from a FIFO */
+  NETWORK_STATUS_SUCCESS            =  0,  /** < The operation was successful          */
 } network_status_t;
 
 /**
@@ -169,5 +184,15 @@ void libnetwork_cycle_connection(void);
  * @brief Configures whether libnetwork should report errors (defaults to true).
  */
 void libnetwork_report_errors(network_context_t *ctx, bool yesno);
+
+/**
+ * @brief Configures the request and response control FIFOs
+ */
+network_status_t libnetwork_configure_control(network_context_t *ctx, control_pair_t control_pair);
+
+/**
+ * @brief Configures the request and response control FIFOs
+ */
+network_status_t libnetwork_request_health(control_pair_t control_pair, int *status);
 
 #endif /* SWIFTNAV_LIBNETWORK_H */


### PR DESCRIPTION
## Overview

+ Implement a simple control pipe for the skylark download daemon that allows us to get the most recent HTTP response code from the Skylark service.

+ Add a `skylark_monitor` to the `health_daemon` that looks at the POS_LLH message and checks for a "no fix" messages (that is, the message `flags` are 0).  A warning is issue every 10 seconds under the following conditions: (1) skylark is enabled; (2) there's no fix; and (3) Skylark is returning a 404 or 504 error code.

The wrinkle in this is the Skylark service tends to wait for an extended period of time before it returns a response code, so this warning check will likely take 30-40 seconds before it shows up.

## Bench testing

+ Disconnected the device antenna and removed device from the Skylark service (then re-added) so that it simulates a device a that's never connected to Skylark (e.g. recently whitelisted and never connected).  Skylark will issue a 404 error code and the device will eventually issue a warning: `Skylark Correction Service - the service cannot function without position fix`.

+ Similar to the above, but re-connecting to the service after previously successfully connecting-- the device will receive a 504 error code, and eventually issue the above error code.