### PR TITLE
EX-156: RTCM MSM support

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.30
+GNSS_CONVERTORS_VERSION = v0.3.34
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.13
+LIBRTCM_VERSION = v0.2.18
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/nmea_daemon/src/Makefile
+++ b/package/nmea_daemon/src/Makefile
@@ -1,6 +1,6 @@
 TARGET=nmea_daemon
 SOURCES= nmea_daemon.c
-LIBS=-lczmq -lsbp -lpiksi -lgnss-convertors
+LIBS=-lczmq -lsbp -lpiksi -lgnss_converters
 CFLAGS=-std=gnu11 -Wmissing-prototypes -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror -ggdb
 
 CROSS=

--- a/package/sbp_rtcm3_bridge/src/Makefile
+++ b/package/sbp_rtcm3_bridge/src/Makefile
@@ -1,6 +1,6 @@
 TARGET=sbp_rtcm3_bridge
 SOURCES= sbp_rtcm3_bridge.c sbp.c
-LIBS=-lczmq -lsbp -lpiksi -lgnss-convertors
+LIBS=-lczmq -lsbp -lpiksi -lgnss_converters
 CFLAGS=-std=gnu11 -Wmissing-prototypes -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror -ggdb
 
 CROSS=


### PR DESCRIPTION
Update pointers to `librtcm` (https://github.com/swift-nav/librtcm/pull/36) and `gnss-converters` (https://github.com/swift-nav/gnss-converters/pull/73) for RTCM MSM support.

This implements support of MSM4-7 messages for all constellations defined in RTCM 10403.3

Note that MSM4/6 does not currently support GLO. There's a follow-up issue https://swift-nav.atlassian.net/browse/EX-155 for that.

## Testing

Tested with live rooftop signal against the only MSM station in range ORIV00FIN0, with baseline of 26km, and sending MSM7 messages for all constellations (>100 obs in total). Produces fix and has been running a couple of nights without incidents.

Tested against other EUREF NTRIP casters producing legacy obs, and MSM4 / MSM5 obs, and verified that base observations arrive to console and look reasonable, but all the stations are too far away for fixing.

Tested switching from MSM stream to a legacy stream, and verified that observations stop for 60 seconds, before continuing with the legacy observations. (cannot position fix with the legacy stream because of too long baseline). Switching back to MSM stream continues measurements immediately and fixes again.

**Update**

Tested with an artificial stream with mixed legacy and MSM messages (converted from a live MSM7 stream with generated with RTKLIB:
`./str2str -in ntrip://<server>#rtcm3 -out tcpcli://192.168.1.13:55556#rtcm3 -msg '1004(1),1006(30),1008(30),1012(1),1019,1020,1077(1),1087(1),1097(1),1107(1),1117(1),1127(1),1230(60)'`)

Sanity testesd with MSM4, MSM5 and MSM6 streams generated by converting the ORIV00FIN0 MSM7 stream with RTKLIB, and verified can get fix with each.