### PR TITLE
[DEVC-559] Hotfix: cellmodem dev override setting

### DIFF
--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.c
@@ -31,12 +31,16 @@
 #include "cellmodem_inotify.h"
 #include "async-child.h"
 
+#define CELLMODEM_DEV_OVERRIDE_DEFAULT "ttyACM0"
+
 static enum modem_type modem_type = MODEM_TYPE_GSM;
 static char *cellmodem_dev;
+
 /* External settings */
 static char cellmodem_apn[32] = "hologram";
 static bool cellmodem_enabled;
 static bool cellmodem_debug;
+static char cellmodem_dev_override[PATH_MAX] = CELLMODEM_DEV_OVERRIDE_DEFAULT;
 static int cellmodem_pppd_pid;
 
 static int cellmodem_notify(void *context);
@@ -109,6 +113,11 @@ int pppd_respawn(zloop_t *loop, int timer_id, void *arg)
   return 0;
 }
 
+char * cellmodem_get_dev_override(void)
+{
+  return strlen(cellmodem_dev_override) == 0 ? NULL : cellmodem_dev_override;
+}
+
 static void pppd_exit_callback(int status, void *arg)
 {
   sbp_zmq_pubsub_ctx_t *pubsub_ctx = arg;
@@ -175,6 +184,9 @@ int cellmodem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ct
                     cellmodem_notify, pubsub_ctx);
   settings_register(settings_ctx, "cell_modem", "debug", &cellmodem_debug,
                     sizeof(cellmodem_debug), SETTINGS_TYPE_BOOL,
+                    NULL, NULL);
+  settings_register(settings_ctx, "cell_modem", "device_override", &cellmodem_dev_override,
+                    sizeof(cellmodem_dev_override), SETTINGS_TYPE_STRING,
                     NULL, NULL);
   async_wait_for_tty(pubsub_ctx);
   return 0;

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.h
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.h
@@ -23,6 +23,7 @@ enum modem_type {
 
 int cellmodem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ctx);
 void cellmodem_set_dev(sbp_zmq_pubsub_ctx_t *pubsub_ctx, char *dev, enum modem_type type);
+char * cellmodem_get_dev_override(void);
 int pppd_respawn(zloop_t *loop, int timer_id, void *arg);
 
 #endif

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_inotify.h
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_inotify.h
@@ -13,7 +13,10 @@
 #ifndef _SWIFT_CELLMODEM_INOTIFY_H
 #define _SWIFT_CELLMODEM_INOTIFY_H
 
+typedef struct inotify_ctx_s inotify_ctx_t;
 bool cellmodem_tty_exists(const char* path);
-void async_wait_for_tty(sbp_zmq_pubsub_ctx_t *pubsub_ctx);
+void cellmodem_scan_for_modem(inotify_ctx_t *ctx);
+void cellmodem_set_dev_to_invalid(inotify_ctx_t *ctx);
+inotify_ctx_t * async_wait_for_tty(sbp_zmq_pubsub_ctx_t *pubsub_ctx);
 
 #endif//_SWIFT_CELLMODEM_INOTIFY_H


### PR DESCRIPTION
To avoid collision between pppd and cell_modem_daemon in 1.5, a new settings has been added to override the device that piksi_system_daemon tries to use in order to connect with the cell modem daemon.

This setting can be changed during operation, but only if the cell modem is disabled first. It will then set the desired override (blank string meaning previous scan behavior) and manually reset and rescan the modem routine.