### PR TITLE
Update librtcm and gnss-converters to support L1P/L2P warnings

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.47
+GNSS_CONVERTORS_VERSION = v0.3.48
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.21
+LIBRTCM_VERSION = v0.2.23
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES


### PR DESCRIPTION
Pull in changes from swift-nav/librtcm#45, swift-nav/librtcm#46, and swift-nav/gnss-converters#87 to address [DEVC-767](https://swift-nav.atlassian.net/browse/DEVC-767)