### PR TITLE
Cell modem device override from v1.5 [DEVC-559, DEVC-590] [#594/#596:master]

### DIFF
--- a/package/cell_modem_daemon/src/cell_modem_inotify.h
+++ b/package/cell_modem_daemon/src/cell_modem_inotify.h
@@ -13,7 +13,10 @@
 #ifndef _SWIFT_CELL_MODEM_INOTIFY_H
 #define _SWIFT_CELL_MODEM_INOTIFY_H
 
+typedef struct inotify_ctx_s inotify_ctx_t;
 bool cell_modem_tty_exists(const char* path);
-void async_wait_for_tty(sbp_zmq_pubsub_ctx_t *pubsub_ctx);
+void cell_modem_scan_for_modem(inotify_ctx_t *ctx);
+void cell_modem_set_dev_to_invalid(inotify_ctx_t *ctx);
+inotify_ctx_t * async_wait_for_tty(sbp_zmq_pubsub_ctx_t *pubsub_ctx);
 
-#endif//_SWIFT_CELLMODEM_INOTIFY_H
+#endif//_SWIFT_CELL_MODEM_INOTIFY_H

--- a/package/cell_modem_daemon/src/cell_modem_probe.h
+++ b/package/cell_modem_daemon/src/cell_modem_probe.h
@@ -13,8 +13,6 @@
 #ifndef __CELL_MODEM_PROBE_H
 #define __CELL_MODEM_PROBE_H
 
-#include <libpiksi/sbp_zmq_pubsub.h>
-
-enum modem_type cell_modem_probe(const char *dev, sbp_zmq_pubsub_ctx_t *pubsub_ctx);
+enum modem_type cell_modem_probe(const char *dev);
 
 #endif

--- a/package/cell_modem_daemon/src/cell_modem_settings.c
+++ b/package/cell_modem_daemon/src/cell_modem_settings.c
@@ -21,7 +21,6 @@
 #include <signal.h>
 #include <stdbool.h>
 
-#include <libpiksi/sbp_zmq_pubsub.h>
 #include <libpiksi/settings.h>
 #include <libpiksi/logging.h>
 #include <libpiksi/runit.h>
@@ -31,12 +30,18 @@
 #include "cell_modem_settings.h"
 #include "cell_modem_inotify.h"
 
+#define CELL_MODEM_DEV_OVERRIDE_DEFAULT "ttyACM0"
+
 static enum modem_type modem_type = MODEM_TYPE_GSM;
 static char *cell_modem_dev;
 /* External settings */
 static char cell_modem_apn[32] = "hologram";
 static bool cell_modem_enabled_;
 static bool cell_modem_debug;
+static char cell_modem_dev_override[PATH_MAX] = CELL_MODEM_DEV_OVERRIDE_DEFAULT;
+
+/* context for rescan on override notify */
+inotify_ctx_t * inotify_ctx = NULL;
 
 static int cell_modem_notify(void *context);
 
@@ -47,7 +52,7 @@ static int cell_modem_notify(void *context);
 
 enum { STORAGE_SIZE = SBP_PAYLOAD_SIZE_MAX-1 };
 
-void cell_modem_set_dev(sbp_zmq_pubsub_ctx_t *pubsub_ctx, char *dev, enum modem_type type)
+void cell_modem_set_dev(char *dev, enum modem_type type)
 {
   cell_modem_dev = dev;
   modem_type = type;
@@ -64,7 +69,7 @@ void cell_modem_set_dev(sbp_zmq_pubsub_ctx_t *pubsub_ctx, char *dev, enum modem_
      (cell_modem_dev != NULL) &&
      (modem_type != MODEM_TYPE_INVALID) &&
      (stat != RUNIT_RUNNING))
-    cell_modem_notify(pubsub_ctx);
+    cell_modem_notify(NULL);
 }
 
 int pppd_respawn(zloop_t *loop, int timer_id, void *arg)
@@ -132,17 +137,51 @@ static int cell_modem_notify(void *context)
   return start_runit_service(&cfg_start);
 }
 
