### PR TITLE
Add an explicit sync call to copy_sys_logs [DEVC-585] [master]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/copy_sys_logs.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/copy_sys_logs.sh
@@ -37,9 +37,11 @@ log_dir="$MOUNTPOINT/logs"
 mkdir -p "$log_dir"
 
 N=0
-while [[ -d "$log_dir/$N" ]] ; do
+while [[ -d "$log_dir/$N" ]]; do
   N=$(($N+1))
 done
+
+log_dir_n="$log_dir/$N"
 
 cleanup_rsync()
 {
@@ -48,11 +50,12 @@ cleanup_rsync()
 
 trap 'cleanup_loggers; cleanup_rsync; exit 0' EXIT TERM INT
 
-mkdir "$log_dir/$N"
+mkdir "$log_dir_n"
 
 while true; do
-  rsync --exclude=tmp.* -r /var/log/ "$log_dir/$N/" &
+  rsync --exclude=tmp.* -r /var/log/ "$log_dir_n" &
   rsync_pid=$!
   wait "$rsync_pid"
+  sync "$log_dir_n"
   sleep 1
 done

--- a/board/piksiv3/rootfs-overlay/etc/init.d/copy_sys_logs.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/copy_sys_logs.sh
@@ -36,12 +36,14 @@ fi
 log_dir="$MOUNTPOINT/logs"
 mkdir -p "$log_dir"
 
-N=0
-while [[ -d "$log_dir/$N" ]]; do
+N=1
+while true; do
+  log_dir_n="$log_dir/$(printf '%04d' $N)"
+  if ! [[ -d "$log_dir_n" ]]; then
+    break;
+  fi
   N=$(($N+1))
 done
-
-log_dir_n="$log_dir/$N"
 
 cleanup_rsync()
 {

--- a/board/piksiv3/rootfs-overlay/etc/init.d/sdcard.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/sdcard.sh
@@ -4,7 +4,7 @@ MOUNTPOINT="$MOUNT_BASE/$MOUNTNAME"
 
 is_mounted()
 {
-    grep -q $MOUNTPOINT /proc/mounts
+  grep -q $MOUNTPOINT /proc/mounts
 }
 
 inotify_wait_mountpoint()


### PR DESCRIPTION
This ensures that data actually makes it to the disk in the event of a
power failure.  For DEVC-585 we were seeing that a new directory was not
getting created in the event of a power cycle.  A new directory was
getting created, it was just the same as the one from the previous boot
because the data was never sync'd to the device.