### PR TITLE
[DEVC-590] Add retry loop for initial AT command probe to candidate modem ttys

### DIFF
--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.h
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.h
@@ -13,6 +13,7 @@
 #ifndef __CELLMODEM_H
 #define __CELLMODEM_H
 
+#include <libpiksi/sbp_zmq_pubsub.h>
 #include <libpiksi/settings.h>
 
 enum modem_type {

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_inotify.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_inotify.c
@@ -70,7 +70,7 @@ static int update_dev_from_probe(inotify_ctx_t *ctx, char *dev)
   if (dev_override != NULL && strcmp(dev_override, dev) != 0) {
     return 1;
   }
-  ctx->modem_type = cellmodem_probe(dev, ctx->pubsub_ctx);
+  ctx->modem_type = cellmodem_probe(dev);
   if (ctx->modem_type != MODEM_TYPE_INVALID) {
     ctx->cellmodem_dev = strdup(dev);
     cellmodem_set_dev(ctx->pubsub_ctx, ctx->cellmodem_dev , ctx->modem_type );

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_probe.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_probe.c
@@ -166,8 +166,7 @@ enum modem_type cellmodem_probe(const char *dev)
       close(fd);
       return MODEM_TYPE_INVALID;
     }
-    piksi_log(LOG_INFO, "Modem %s: %s", c->display, r);
-    sbp_log(LOG_INFO, "Modem %s: %s", c->display, r);
+    piksi_log(LOG_INFO|LOG_SBP, "Modem %s: %s", c->display, r);
   }
 
   /* Check for GSM/CDMA: Try GSM 'AT+CGDCONT?', ignore the response,

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_probe.h
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_probe.h
@@ -13,8 +13,6 @@
 #ifndef __CELLMODEM_PROBE_H
 #define __CELLMODEM_PROBE_H
 
-#include <libpiksi/sbp_zmq_pubsub.h>
-
-enum modem_type cellmodem_probe(const char *dev, sbp_zmq_pubsub_ctx_t *pubsub_ctx);
+enum modem_type cellmodem_probe(const char *dev);
 
 #endif


### PR DESCRIPTION
Retries added to initial modem probe attempt in `cellmodem_probe.c`

Also removed manual sbp log routine which has been superseded by `sbp_log` from `libpiksi`