### PR TITLE
NTRIP GGA improvements [DEVC-708] [v1.5]

### DIFF
--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -112,6 +112,8 @@ struct network_context_s {
   size_t gga_xfer_fill;        /**< How much of the GGA sentence buffer is filled */
 
   int gga_error_count;         /**< Number of consecutive errors reading GGA file */
+
+  bool gga_rev1;               /**< Should we use rev1 style GGA sentence? */
 };
 
 struct context_node {
@@ -156,6 +158,7 @@ static network_context_t empty_context = {
   .gga_xfer_buflen = 0,
   .gga_xfer_fill = 0,
   .gga_error_count = 0,
+  .gga_rev1 = false,
 };
 
 #define NMEA_GGA_FILE "/var/run/nmea_GGA"
@@ -164,6 +167,8 @@ static network_context_t empty_context = {
 #define NTRIP_DROPPED_CONNECTION_WARNING "Connection dropped with no data. This may be because this NTRIP caster expects an NMEA GGA string to be sent from the receiver. You can enable this through the ntrip.gga_period setting."
 
 static void trim_crlf(char* buf) __attribute__((nonnull(1)));
+static void log_with_rate_limit(network_context_t* ctx, int priority, const char *format, ...)
+  __attribute__((nonnull(1,3)));
 
 void libnetwork_shutdown()
 {
@@ -374,6 +379,12 @@ network_status_t libnetwork_set_gga_upload_interval(network_context_t* context, 
   return NETWORK_STATUS_SUCCESS;
 }
 
+network_status_t libnetwork_set_gga_upload_rev1(network_context_t* context, bool use_rev1)
+{
+  context->gga_rev1 = use_rev1;
+  return NETWORK_STATUS_SUCCESS;
+}
+
 static void warn_on_pipe_full(int fd, size_t pending_write, bool debug)
 {
   static time_t last_pipe_warn_time = 0;
@@ -561,10 +572,6 @@ static size_t fetch_gga_string(network_context_t *ctx, char *buf, size_t buf_siz
   fclose(fp_gga_cache);
   cache_gga_xfer_buffer(ctx, buf, buf_size, byte_count);
 
-  if (ctx->debug) {
-    piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", buf);
-  }
-
   return byte_count;
 }
 
@@ -588,12 +595,25 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
     return CURL_READFUNC_PAUSE;
   }
 
-  size_t header_size = snprintf(buf, size*n, "Ntrip-GGA: %s\r\n", gga_buf);
+  size_t header_size = 0;
+
+  if (ctx->gga_rev1) {
+    header_size = snprintf(buf, size*n, "%s\r\n", gga_buf);
+  } else {
+    header_size = snprintf(buf, size*n, "Ntrip-GGA: %s\r\n", gga_buf);
+  }
 
   if ( header_size >= size*n ) {
     sbp_log(LOG_ERR|LOG_SBP, "%s: unexpected buffer error building GGA string (%s:%d)",
             __FUNCTION__, __FILE__, __LINE__);
     return CURL_READFUNC_PAUSE;
+  }
+
+  if (ctx->debug) {
+    char gga_buf_log[256] = {0};
+    strncpy(gga_buf_log, buf, sizeof(gga_buf_log) - 1);
+    trim_crlf(gga_buf_log);
+    piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", gga_buf_log);
   }
 
   ctx->last_xfer_time = now;
@@ -690,7 +710,7 @@ static int network_progress_check(network_context_t *ctx, curl_off_t bytes)
   if (ctx->bytes_transfered == bytes) {
     if (ctx->stall_count++ > MAX_STALLED_INTERVALS) {
 
-      sbp_log(LOG_WARNING, "connection stalled");
+      log_with_rate_limit(ctx, LOG_WARNING, "connection stalled");
       ctx->stall_count = 0;
 
       return -1;
@@ -831,6 +851,27 @@ static int network_response_code_check(network_context_t* ctx)
   return result;
 }
 
+static void log_with_rate_limit(network_context_t* ctx, int priority, const char *format, ...)
+{
+  time_t current_time = time(NULL);
+  time_t last_error_delta = current_time - ctx->last_curl_error_time;
+
+  int facpri = priority;
+
+  if (last_error_delta >= ERROR_REPORTING_INTERVAL && ctx->report_errors) {
+    facpri =  LOG_SBP|LOG_WARNING;
+    ctx->last_curl_error_time = current_time;
+  }
+
+  va_list ap;
+  va_start(ap, format);
+
+  piksi_vlog(facpri, format, ap);
+
+  va_end(ap);
+}
+
+
 static void network_request(network_context_t* ctx, CURL *curl)
 {
   char error_buf[CURL_ERROR_SIZE];
@@ -864,17 +905,10 @@ static void network_request(network_context_t* ctx, CURL *curl)
     ctx->response_code = response;
 
     if (code != CURLE_OK) {
-      time_t current_time = time(NULL);
-      time_t last_error_delta = current_time - ctx->last_curl_error_time;
-      int facpri = LOG_WARNING;
-      if (last_error_delta >= ERROR_REPORTING_INTERVAL && ctx->report_errors) {
-        facpri =  LOG_SBP|LOG_WARNING;
-        ctx->last_curl_error_time = current_time;
-      }
-      piksi_log(facpri, "curl request (error: %d) \"%s\"", code, error_buf);
+      log_with_rate_limit(ctx, LOG_WARNING, "curl request (error: %d) \"%s\"", code, error_buf);
     } else {
       if (response != 0) {
-        piksi_log(LOG_SBP|LOG_INFO, "curl request code %d", response);
+        log_with_rate_limit(ctx, LOG_WARNING, "curl request (code: %d) \"%s\"", code, error_buf);
         network_response_code_check(ctx);
       }
     }

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -166,7 +166,7 @@ static network_context_t empty_context = {
 #define HTTP_RESPONSE_CODE_OK (200L)
 #define NTRIP_DROPPED_CONNECTION_WARNING "Connection dropped with no data. This may be because this NTRIP caster expects an NMEA GGA string to be sent from the receiver. You can enable this through the ntrip.gga_period setting."
 
-static void trim_crlf(char* buf) __attribute__((nonnull(1)));
+static void trim_crlf(char* buf, size_t *byte_count) __attribute__((nonnull(1)));
 static void log_with_rate_limit(network_context_t* ctx, int priority, const char *format, ...)
   __attribute__((nonnull(1,3)));
 
@@ -488,10 +488,11 @@ static size_t network_upload_read(char *buf, size_t size, size_t n, void *data)
   return -1;
 }
 
-static void trim_crlf(char* buf)
+static void trim_crlf(char *buf, size_t *byte_count)
 {
   char *crlf = strstr(buf, "\r\n");
   if (crlf != NULL) *crlf = '\0';
+  if (byte_count != NULL) *byte_count = strlen(buf) + 1;
 }
 
 static void cache_gga_xfer_buffer(network_context_t *ctx, char* buf, size_t buflen, size_t fill)
@@ -565,7 +566,7 @@ static size_t fetch_gga_string(network_context_t *ctx, char *buf, size_t buf_siz
 
   // Null terminate
   buf[byte_count] = '\0';
-  trim_crlf(buf);
+  trim_crlf(buf, &byte_count);
 
   ctx->gga_error_count = 0;
 
@@ -612,7 +613,7 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
   if (ctx->debug) {
     char gga_buf_log[256] = {0};
     strncpy(gga_buf_log, buf, sizeof(gga_buf_log) - 1);
-    trim_crlf(gga_buf_log);
+    trim_crlf(gga_buf_log, NULL);
     piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", gga_buf_log);
   }
 

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -163,6 +163,8 @@ static network_context_t empty_context = {
 #define HTTP_RESPONSE_CODE_OK (200L)
 #define NTRIP_DROPPED_CONNECTION_WARNING "Connection dropped with no data. This may be because this NTRIP caster expects an NMEA GGA string to be sent from the receiver. You can enable this through the ntrip.gga_period setting."
 
+static void trim_crlf(char* buf) __attribute__((nonnull(1)));
+
 void libnetwork_shutdown()
 {
   context_node_t* node;
@@ -475,18 +477,16 @@ static size_t network_upload_read(char *buf, size_t size, size_t n, void *data)
   return -1;
 }
 
-static void trim_crlf(char* in_buf, char* out_buf, size_t buf_size)
+static void trim_crlf(char* buf)
 {
-  strncpy(out_buf, in_buf, buf_size);
-  char* crlf = strstr(out_buf, "\r\n");
-  *crlf = '\0';
+  char *crlf = strstr(buf, "\r\n");
+  if (crlf != NULL) *crlf = '\0';
 }
 
 static void cache_gga_xfer_buffer(network_context_t *ctx, char* buf, size_t buflen, size_t fill)
 {
   if (ctx->gga_xfer_buffer == NULL || buflen != ctx->gga_xfer_buflen) {
-    if (ctx->gga_xfer_buffer != NULL)
-      free(ctx->gga_xfer_buffer);
+    if (ctx->gga_xfer_buffer != NULL) free(ctx->gga_xfer_buffer);
     ctx->gga_xfer_buffer = malloc(buflen);
     ctx->gga_xfer_buflen = buflen;
   }
@@ -498,21 +498,74 @@ static void cache_gga_xfer_buffer(network_context_t *ctx, char* buf, size_t bufl
 static size_t fill_with_gga_xfer_cache(network_context_t *ctx, char* buf, size_t buflen)
 {
   // If there's no cache, pause
-  if (ctx->gga_xfer_buffer != NULL) {
-    piksi_log(LOG_DEBUG, "%s: no cache, pausing cURL read function", __FUNCTION__);
-    return CURL_READFUNC_PAUSE;
+  if (ctx->gga_xfer_buffer == NULL) {
+    piksi_log(LOG_DEBUG, "%s: no cached GGA sentence is present", __FUNCTION__);
+    return 0;
   }
 
   size_t fill = ctx->gga_xfer_fill;
 
   if (ctx->gga_xfer_fill > buflen) {
-    piksi_log(LOG_WARNING, "%s: cached gga xfer buf larger than cURL read buf", __FUNCTION__);
+    piksi_log(LOG_WARNING, "%s: cached GGA sentence is larger than provided buffer", __FUNCTION__);
     fill = buflen;
   }
 
   memcpy(buf, ctx->gga_xfer_buffer, fill);
 
   return fill;
+}
+
+static size_t fetch_gga_string(network_context_t *ctx, char *buf, size_t buf_size)
+{
+  FILE *fp_gga_cache = fopen(NMEA_GGA_FILE, "r");
+
+  if (fp_gga_cache == NULL) {
+    piksi_log(LOG_WARNING, "failed to open '" NMEA_GGA_FILE "' file: %s", strerror(errno));
+    return fill_with_gga_xfer_cache(ctx, buf, buf_size);
+  }
+
+  if (ctx->debug) {
+    piksi_log(LOG_DEBUG, "provided buffer size: %lu", buf_size);
+  }
+
+  // Subtract one to ensure we can null terminate
+  size_t byte_count = fread(buf, 1, buf_size - 1, fp_gga_cache);
+
+  if (byte_count == 0 || ferror(fp_gga_cache)) {
+
+    if (++ctx->gga_error_count >= MAX_GGA_UPLOAD_READ_ERRORS) {
+      piksi_log(LOG_SBP|LOG_ERR, "max number of GGA file read errors exceeded (" NMEA_GGA_FILE ")");
+    }
+
+    if (ferror(fp_gga_cache)) {
+      piksi_log(LOG_WARNING, "error reading '" NMEA_GGA_FILE "': %s", strerror(errno));
+    } else {
+      piksi_log(LOG_WARNING, "no data while reading '" NMEA_GGA_FILE "'");
+    }
+
+    fclose(fp_gga_cache);
+
+    return fill_with_gga_xfer_cache(ctx, buf, buf_size);
+  }
+
+  if (ctx->debug) {
+    piksi_log(LOG_DEBUG, "'" NMEA_GGA_FILE "' read count: %lu", byte_count);
+  }
+
+  // Null terminate
+  buf[byte_count] = '\0';
+  trim_crlf(buf);
+
+  ctx->gga_error_count = 0;
+
+  fclose(fp_gga_cache);
+  cache_gga_xfer_buffer(ctx, buf, buf_size, byte_count);
+
+  if (ctx->debug) {
+    piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", buf);
+  }
+
+  return byte_count;
 }
 
 static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
@@ -523,68 +576,29 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
 
   if (now - ctx->last_xfer_time < ctx->gga_xfer_secs) {
     if (ctx->debug) {
-      piksi_log(LOG_DEBUG, "Last transfer too recent, pausing");
+      piksi_log(LOG_DEBUG, "Last GGA upload too recent, pausing");
     }
+    return CURL_READFUNC_PAUSE;
+  }
+
+  char gga_buf[256] = {0};
+  size_t byte_count = fetch_gga_string(ctx, gga_buf, sizeof(gga_buf));
+
+  if (byte_count == 0) {
+    return CURL_READFUNC_PAUSE;
+  }
+
+  size_t header_size = snprintf(buf, size*n, "Ntrip-GGA: %s\r\n", gga_buf);
+
+  if ( header_size >= size*n ) {
+    sbp_log(LOG_ERR|LOG_SBP, "%s: unexpected buffer error building GGA string (%s:%d)",
+            __FUNCTION__, __FILE__, __LINE__);
     return CURL_READFUNC_PAUSE;
   }
 
   ctx->last_xfer_time = now;
 
-  FILE *fp_gga_cache = fopen(NMEA_GGA_FILE, "r");
-
-  if (fp_gga_cache == NULL) {
-    piksi_log(LOG_WARNING, "failed to open '" NMEA_GGA_FILE "' file: %s", strerror(errno));
-    return fill_with_gga_xfer_cache(ctx, buf, size*n);
-  }
-
-  if (ctx->debug) {
-    piksi_log(LOG_DEBUG, "cURL provided buffer size: %lu (size: %lu, count: %lu)", size*n, size, n);
-  }
-
-  size_t byte_count = fread(buf, 1, size*n, fp_gga_cache);
-
-  if (byte_count == 0) {
-
-    if (++ctx->gga_error_count == MAX_GGA_UPLOAD_READ_ERRORS) {
-      sbp_log(LOG_ERR, "max number of GGA file read errors exceeded (" NMEA_GGA_FILE ")");
-    }
-
-    fclose(fp_gga_cache);
-    piksi_log(LOG_WARNING, "no data while reading '" NMEA_GGA_FILE "'");
-
-    return fill_with_gga_xfer_cache(ctx, buf, size*n);
-  }
-
-  if (ctx->debug) {
-    piksi_log(LOG_DEBUG, "'" NMEA_GGA_FILE "' read count: %lu", byte_count);
-  }
-
-  if (ferror(fp_gga_cache)) {
-
-    if (++ctx->gga_error_count == MAX_GGA_UPLOAD_READ_ERRORS) {
-      sbp_log(LOG_ERR, "max number of GGA file read errors exceeded (" NMEA_GGA_FILE ")");
-    }
-
-    fclose(fp_gga_cache);
-    piksi_log(LOG_WARNING, "error reading '" NMEA_GGA_FILE "': %s", strerror(errno));
-
-    return fill_with_gga_xfer_cache(ctx, buf, size*n);
-  }
-
-  ctx->gga_error_count = 0;
-
-  fclose(fp_gga_cache);
-  cache_gga_xfer_buffer(ctx, buf, size*n, byte_count);
-
-  if (ctx->debug) {
-
-    char log_buf[512];
-    trim_crlf(buf, log_buf, sizeof(log_buf));
-
-    piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", log_buf);
-  }
-
-  return byte_count;
+  return header_size;
 }
 
 static void service_control_fifo(network_context_t *ctx)
@@ -869,13 +883,31 @@ static void network_request(network_context_t* ctx, CURL *curl)
   }
 }
 
-static struct curl_slist *ntrip_init(CURL *curl)
+static struct curl_slist *ntrip_init(network_context_t *ctx, CURL *curl)
 {
   struct curl_slist *chunk = NULL;
+
   chunk = curl_slist_append(chunk, "Ntrip-Version: Ntrip/2.0");
+  chunk = curl_slist_append(chunk, "Expect:");
+
+  char gga_buf[128] = {0};
+  size_t gga_len = fetch_gga_string(ctx, gga_buf, sizeof(gga_buf));
+
+  if (gga_len > 0) {
+
+    char header_buf[256] = {0};
+
+    size_t c = snprintf(header_buf, sizeof(header_buf), "Ntrip-GGA: %s", gga_buf);
+    assert( c < sizeof(header_buf) );
+
+    curl_slist_append(chunk, header_buf);
+
+  } else {
+    piksi_log(LOG_WARNING, "was not able to insert NTRIP GGA header");
+  }
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
-  curl_easy_setopt(curl, CURLOPT_USERAGENT,  "NTRIP ntrip-client/1.0");
+  curl_easy_setopt(curl, CURLOPT_USERAGENT,  "NTRIP swift-ntrip-client/1.0");
 
   return chunk;
 }
@@ -917,7 +949,7 @@ void ntrip_download(network_context_t *ctx)
     return;
   }
 
-  struct curl_slist *chunk = ntrip_init(curl);
+  struct curl_slist *chunk = ntrip_init(ctx, curl);
 
   if (ctx->gga_xfer_secs > 0) {
 
@@ -927,6 +959,7 @@ void ntrip_download(network_context_t *ctx)
     curl_easy_setopt(curl, CURLOPT_READDATA,         ctx);
 
     chunk = curl_slist_append(chunk, "Transfer-Encoding:");
+
   } else {
     ctx->response_code_check = ntrip_response_code_check;
   }

--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -488,11 +488,11 @@ static size_t network_upload_read(char *buf, size_t size, size_t n, void *data)
   return -1;
 }
 
-static void trim_crlf(char *buf, size_t *byte_count)
+static void trim_crlf(char *buf, size_t *len)
 {
   char *crlf = strstr(buf, "\r\n");
   if (crlf != NULL) *crlf = '\0';
-  if (byte_count != NULL) *byte_count = strlen(buf) + 1;
+  if (len != NULL) *len = strlen(buf);
 }
 
 static void cache_gga_xfer_buffer(network_context_t *ctx, char* buf, size_t buflen, size_t fill)
@@ -527,7 +527,7 @@ static size_t fill_with_gga_xfer_cache(network_context_t *ctx, char* buf, size_t
   return fill;
 }
 
-static size_t fetch_gga_string(network_context_t *ctx, char *buf, size_t buf_size)
+static size_t fetch_gga_buffer(network_context_t *ctx, char *buf, size_t buf_size)
 {
   FILE *fp_gga_cache = fopen(NMEA_GGA_FILE, "r");
 
@@ -541,9 +541,9 @@ static size_t fetch_gga_string(network_context_t *ctx, char *buf, size_t buf_siz
   }
 
   // Subtract one to ensure we can null terminate
-  size_t byte_count = fread(buf, 1, buf_size - 1, fp_gga_cache);
+  size_t read_count = fread(buf, 1, buf_size - 1, fp_gga_cache);
 
-  if (byte_count == 0 || ferror(fp_gga_cache)) {
+  if (read_count == 0 || ferror(fp_gga_cache)) {
 
     if (++ctx->gga_error_count >= MAX_GGA_UPLOAD_READ_ERRORS) {
       piksi_log(LOG_SBP|LOG_ERR, "max number of GGA file read errors exceeded (" NMEA_GGA_FILE ")");
@@ -561,19 +561,21 @@ static size_t fetch_gga_string(network_context_t *ctx, char *buf, size_t buf_siz
   }
 
   if (ctx->debug) {
-    piksi_log(LOG_DEBUG, "'" NMEA_GGA_FILE "' read count: %lu", byte_count);
+    piksi_log(LOG_DEBUG, "'" NMEA_GGA_FILE "' read count: %lu", read_count);
   }
 
-  // Null terminate
-  buf[byte_count] = '\0';
-  trim_crlf(buf, &byte_count);
+  size_t gga_str_len = read_count;
+
+  // Null terminate so trim_crlf won't walk off end of buffer
+  buf[read_count] = '\0';
+  trim_crlf(buf, &gga_str_len);
 
   ctx->gga_error_count = 0;
 
   fclose(fp_gga_cache);
-  cache_gga_xfer_buffer(ctx, buf, buf_size, byte_count);
+  cache_gga_xfer_buffer(ctx, buf, buf_size, gga_str_len);
 
-  return byte_count;
+  return gga_str_len;
 }
 
 static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
@@ -589,8 +591,8 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
     return CURL_READFUNC_PAUSE;
   }
 
-  char gga_buf[256] = {0};
-  size_t byte_count = fetch_gga_string(ctx, gga_buf, sizeof(gga_buf));
+  char gga_string[256] = {0};
+  size_t byte_count = fetch_gga_buffer(ctx, gga_string, sizeof(gga_string) - 1);
 
   if (byte_count == 0) {
     return CURL_READFUNC_PAUSE;
@@ -599,9 +601,9 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
   size_t header_size = 0;
 
   if (ctx->gga_rev1) {
-    header_size = snprintf(buf, size*n, "%s\r\n", gga_buf);
+    header_size = snprintf(buf, size*n, "%s\r\n", gga_string);
   } else {
-    header_size = snprintf(buf, size*n, "Ntrip-GGA: %s\r\n", gga_buf);
+    header_size = snprintf(buf, size*n, "Ntrip-GGA: %s\r\n", gga_string);
   }
 
   if ( header_size >= size*n ) {
@@ -611,10 +613,10 @@ static size_t network_upload_write(char *buf, size_t size, size_t n, void *data)
   }
 
   if (ctx->debug) {
-    char gga_buf_log[256] = {0};
-    strncpy(gga_buf_log, buf, sizeof(gga_buf_log) - 1);
-    trim_crlf(gga_buf_log, NULL);
-    piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", gga_buf_log);
+    char gga_string_log[256] = {0};
+    strncpy(gga_string_log, buf, sizeof(gga_string_log) - 1);
+    trim_crlf(gga_string_log, NULL);
+    piksi_log(LOG_DEBUG, "Sending up GGA data: '%s'", gga_string_log);
   }
 
   ctx->last_xfer_time = now;
@@ -925,14 +927,14 @@ static struct curl_slist *ntrip_init(network_context_t *ctx, CURL *curl)
   chunk = curl_slist_append(chunk, "Ntrip-Version: Ntrip/2.0");
   chunk = curl_slist_append(chunk, "Expect:");
 
-  char gga_buf[128] = {0};
-  size_t gga_len = fetch_gga_string(ctx, gga_buf, sizeof(gga_buf));
+  char gga_string[128] = {0};
+  size_t gga_len = fetch_gga_buffer(ctx, gga_string, sizeof(gga_string) - 1);
 
   if (gga_len > 0) {
 
     char header_buf[256] = {0};
 
-    size_t c = snprintf(header_buf, sizeof(header_buf), "Ntrip-GGA: %s", gga_buf);
+    size_t c = snprintf(header_buf, sizeof(header_buf), "Ntrip-GGA: %s", gga_string);
     assert( c < sizeof(header_buf) );
 
     curl_slist_append(chunk, header_buf);

--- a/package/libnetwork/src/libnetwork.h
+++ b/package/libnetwork/src/libnetwork.h
@@ -84,50 +84,35 @@ void libnetwork_destroy(network_context_t **ctx);
 /**
  * @brief Set the FD for this context
  *
- * @return                   The operation result.
- *
- * @retval  0                The setting was registered successfully.
- * @retval <0                An error occurred. @see @c network_status_t
+ * @return                   The operation result.  See @ref network_status_t.
  */
 network_status_t libnetwork_set_fd(network_context_t* context, int fd);
 
 /**
  * @brief Set the username for this context
  *
- * @return                   The operation result.
- *
- * @retval  0                The setting was registered successfully.
- * @retval <0                An error occurred. @see @c network_status_t
+ * @return                   The operation result.  See @ref network_status_t.
  */
 network_status_t libnetwork_set_username(network_context_t* context, const char* username);
 
 /**
  * @brief Set the password for this context
  *
- * @return                   The operation result.
- *
- * @retval  0                The setting was registered successfully.
- * @retval <0                An error occurred. @see @c network_status_t
+ * @return                   The operation result.  See @ref network_status_t.
  */
 network_status_t libnetwork_set_password(network_context_t* context, const char* password);
 
 /**
  * @brief Set the url for this context
  *
- * @return                   The operation result.
- *
- * @retval  0                The setting was registered successfully.
- * @retval <0                An error occurred. @see @c network_status_t
+ * @return                   The operation result.  See @ref network_status_t.
  */
 network_status_t libnetwork_set_url(network_context_t* context, const char* url);
 
 /**
  * @brief Set the debug flag for this context
  *
- * @return                   The operation result.
- *
- * @retval  0                The setting was registered successfully.
- * @retval <0                An error occurred. @see @c network_status_t
+ * @return                   The operation result.  See @ref network_status_t.
  */
 network_status_t libnetwork_set_debug(network_context_t* context, bool debug);
 
@@ -136,12 +121,18 @@ network_status_t libnetwork_set_debug(network_context_t* context, bool debug);
  *
  * @param[in] gga_interval   The GGA upload interval in seconds.
  *
- * @return                   The operation result.
- *
- * @retval  0                The setting was registered successfully.
- * @retval <0                An error occurred. @see @c network_status_t
+ * @return                   The operation result.  See @ref network_status_t.
  */
 network_status_t libnetwork_set_gga_upload_interval(network_context_t* context, int gga_interval);
+
+/**
+ * @brief Set the NTRIP GGA upload style to NTRIP 1.0
+ *
+ * @param[in] use_rev1       If true, the NTRIP GGA string will be formatted according to NTRIP 1.0
+ *
+ * @return                   The operation result.  See @ref network_status_t.
+ */
+network_status_t libnetwork_set_gga_upload_rev1(network_context_t* context, bool use_rev1);
 
 /**
  * @brief   Download from ntrip.

--- a/package/nmea_daemon/src/nmea_daemon.c
+++ b/package/nmea_daemon/src/nmea_daemon.c
@@ -112,7 +112,6 @@ static int nmea_reader_handler(zloop_t *zloop, zsock_t *zsock, void *arg)
 
   if (rename(tmp_file_name, NMEA_GGA_OUTPUT_PATH) < 0) {
     sbp_log(LOG_WARNING, "rename failed: %s", strerror(errno));
-    return 0;
   }
 
 exit_success:

--- a/package/ntrip_daemon/src/ntrip_daemon.c
+++ b/package/ntrip_daemon/src/ntrip_daemon.c
@@ -24,6 +24,7 @@ static const char *fifo_file_path = NULL;
 static const char *username = NULL;
 static const char *password = NULL;
 static const char *url = NULL;
+static bool rev1gga = false;
 
 static double gga_xfer_secs = 0.0;
 
@@ -37,6 +38,10 @@ static void usage(char *command)
   puts("\t--password <password>");
   puts("\t--url <url>");
 
+  puts("\nGGA options");
+  puts("\t--interval <secs>");
+  puts("\t--rev1gga <y|n>");
+
   puts("\nMisc options");
   puts("\t--debug");
 }
@@ -49,7 +54,8 @@ static int parse_options(int argc, char *argv[])
     OPT_ID_DEBUG,
     OPT_ID_INTERVAL,
     OPT_ID_USERNAME,
-    OPT_ID_PASSWORD
+    OPT_ID_PASSWORD,
+    OPT_ID_REV1GGA,
   };
 
   const struct option long_opts[] = {
@@ -58,6 +64,7 @@ static int parse_options(int argc, char *argv[])
     {"password",  required_argument, 0, OPT_ID_PASSWORD},
     {"url  ",     required_argument, 0, OPT_ID_URL},
     {"interval",  required_argument, 0, OPT_ID_INTERVAL},
+    {"rev1gga",   required_argument, 0, OPT_ID_REV1GGA},
     {"debug",     no_argument,       0, OPT_ID_DEBUG},
     {0, 0, 0, 0},
   };
@@ -91,6 +98,11 @@ static int parse_options(int argc, char *argv[])
 
       case OPT_ID_DEBUG: {
         debug = true;
+      }
+      break;
+
+      case OPT_ID_REV1GGA: {
+        rev1gga = *optarg == 'y';
       }
       break;
 
@@ -157,6 +169,8 @@ static bool configure_libnetwork(network_context_t* ctx, int fd)
     goto exit_error;
   if ((status = libnetwork_set_gga_upload_interval(ctx, gga_xfer_secs))
       != NETWORK_STATUS_SUCCESS)
+    goto exit_error;
+  if ((status = libnetwork_set_gga_upload_rev1(ctx, rev1gga)) != NETWORK_STATUS_SUCCESS)
     goto exit_error;
 
   return true;

--- a/package/piksi_system_daemon/piksi_system_daemon/src/ntrip.c
+++ b/package/piksi_system_daemon/piksi_system_daemon/src/ntrip.c
@@ -22,15 +22,17 @@ static bool ntrip_debug;
 static char ntrip_username[256];
 static char ntrip_password[256];
 static char ntrip_url[256];
-static char ntrip_interval_s[16];
-
 static int ntrip_interval = 0;
+static char ntrip_interval_s[16];
+static bool ntrip_rev1gga = false;
+static char ntrip_rev1gga_s[] = "n";
 
 static char *ntrip_argv_normal[] = {
   "ntrip_daemon",
   "--file", FIFO_FILE_PATH,
   "--url", ntrip_url,
   "--interval", ntrip_interval_s,
+  "--rev1gga", ntrip_rev1gga_s,
   NULL,
 };
 
@@ -40,6 +42,7 @@ static char *ntrip_argv_debug[] = {
   "--file", FIFO_FILE_PATH,
   "--url", ntrip_url,
   "--interval", ntrip_interval_s,
+  "--rev1gga", ntrip_rev1gga_s,
   NULL,
 };
 
@@ -50,6 +53,7 @@ static char *ntrip_argv_username[] = {
   "--password", ntrip_password,
   "--url", ntrip_url,
   "--interval", ntrip_interval_s,
+  "--rev1gga", ntrip_rev1gga_s,
   NULL,
 };
 
@@ -61,6 +65,7 @@ static char *ntrip_argv_username_debug[] = {
   "--password", ntrip_password,
   "--url", ntrip_url,
   "--interval", ntrip_interval_s,
+  "--rev1gga", ntrip_rev1gga_s,
   NULL,
 };
 
@@ -100,6 +105,7 @@ static int ntrip_notify(void *context)
   (void)context;
 
   snprintf(ntrip_interval_s, sizeof(ntrip_interval_s), "%d", ntrip_interval);
+  ntrip_rev1gga_s[0] = ntrip_rev1gga ? 'y' : 'n';
 
   for (int i=0; i<ntrip_processes_count; i++) {
     ntrip_process_t *process = &ntrip_processes[i];
@@ -175,6 +181,11 @@ void ntrip_init(settings_ctx_t *settings_ctx)
   settings_register(settings_ctx, "ntrip", "gga_out_interval",
                     &ntrip_interval, sizeof(ntrip_interval),
                     SETTINGS_TYPE_INT,
+                    ntrip_notify, NULL);
+
+  settings_register(settings_ctx, "ntrip", "gga_out_rev1",
+                    &ntrip_rev1gga, sizeof(ntrip_rev1gga),
+                    SETTINGS_TYPE_BOOL,
                     ntrip_notify, NULL);
 }
 


### PR DESCRIPTION
Changes:
- Format GGA upload string according to the NTRIP 2.0 spec
- Add an option (defaulting to false) that allows the user to enable NTRIP 1.0 style GGA upload
- Rate limit the "connection stalled" message so that the user isn't spammed when the device is starting up
- Strip the "Expect" header from the what cURL sends by default when doing an upload so that cURL won't expect the server to do the "expect/continue" behavior (which is intended as a way to ask the server if an upload is ok).
- Fix a logic inversion bug in the handling of the cache for `fill_with_gga_xfer_cache`, previously we would error out if there was a cache

Bench testing:
- Bench test overnight connected to a SNIP NTRIP caster without error