### PR TITLE
Add binutils to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ let
   targetPkgs = pkgs: with pkgs; [
     awscli
     bash
+    binutils
     bc
     bison
     bzip2


### PR DESCRIPTION
When I set up my system with NixOS 18.03 I had to add this to default.nix in order to get it to build.