### PR TITLE
[DEVC-426] Add warning if no base obs seen when ntrip is enabled

### DIFF
--- a/package/health_daemon/src/Makefile
+++ b/package/health_daemon/src/Makefile
@@ -1,5 +1,5 @@
 TARGET=health_daemon
-SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c glo_health_context.c skylark_monitor.c
+SOURCES=health_daemon.c health_monitor.c baseline_monitor.c glo_bias_monitor.c glo_obs_monitor.c glo_health_context.c skylark_monitor.c ntrip_obs_monitor.c
 LIBS=-luv -lnanomsg -lsbp -lpiksi -lm -lnetwork -lcurl
 CFLAGS=-std=gnu11 -Wmissing-prototypes -Wconversion -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wall -Wextra -Wno-strict-prototypes -Werror
 

--- a/package/health_daemon/src/health_daemon.c
+++ b/package/health_daemon/src/health_daemon.c
@@ -31,6 +31,7 @@
 #include "glo_obs_monitor.h"
 #include "glo_bias_monitor.h"
 #include "skylark_monitor.h"
+#include "ntrip_obs_monitor.h"
 
 #define PROGRAM_NAME "health_daemon"
 
@@ -80,6 +81,8 @@ static health_monitor_init_fn_pair_t health_monitor_init_pairs[] = {
     glo_bias_timeout_health_monitor_deinit },
   { skylark_monitor_init,
     skylark_monitor_deinit },
+  { ntrip_obs_timeout_health_monitor_init,
+    ntrip_obs_timeout_health_monitor_deinit }
 };
 static size_t health_monitor_init_pairs_n =
   (sizeof(health_monitor_init_pairs) / sizeof(health_monitor_init_fn_pair_t));
