### PR TITLE
EX-155: MSM4/6 GLO support

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.40
+GNSS_CONVERTORS_VERSION = v0.3.46
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.19
+LIBRTCM_VERSION = v0.2.20
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/libsbp/libsbp.mk
+++ b/package/libsbp/libsbp.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSBP_VERSION = v2.3.14
+LIBSBP_VERSION = v2.3.17
 LIBSBP_SITE = https://github.com/swift-nav/libsbp
 LIBSBP_SITE_METHOD = git
 LIBSBP_INSTALL_STAGING = YES


### PR DESCRIPTION
Add callbacks for GLO FCN map and update librtcm & gnss-converters pointers to pull in https://github.com/swift-nav/gnss-converters/pull/83 and https://github.com/swift-nav/librtcm/pull/42.

Note that `libsbp` version must match with FW so that correct GLO ephemeris messages are picked up.

Tested on the bench
- against live MSM7 stream from ORIV00FIN0 converted into MSM4 stream with RTKLIB `str2str`
- against zero-baseline Novatel OEM6 native stream converted into MSM5 stream with RTKLIB `str2str`

Fixes nicely in all cases with the dev FW+LNSP PRs that map L2 observations into usable ones (https://github.com/swift-nav/piksi_firmware_private/pull/2057)

(I got only float solution on the zero-baseline Novatel setup with current master FW, although the result is same when converting the stream into 1004+1012 RTCM messages so the problem probably is not in MSM decoding.)
