### PR TITLE
DEVC-732: Integrate sdk fpga into image generation

### DIFF
--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -40,28 +40,21 @@ fetch() {
 }
 
 download_fw() {
-  HW_CONFIG=$1
-  FIRMWARE_DIR=firmware/$HW_CONFIG
+  FIRMWARE_DIR=firmware/prod
 
   # Make firmware download dir
   mkdir -p $FIRMWARE_DIR
 
   # Download piksi_firmware
-  fetch $FW_S3_PATH/piksi_firmware_v3_$HW_CONFIG.stripped.elf \
+  fetch $FW_S3_PATH/piksi_firmware_v3_prod.stripped.elf \
     $FIRMWARE_DIR/piksi_firmware.elf
 
-  # Download piksi_fpga
-  if [ "$HW_CONFIG" == "microzed" ]; then
-    # Microzed FPGA image breaks the naming convention so deal with it as a special case
-    fetch $NAP_S3_PATH/piksi_microzed_nt1065_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
-  else
-    fetch $NAP_S3_PATH/piksi_${HW_CONFIG}_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
-  fi
-
+  # Download piksi_fpga, try the prod variant first, then sdk variant
+  fetch $NAP_S3_PATH/piksi_prod_fpga.bit $FIRMWARE_DIR/piksi_fpga.bit
 }
 
 if [[ -z "$GENERATE_REQUIREMENTS" ]]; then
-  download_fw "prod" || echo "ERROR: failed to download FPGA and RTOS artifacts"
+  download_fw || echo "ERROR: failed to download FPGA and RTOS artifacts"
 else
   REQUIREMENTS_M4="$D/requirements.yaml.m4"
   REQUIREMENTS_OUT="${REQUIREMENTS_M4%.m4}"


### PR DESCRIPTION
Test strategy:
1. with aws credentials (succeeds as expected): 
m4 -DM4_BUCKET=swiftnav-artifacts -DM4_FW_VERSION=v1.5.0-develop-2018062919 -DM4_NAP_VERSION=v1.5.0-develop-2018062919 fetch_firmware.sh.m4 > fetch_firmware.sh
./fetch_firmware.sh

2. without aws credentials (fails as expected):
m4 -DM4_BUCKET=swiftnav-artifacts -DM4_FW_VERSION=v1.5.0-develop-2018062919 -DM4_NAP_VERSION=v1.5.0-develop-2018062919 fetch_firmware.sh.m4 > fetch_firmware.sh
./fetch_firmware.sh

3. with aws credentials (succeeds as expected):
m4 -DM4_BUCKET=swiftnav-artifacts -DM4_FW_VERSION=v1.6.3 -DM4_NAP_VERSION=v1.6.3 fetch_firmware.sh.m4 > fetch_firmware.sh
./fetch_firmware.sh

4. without aws credentials (fails as expected):
m4 -DM4_BUCKET=swiftnav-artifacts -DM4_FW_VERSION=v1.6.3 -DM4_NAP_VERSION=v1.6.3 fetch_firmware.sh.m4 > fetch_firmware.sh
./fetch_firmware.sh

5. without aws credentials (succeeds as expected):
m4 -DM4_BUCKET=swiftnav-releases -DM4_FW_VERSION=v1.6.3 -DM4_NAP_VERSION=v1.6.3 fetch_firmware.sh.m4 > fetch_firmware.sh
./fetch_firmware.sh