### PR TITLE
Adding touch to control/socket so settings loop init doesn't fail

### DIFF
--- a/package/ntrip_daemon/overlay/etc/init.d/S82ntrip_daemon
+++ b/package/ntrip_daemon/overlay/etc/init.d/S82ntrip_daemon
@@ -8,7 +8,8 @@ user="ntripd"
 setup_permissions() {
 
   mkdir -p /var/run/ntrip/control
-  chown -R $user:$user /var/run/ntrip
+  touch /var/run/ntrip/control/socket
+  chown $user:$user /var/run/ntrip/control/socket
 
   # Sticky bit is set so that ntrip_daemon can create it's
   #   control socket but (and allow others to write to it)
@@ -18,6 +19,8 @@ setup_permissions() {
   touch /var/run/ntrip/enabled
   chown $user:$user /var/run/ntrip/enabled
   chmod 0644 /var/run/ntrip/enabled
+
+  chown -R $user:$user /var/run/ntrip
 }
 
 source /etc/init.d/template_process.inc.sh

--- a/package/skylark_daemon/overlay/etc/init.d/S82skylark_daemon
+++ b/package/skylark_daemon/overlay/etc/init.d/S82skylark_daemon
@@ -8,7 +8,8 @@ user="skylarkd"
 setup_permissions() {
 
   mkdir -p /var/run/skylark/control
-  chown -R $user:$user /var/run/skylark
+  touch /var/run/skylark/control/socket
+  chown $user:$user /var/run/skylark/control/socket
 
   chown $user:$user /etc/skylark_upload_filter_out_config
 
@@ -20,6 +21,8 @@ setup_permissions() {
   touch /var/run/skylark/enabled
   chown $user:$user /var/run/skylark/enabled
   chmod 0644 /var/run/skylark/enabled
+
+  chown -R $user:$user /var/run/skylark
 }
 
 source /etc/init.d/template_process.inc.sh


### PR DESCRIPTION
Behavior that cropped up in #639, not sure why this wasn't happening on master previously.