### PR TITLE
Make sure /var/run/nmea/GGA is never empty [DEVC-764]

### DIFF
--- a/package/nmea_daemon/src/nmea_daemon.c
+++ b/package/nmea_daemon/src/nmea_daemon.c
@@ -28,6 +28,8 @@
 
 #define BASE_DIRECTORY    "/var/run/nmea"
 
+#define NO_FIX_GGA        "$GPGGA,,,,,,0,,,,M,,M,,*66"
+
 const char* const NMEA_GGA_OUTPUT_PATH = BASE_DIRECTORY "/GGA";
 
 bool nmea_debug = false;
@@ -184,6 +186,15 @@ int main(int argc, char *argv[])
                                   nmea_reader_handler,
                                   &ctx) == NULL) {
     piksi_log(LOG_ERR, "error registering reader");
+    exit(cleanup(EXIT_FAILURE, &ctx));
+  }
+
+  FILE* fp = fopen(NMEA_GGA_OUTPUT_PATH, "w");
+  if (fp != NULL) {
+    fprintf(fp, "%s\r\n", NO_FIX_GGA);
+    fclose(fp);
+  } else {
+    piksi_log(LOG_SBP|LOG_ERR, "unable to open '%s'");
     exit(cleanup(EXIT_FAILURE, &ctx));
   }
 


### PR DESCRIPTION
Change the contract for /var/run/nmea/GGA so that it's never expected to
be empty if we can access it.  This makes the error logging here not
result in an error when the device starts up and has not yet gotten a
fix yet.

See https://swift-nav.atlassian.net/browse/DEVC-764