### PR TITLE
Add more sophisticated facilities for terminating pppd/chat, fix crashes in capturing output [DEVC-560]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -6,48 +6,7 @@ lib_output_path="/lib/firmware"
 persistent_output_path="/persistent"
 script_path="/root"
 
-copy_from_sd() {
-  local sd_path=$1
-  local filename=$2
-  local output_path=$3
-  local sd_file="$sd_path/$filename"
-  local output_file="$output_path/$filename"
-
-  if [ -f "$sd_file" ]; then
-    rm -f "$output_file"
-    echo "Copying $filename from SD card"
-    mkdir -p "$output_path"
-    cp "$sd_file" "$output_file"
-
-    if [ ! -f "$output_file" ]; then
-      echo "ERROR: copy failed for $output_file"
-    fi
-  fi
-}
-
-copy_from_net() {
-  local server_ip=$1
-  local filename=$2
-  local output_path=$3
-  local uuid=`cat /factory/uuid`
-  local net_file="PK$uuid/$filename"
-  local output_file="$output_path/$filename"
-  local tmp_file="/tmp/$filename"
-
-  echo "Retrieving $filename from network"
-  tftp -g -r "$net_file" -l "$tmp_file" -b 65464 "$server_ip"
-
-  if [ -f "$tmp_file" ]; then
-    rm -f "$output_file"
-    echo "Copying $filename from network"
-    mkdir -p "$output_path"
-    cp "$tmp_file" "$output_file"
-
-    if [ ! -f "$output_file" ]; then
-      echo "ERROR: copy failed for $output_file"
-    fi
-  fi
-}
+source /etc/init.d/copy_from.sh
 
 start() {
   # Get 'dev_boot' bootarg
@@ -104,7 +63,8 @@ start() {
   # Run custom script if present
   if [ -f "$script_path/init_script.sh" ]; then
     echo "Running init_script.sh"
-    sh "$script_path/init_script.sh"
+    SERVER_IP=$server_ip SD_PATH=$sd_path \
+      sh "$script_path/init_script.sh"
   fi
 }
 

--- a/board/piksiv3/rootfs-overlay/etc/init.d/copy_from.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/copy_from.sh
@@ -1,0 +1,45 @@
+copy_from_sd()
+{
+  local sd_path=$1; shift
+  local filename=$1; shift
+  local output_path=$1; shift
+  local sd_file="$sd_path/$filename"
+  local output_file="$output_path/$filename"
+
+  if [ -f "$sd_file" ]; then
+    rm -f "$output_file"
+    echo "Copying $filename from SD card"
+    mkdir -p "$output_path"
+    cp "$sd_file" "$output_file"
+
+    if [ ! -f "$output_file" ]; then
+      echo "ERROR: copy failed for $output_file"
+    fi
+  fi
+}
+
+copy_from_net()
+{
+  local server_ip=$1; shift
+  local filename=$1; shift
+  local output_path=$1; shift
+  local uuid=`cat /factory/uuid`
+  local net_file="PK$uuid/$filename"
+  local output_file="$output_path/$filename"
+  local tmp_file="/tmp/$filename"
+
+  echo "Retrieving $filename from network"
+  tftp -g -r "$net_file" -l "$tmp_file" -b 65464 "$server_ip"
+
+  if [ -f "$tmp_file" ]; then
+    rm -f "$output_file"
+    echo "Copying $filename from network"
+    mkdir -p "$output_path"
+    cp "$tmp_file" "$output_file"
+
+    if [ ! -f "$output_file" ]; then
+      echo "ERROR: copy failed for $output_file"
+    fi
+  fi
+}
+

--- a/board/piksiv3/rootfs-overlay/usr/bin/chat_command
+++ b/board/piksiv3/rootfs-overlay/usr/bin/chat_command
@@ -1,0 +1,14 @@
+#!/bin/ash
+
+set -e
+
+network_type=$1; shift
+apn=$1
+
+echo $$ >/var/run/chat_command.pid
+
+if [[ "$network_type" == "gsm" ]]; then
+  exec /usr/sbin/chat -v -T $apn -f /etc/ppp/chatscript-gsm
+else
+  exec /usr/sbin/chat -v -f /etc/ppp/chatscript-cdma
+fi

--- a/board/piksiv3/rootfs-overlay/usr/bin/kill_chat_command
+++ b/board/piksiv3/rootfs-overlay/usr/bin/kill_chat_command
@@ -1,0 +1,23 @@
+#!/bin/ash
+
+tag=kill_chat_command
+
+warn=daemon.warn
+debug=daemon.debug
+
+pid=$(cat /var/run/chat_command.pid 2>/dev/null)
+
+if [[ -z "$pid" ]]; then
+  echo "chat command PID file not found (or empty)" | logger -t $tag -p $warn
+  exit 0
+fi
+
+if ! [[ -d "/proc/$pid" ]]; then
+  echo "chat command not running" | logger -t $tag -p $debug
+  exit 0
+fi
+
+kill $pid
+
+sleep 0.1
+kill -SIGKILL $pid

--- a/package/piksi_system_daemon/piksi_system_daemon/src/async-child.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/async-child.c
@@ -108,7 +108,10 @@ static int raw_fgets(char *str, size_t len, int fd)
 static int async_output_cb(zloop_t *loop, zmq_pollitem_t *item, void *arg)
 {
   struct async_child_ctx *ctx = arg;
-  char buf[128];
+  char buf[128] = { 0 };
+
+  assert(ctx != NULL);
+  assert(item != NULL);
 
   if (raw_fgets(buf, sizeof(buf), item->fd) > 0) {
     if (ctx->output_callback)

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.c
@@ -51,49 +51,25 @@ inotify_ctx_t * inotify_ctx = NULL;
 static int cellmodem_notify(void *context);
 
 #define SBP_PAYLOAD_SIZE_MAX (255u)
-enum { STORAGE_SIZE = SBP_PAYLOAD_SIZE_MAX-1 };
+
+// One less so the buffer is always NULL terminated
+enum { MAX_STR_LENGTH = SBP_PAYLOAD_SIZE_MAX-1 };
 
 static void pppd_output_callback(const char *buf, void *arg)
 {
   sbp_zmq_pubsub_ctx_t *pubsub_ctx = arg;
 
-  if (!cellmodem_debug)
+  if (!cellmodem_debug || buf == NULL)
     return;
 
-  int len = strlen(buf);
-  static char storage[SBP_PAYLOAD_SIZE_MAX] = {0};
+  msg_log_t *msg = alloca(SBP_PAYLOAD_SIZE_MAX);
+  memset(msg, 0, SBP_PAYLOAD_SIZE_MAX);
 
-  static char* buffer = storage;
-  static size_t remaining = STORAGE_SIZE;
-
-  size_t copy_len = MIN(remaining, len);
-
-  memcpy(buffer, buf, copy_len);
-  buffer = &buffer[copy_len];
-
-  remaining -= copy_len;
-
-  // Hacky workaround for things that are sent one character at a time...
-  if (len == 1 && (strcmp(storage, "NO CARRIER") != 0 &&
-                   strcmp(storage, "OK") != 0 &&
-                   strcmp(storage, "AT") != 0 &&
-                   strcmp(storage, "AT&D2") != 0))
-  {
-     return;
-  }
-
-  msg_log_t *msg = alloca(sizeof(storage) + 1);
   msg->level = 7;
-
-  strncpy(msg->text, storage, sizeof(storage));
+  strncpy(msg->text, buf, MAX_STR_LENGTH);
 
   sbp_zmq_tx_send(sbp_zmq_pubsub_tx_ctx_get(pubsub_ctx),
-                  SBP_MSG_LOG, sizeof(*msg) + strlen(storage), (void*)msg);
-
-  // Reset
-  buffer = &storage[0];
-  remaining = STORAGE_SIZE;
-  memset(buffer, 0, remaining);
+                  SBP_MSG_LOG, sizeof(*msg) + strlen(msg->text), (void*)msg);
 }
 
 void cellmodem_set_dev(sbp_zmq_pubsub_ctx_t *pubsub_ctx, char *dev, enum modem_type type)


### PR DESCRIPTION
## Overview

Do work to make sure pppd and chat are fully terminated
+  Add a wrapper for the chatscript that records the process id, so we can
    request that it stop when the cell modem is disabled.
+  Make sure pppd is fully terminated by sending it SIGINT, SIGTERM, then
    SIGKILL.

Fix crash when dumping pppd output
+  Remove hack that tried to fix-up strings that pppd/chat would write one
    character at a time... just in case this was contributing to the crash.
+  Also, guard against a null buffer pointer and make sure that we call
    strlen on something that's guaranteed to be null temrinated.
+  The current working theory is that when the pppd daemon would
    occasionally start outputing "garbage" from the ppp stream, this would
    overflow the SBP max payload and strlen would not terminate the
    buffer... thus the call to `strlen(storage)` would crash.

## Bench testing
+ Toggled cell modem daemon on and off a bunch