### PR TITLE
Fix upgrade_tool compatibility with NAP >= 4.x

### DIFF
--- a/package/upgrade_tool/upgrade_tool.mk
+++ b/package/upgrade_tool/upgrade_tool.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UPGRADE_TOOL_VERSION = v1.4.0-develop-2018060121
+UPGRADE_TOOL_VERSION = v1.4.0-develop-2018061321
 UPGRADE_TOOL_SITE = git@github.com:swift-nav/piksi_upgrade_tool_bin.git
 UPGRADE_TOOL_SITE_METHOD = git
 


### PR DESCRIPTION
The current `upgrade_tool` can't upgrade if a NAP version > 4.x is loaded, fix this by bringing in these changes:
- https://github.com/swift-nav/piksi_upgrade_tool/commit/07c40c75a2227530dc086471de3672775f4d6cc2
- https://github.com/swift-nav/piksi_inertial_ipsec/commit/52ca08dd1965ef2f90b18b083a733573bdba291c