### PR TITLE
Fix the --no-error-reporting switch

### DIFF
--- a/package/skylark_upload_daemon/src/skylark_upload_daemon.c
+++ b/package/skylark_upload_daemon/src/skylark_upload_daemon.c
@@ -48,7 +48,7 @@ static int parse_options(int argc, char *argv[])
   const struct option long_opts[] = {
     {"file",               required_argument, 0, OPT_ID_FILE},
     {"url",                required_argument, 0, OPT_ID_URL},
-    {"no-error-reporting", required_argument, 0, OPT_ID_NO_ERROR_REPORTING},
+    {"no-error-reporting", no_argument,       0, OPT_ID_NO_ERROR_REPORTING},
     {"debug",              no_argument,       0, OPT_ID_DEBUG},
     {0, 0, 0, 0},
   };


### PR DESCRIPTION
Accidentally made the new `--no-error-reporting` switch require an argument, fix this.

Bench testing: verified that Skylark upload daemon works again.