### PR TITLE
Fix usb_upgrade return code issue (DEVC-428)

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/usb_upgrade.sh
@@ -3,6 +3,13 @@
 export FIRMWARE="/media/sda*/PiksiMulti-*.bin"
 export LOGLEVEL="--warn"
 
+UT_RET=UPGRADE_ERROR_UNKNOWN,UPGRADE_ERROR_OPTIONS
+UT_RET=${UT_RET},UPGRADE_ERROR_IN_PROGRESS,UPGRADE_ERROR_PART_INFO_POP
+UT_RET=${UT_RET},UPGRADE_ERROR_PART_INFO_VERIFY,UPGRADE_ERROR_TARGET_PARAMS_GET
+UT_RET=${UT_RET},UPGRADE_ERROR_DATA_LOAD,UPGRADE_ERROR_DATA_VERIFY,UPGRADE_ERROR_FACTORY_DATA
+UT_RET=${UT_RET},UPGRADE_ERROR_INVALID_HARDWARE,UPGRADE_ERROR_IMAGE_TABLE
+UT_RET=${UT_RET},UPGRADE_ERROR_IMAGE_POPULATE,UPGRADE_ERROR_UPGRADE_INSTALL
+
 _dir_wait () {
     [[ $# -lt 3 ]] && {
         echo "Usage: ${FUNCNAME} <num_timeout> <len_timeout_ms> <path>"; return 1
@@ -39,8 +46,10 @@ echo "Performing upgrade..."
 # Killing monit and USB logger
 monit stop standalone_file_logger
 monit stop zmq_adapter_rpmsg_piksi100
-upgrade_tool $FIRMWARE | sbp_log $LOGLEVEL
+upgrade_tool_output=$(upgrade_tool $FIRMWARE) 
 RETVAL=$?
+echo $upgrade_tool_output | sbp_log $LOGLEVEL
+echo $upgrade_tool_output
 umount /media/sda1
 sync
 if [ $RETVAL -eq 0 ]; then
@@ -52,8 +61,8 @@ if [ $RETVAL -eq 0 ]; then
 fi
 if [ $RETVAL -ne 0 ]; then
   while [ 1 ]; do
-    echo "ERROR: Upgrade was unsuccessful. Please verify the image and try again."  | sbp_log $LOGLEVEL
-    echo "ERROR: Upgrade was unsuccessful. Please verify the image and try again."
+    echo "$(echo ${UT_RET} | cut -d',' -f$RETVAL): Upgrade was unsuccessful. Please verify the image and try again."  | sbp_log $LOGLEVEL
+    echo "$(echo ${UT_RET} | cut -d',' -f$RETVAL): Upgrade was unsuccessful. Please verify the image and try again."
     sleep 1
   done
 fi


### PR DESCRIPTION
should fix DEVC-428 and provide more informative user output if the image is corrupt or similar.  

The crux of the issue was using $? to try and get upgrade_tool return code after piping through sbp_log, which gives you return code from sbp_log instead of upgrade_tool

The cut thing is a little hacky but I think it's better than other ways to have a lookup table of strings for return codes