### PR TITLE
Allow init_script.sh to pull down things from TFTP

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S75dev_boot
@@ -63,7 +63,8 @@ start() {
   # Run custom script if present
   if [ -f "$script_path/init_script.sh" ]; then
     echo "Running init_script.sh"
-    sh "$script_path/init_script.sh"
+    SERVER_IP=$server_ip SD_PATH=$sd_path \
+      sh "$script_path/init_script.sh"
   fi
 }
 

--- a/board/piksiv3/rootfs-overlay/etc/init.d/copy_from.sh
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/copy_from.sh
@@ -1,8 +1,8 @@
 copy_from_sd()
 {
-  local sd_path=$1
-  local filename=$2
-  local output_path=$3
+  local sd_path=$1; shift
+  local filename=$1; shift
+  local output_path=$1; shift
   local sd_file="$sd_path/$filename"
   local output_file="$output_path/$filename"
 
@@ -20,9 +20,9 @@ copy_from_sd()
 
 copy_from_net()
 {
-  local server_ip=$1
-  local filename=$2
-  local output_path=$3
+  local server_ip=$1; shift
+  local filename=$1; shift
+  local output_path=$1; shift
   local uuid=`cat /factory/uuid`
   local net_file="PK$uuid/$filename"
   local output_file="$output_path/$filename"


### PR DESCRIPTION
Pass SERVER_IP and SD_PATH, sync copy_from.sh with v1.5: these are passed so that an init_script.sh can pull things from tftp if it desires.