### PR TITLE
[DEVC-675] Add probe retries timer callback for device override during boot period

### DIFF
--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.h
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem.h
@@ -26,5 +26,6 @@ int cellmodem_init(sbp_zmq_pubsub_ctx_t *pubsub_ctx, settings_ctx_t *settings_ct
 void cellmodem_set_dev(sbp_zmq_pubsub_ctx_t *pubsub_ctx, char *dev, enum modem_type type);
 char * cellmodem_get_dev_override(void);
 int pppd_respawn(zloop_t *loop, int timer_id, void *arg);
+int override_probe_retry(zloop_t *loop, int timer_id, void *arg);
 
 #endif

--- a/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_inotify.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/cellmodem_inotify.c
@@ -75,6 +75,10 @@ static int update_dev_from_probe(inotify_ctx_t *ctx, char *dev)
     ctx->cellmodem_dev = strdup(dev);
     cellmodem_set_dev(ctx->pubsub_ctx, ctx->cellmodem_dev , ctx->modem_type );
     return 0;
+  } else if (dev_override != NULL && strcmp(dev_override, dev) == 0) {
+    piksi_log(LOG_WARNING,
+              "Override device failed probe: %s",
+              dev);
   }
   return 1;
 }
@@ -182,6 +186,8 @@ inotify_ctx_t * async_wait_for_tty(sbp_zmq_pubsub_ctx_t *pubsub_ctx)
   zloop_poller(ctx->loop, &ctx->pollitem, inotify_output_cb, ctx);
 
   cellmodem_scan_for_modem(ctx);
+
+  zloop_timer(sbp_zmq_pubsub_zloop_get(pubsub_ctx), 1000, 0, override_probe_retry, ctx);
 
   return ctx;
 


### PR DESCRIPTION
DEVC-675