### PR TITLE
Make repo name lower case for OSX

### DIFF
--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -16,8 +16,9 @@ UID := $(shell id -u)
 GID := $(shell id -g)
 endif
 
-DOCKER_BUILD_VOLUME = piksi_buildroot-$(USER)$(_DOCKER_SUFFIX)
-DOCKER_TAG = piksi_buildroot-$(USER)$(_DOCKER_SUFFIX)
+LOWER_USER = $(shell echo $(USER) | tr A-Z a-z)
+DOCKER_BUILD_VOLUME = piksi_buildroot-$(LOWER_USER)$(_DOCKER_SUFFIX)
+DOCKER_TAG = piksi_buildroot-$(LOWER_USER)$(_DOCKER_SUFFIX)
 
 PIKSI_INS_REF_REPO := git@github.com:swift-nav/piksi_inertial_ipsec_crl.git
 


### PR DESCRIPTION

Without this change I was getting an error running 'make docker-setup' due to a upper case character in my username. This seems to fix it but not sure this is the 'correct' way to fix it.
