### PR TITLE
[DEVC-694] Add 2nd virtual com for SBP

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S38usb_gadget
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S38usb_gadget
@@ -20,9 +20,9 @@ PRODUCT="Piksi Multi"
 SERIAL_NUMBER=`cat /factory/uuid`
 
 if lockdown; then
-  ACM="ACM"
-else
   ACM="2xACM"
+else
+  ACM="3xACM"
 fi
 
 CONFIGURATION="CDC ${ACM}"
@@ -46,6 +46,7 @@ start() {
   # Functions
   mkdir functions/acm.GS0
   lockdown || mkdir functions/acm.GS1
+  mkdir functions/acm.GS2
 
   net && mkdir functions/rndis.usb0
   net && mkdir functions/ecm.usb0
@@ -59,6 +60,7 @@ start() {
 
   ln -s functions/acm.GS0 configs/c.1
   lockdown || ln -s functions/acm.GS1 configs/c.1
+  ln -s functions/acm.GS2 configs/c.1
 
   net && ln -s functions/ecm.usb0 configs/c.1
 
@@ -69,6 +71,7 @@ start() {
     echo "$CONFIGURATION2" > configs/c.2/strings/0x409/configuration
     ln -s functions/acm.GS0 configs/c.2
     [[ -f /etc/release_lockdown ]] || ln -s functions/acm.GS1 configs/c.2
+    ln -s functions/acm.GS2 configs/c.2
     ln -s functions/rndis.usb0 configs/c.2
 
     # Make Windows10 prefer config c.2 by creating Microsoft OS Descriptor
@@ -109,7 +112,7 @@ start() {
 
 stop() {
   echo "" > UDC
-  # To remove acm.GS0 and acm.GS1 from the functions directory
+  # To remove acm.GS0 and acm.GS1 and acm.GS2 from the functions directory
   #  1. stop the getty spawned by init
   #  2. stop SBP service
 }

--- a/package/ports_daemon/overlay/etc/init.d/S82ports_daemon
+++ b/package/ports_daemon/overlay/etc/init.d/S82ports_daemon
@@ -13,6 +13,7 @@ setup_permissions() {
   chown portsd:portsd /dev/ttyPS0
   chown portsd:portsd /dev/ttyPS1
   chown portsd:portsd /dev/ttyGS0
+  chown portsd:portsd /dev/ttyGS2
 
   # Setup runit dir dynamic services
   mkdir -p /var/run/${name}/sv

--- a/package/ports_daemon/ports_daemon/src/serial.c
+++ b/package/ports_daemon/ports_daemon/src/serial.c
@@ -69,6 +69,12 @@ static uart_t usb0 = {
   .flow_control = FLOW_CONTROL_NONE
 };
 
+static uart_t usb2 = {
+  .tty_path = "/dev/ttyGS2",
+  .baudrate = BAUDRATE_9600,
+  .flow_control = FLOW_CONTROL_NONE
+};
+
 static int uart_configure(const uart_t *uart)
 {
   int fd = open(uart->tty_path, O_RDONLY | O_NONBLOCK);
@@ -129,6 +135,9 @@ int serial_init(settings_ctx_t *settings_ctx)
 {
   /* Configure USB0 */
   uart_configure(&usb0);
+
+  /* Configure USB2 */
+  uart_configure(&usb2);
 
   /* Register settings */
   settings_type_t settings_type_baudrate;


### PR DESCRIPTION
This simply duplicates all related code for ttyGS0/usb0, s/0/2g, and bypasses the settings registration so that this port cannot be altered and is always available.