@@ -138,6 +141,12 @@ int main(int argc, char *argv[])
   health_ctx.sbp_ctx =
     sbp_pubsub_create(SBP_PUB_ENDPOINT, SBP_SUB_ENDPOINT);
   if (health_ctx.sbp_ctx == NULL) {
+    status = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  if (sbp_rx_attach(sbp_pubsub_rx_ctx_get(health_ctx.sbp_ctx), health_ctx.loop) != 0) {
+    sbp_log(LOG_ERR, "Error registering for pubsub read!");
     status = EXIT_FAILURE;
     goto cleanup;
   }

--- a/package/health_daemon/src/ntrip_obs_monitor.c
+++ b/package/health_daemon/src/ntrip_obs_monitor.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**
+ * \file ntrip_obs_monitor.c
+ * \brief NTRIP Observations Health Monitor
+ *
+ * When the ntrip client is enabled, it is expected that base obs
+ * measurements will be received periodically. This monitor will
+ * track base obs messages, and subsequently alert after a specified
+ * time period if none are received.
+ * \author Ben Altieri
+ * \version v1.6.0
+ * \date 2018-06-13
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libpiksi/logging.h>
+
+#include <libsbp/sbp.h>
+#include <libsbp/observation.h>
+
+#include "health_monitor.h"
+
+#include "ntrip_obs_monitor.h"
+
+#define SETTING_SECTION_NTRIP "ntrip"
+#define SETTING_NTRIP_ENABLE "enable"
+
+/* these are from fw private, consider moving to libpiski */
+#define MSG_FORWARD_SENDER_ID (0u)
+
+#define NTRIP_OBS_ALERT_RATE_LIMIT (10000u)   /* ms */
+#define NTRIP_OBS_PERIOD_BEFORE_WARN (20000u) /* ms */
+
+/**
+ * \brief Private context for the ntrip obs health monitor
+ */
+static health_monitor_t *ntrip_obs_monitor;
+
+static u8 max_timeout_count_before_warn =
+  (u8)(NTRIP_OBS_ALERT_RATE_LIMIT / NTRIP_OBS_PERIOD_BEFORE_WARN);
+
+/**
+ * \brief Private global data for ntrip obs callbacks
+ */
+static struct ntrip_obs_ctx_s {
+  bool ntrip_enabled;
+  u8 timeout_counter;
+} ntrip_obs_ctx = { .ntrip_enabled = false, .timeout_counter = 0 };
+
+/**
+ * \brief notify_ntrip_enabled - notify from watch
+ * \param context: pointer to ntrip_enabled
+ * \return
+ */
+static int notify_ntrip_enabled(void *context)
+{
+  (void)context;
+  piksi_log(LOG_DEBUG, "NTRIP Health Monitor Setting Callback! ntrip en: %d", ntrip_obs_ctx.ntrip_enabled);
+  if (ntrip_obs_ctx.ntrip_enabled) {
+    ntrip_obs_ctx.timeout_counter = 0;
+  }
+  return 0;
+}
+
+/**
+ * \brief sbp_msg_ntrip_obs_callback - handler for obs sbp messages
+ * \param monitor: health monitor associated with this callback
+ * \param sender_id: message sender id
+ * \param len: length of the message in bytes
+ * \param msg_[]: pointer to message data
+ * \param ctx: user context associated with the monitor
+ * \return 0 resets timeout, 1 skips the reset, -1 for error
+ */
+static int sbp_msg_ntrip_obs_callback(health_monitor_t *monitor,
+                                      u16 sender_id,
+                                      u8 len,
+                                      u8 msg_[],
+                                      void *ctx)
+{
+  (void)monitor;
+  (void)len;
+  (void)msg_;
+  (void)ctx;
+
+  // reset timer on base obs received from firmware
+  if (sender_id == MSG_FORWARD_SENDER_ID) {
+    ntrip_obs_ctx.timeout_counter = 0;
+    return 0;
+  }
+  return 1; // only reset if base obs found
+}
+
+/**
+ * \brief ntrip_obs_timer_callback - handler for ntrip_obs_monitor timeouts
+ * \param monitor: health monitor associated with this callback
+ * \param context: user context associated with this callback
+ * \return 0 for success, otherwise error
+ */
+static int ntrip_obs_timer_callback(health_monitor_t *monitor, void *context)
+{
+  (void)monitor;
+  (void)context;
+  if (ntrip_obs_ctx.ntrip_enabled) {
+      if (ntrip_obs_ctx.timeout_counter > max_timeout_count_before_warn) {
+        piksi_log(LOG_WARNING|LOG_SBP,
+                  "Reference NTRIP Observations Timeout - no observations received from base station within %d sec window. Check URL and mountpoint settings, or disable NTRIP to suppress this message.",
+                  NTRIP_OBS_ALERT_RATE_LIMIT / 1000);
+      } else {
+        ntrip_obs_ctx.timeout_counter++;
+      }
+  }
+
+  return 0;
+}
+
+int ntrip_obs_timeout_health_monitor_init(health_ctx_t *health_ctx)
+{
+  ntrip_obs_monitor = health_monitor_create();
+  if (ntrip_obs_monitor == NULL) {
+    return -1;
+  }
+
+  if (health_monitor_init(ntrip_obs_monitor,
+                          health_ctx,
+                          SBP_MSG_OBS,
+                          sbp_msg_ntrip_obs_callback,
+                          NTRIP_OBS_ALERT_RATE_LIMIT,
+                          ntrip_obs_timer_callback,
+                          NULL)
+      != 0) {
+    return -1;
+  }
+
+  if (health_monitor_add_setting_watch(ntrip_obs_monitor,
+                                       SETTING_SECTION_NTRIP,
+                                       SETTING_NTRIP_ENABLE,
+                                       &ntrip_obs_ctx.ntrip_enabled,
+                                       sizeof(ntrip_obs_ctx.ntrip_enabled),
+                                       SETTINGS_TYPE_BOOL,
+                                       notify_ntrip_enabled,
+                                       NULL)
+      != 0) {
+    return -1;
+  }
+
+  return 0;
+}
+
+void ntrip_obs_timeout_health_monitor_deinit(void)
+{
+  if (ntrip_obs_monitor != NULL) {
+    health_monitor_destroy(&ntrip_obs_monitor);
+  }
+}

--- a/package/health_daemon/src/ntrip_obs_monitor.h
+++ b/package/health_daemon/src/ntrip_obs_monitor.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef __HEALTH_MONITOR_NTRIP_OBS_H
+#define __HEALTH_MONITOR_NTRIP_OBS_H
+
+int ntrip_obs_timeout_health_monitor_init(health_ctx_t *health_ctx);
+void ntrip_obs_timeout_health_monitor_deinit(void);
+
+#endif /* __HEALTH_MONITOR_NTRIP_OBS_H */


### PR DESCRIPTION
Adds a timer that checks for base obs gated on ntrip enabled.

Also fixes a bug from the zmq refactor where the pubsub context wasn't getting attached properly to the loop context.