+char * cell_modem_get_dev_override(void)
+{
+  return strlen(cell_modem_dev_override) == 0 ? NULL : cell_modem_dev_override;
+}
+
+static int cell_modem_notify_dev_override(void *context)
+{
+  inotify_ctx_t *ctx = *((inotify_ctx_t **)context);
+  if (ctx == NULL) {
+    return 0;
+  }
+  // Don't allow changes if cell modem is enabled
+  if (cell_modem_enabled_) {
+      sbp_log(LOG_WARNING, "Modem must be disabled to modify device override");
+    return 1;
+  }
+
+  // override updated
+  if (cell_modem_get_dev_override() != NULL) {
+    if (!cell_modem_tty_exists(cell_modem_dev_override)) {
+      sbp_log(LOG_WARNING,
+              "Modem device override tty does not exist: '%s'",
+              cell_modem_dev_override);
+    }
+  }
+  cell_modem_set_dev_to_invalid(ctx);
+  cell_modem_notify(NULL);
+  cell_modem_scan_for_modem(ctx);
+  return 0;
+}
+
 int cell_modem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ctx)
 {
   settings_register(settings_ctx, "cell_modem", "APN", &cell_modem_apn,
                     sizeof(cell_modem_apn), SETTINGS_TYPE_STRING,
-                    cell_modem_notify, pubsub_ctx);
+                    cell_modem_notify, NULL);
   settings_register(settings_ctx, "cell_modem", "enable", &cell_modem_enabled_,
                     sizeof(cell_modem_enabled_), SETTINGS_TYPE_BOOL,
-                    cell_modem_notify, pubsub_ctx);
+                    cell_modem_notify, NULL);
   settings_register(settings_ctx, "cell_modem", "debug", &cell_modem_debug,
                     sizeof(cell_modem_debug), SETTINGS_TYPE_BOOL,
                     NULL, NULL);
-  async_wait_for_tty(pubsub_ctx);
+  settings_register(settings_ctx, "cell_modem", "device_override", &cell_modem_dev_override,
+                    sizeof(cell_modem_dev_override), SETTINGS_TYPE_STRING,
+                    cell_modem_notify_dev_override, &inotify_ctx);
+  inotify_ctx = async_wait_for_tty(pubsub_ctx);
   return 0;
 }

--- a/package/cell_modem_daemon/src/cell_modem_settings.h
+++ b/package/cell_modem_daemon/src/cell_modem_settings.h
@@ -13,6 +13,7 @@
 #ifndef __CELL_MODEM_SETTINGS_H
 #define __CELL_MODEM_SETTINGS_H
 
+#include <libpiksi/sbp_zmq_pubsub.h>
 #include <libpiksi/settings.h>
 
 enum modem_type {
@@ -22,8 +23,9 @@ enum modem_type {
 };
 
 int cell_modem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ctx);
-void cell_modem_set_dev(sbp_zmq_pubsub_ctx_t *pubsub_ctx, char *dev, enum modem_type type);
+void cell_modem_set_dev(char *dev, enum modem_type type);
 int pppd_respawn(zloop_t *loop, int timer_id, void *arg);
 bool cell_modem_enabled(void);
+char * cell_modem_get_dev_override(void);
 
 #endif


### PR DESCRIPTION
Squashes commits from #594 and #596, as well as removing pubsub_ctx that was
getting passed around and not being used since we have now moved to runit.

Overall summary:
A new cell_modem setting, device_override, will interject during modem
tty scans and reject candidates that do not match the override. If the
setting is changed during operation (provided cell modem is not enabled)
the currently used device will be unset and devices will be rescanned.
The refactor to remove pubsub context was merely to remove a vestigial
sbp log message routine that has been superceded by libpiksi's sbp_log
(as well as piksi_log with the SBP_LOG flag). Finally, retry logic was
added to the cell modem probe routine to allow a 'flush' on any modem
that initially emits unsolicited output.

Previous commit messages:
 -Creating device_override setting that hardcodes the device we want to use for pppd
 -Add notify for dev override and force rescan when altered
 -Add retry loop for initial AT command probe to candidate modem ttys