### PR TITLE
Prevent dhcpcd from grabbing eth0 [DEVC-802] [v1.6]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S09sysctl
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S09sysctl
@@ -3,3 +3,4 @@ chmod a+rwx /tmp/cores
 /sbin/sysctl -p /etc/sysctl.conf
 mkdir -p /var/run/fifos
 chmod 1777 /var/run/fifos
+echo "denyinterfaces eth0" >> /etc/dhcpcd.conf

--- a/board/piksiv3/rootfs-overlay/etc/network/interfaces
+++ b/board/piksiv3/rootfs-overlay/etc/network/interfaces
@@ -3,4 +3,3 @@ iface lo inet loopback
 
 auto eth0
 iface eth0 inet manual
-

--- a/package/common_init/overlay/etc/ifplugd/ifplugd.action
+++ b/package/common_init/overlay/etc/ifplugd/ifplugd.action
@@ -11,21 +11,33 @@ source /etc/init.d/logging.sh
 
 setup_loggers
 
+has_dhcp()
+{
+  grep -q dhcp /etc/network/interfaces
+}
+
+has_dhcp_yn()
+{
+  has_dhcp && echo y || echo n
+}
+
+env
+
 case "$action" in
   up)
-    logi "bringing interface '$interface' up"
-    sudo ifup $interface; status=$?
+    logi "bringing interface '$interface' up (dhcp: $(has_dhcp_yn))"
+    ifup $interface; status=$?
     if [[ $status -ne 0 ]] ; then
       logw "ifup reported non-zero exit status: $status"
     fi
-    if grep -q dhcp /etc/network/interfaces; then
+    if has_dhcp; then
       dhcpcd --rebind $interface
     fi
     break
   ;;
   down)
     logi "bringing interface '$interface' down"
-    sudo ifdown $interface; status=$?
+    ifdown $interface; status=$?
     if [[ $status -ne 0 ]] ; then
       logw "ifdown reported non-zero exit status: $?"
     fi
@@ -36,3 +48,5 @@ case "$action" in
     break;
   ;;
 esac
+
+# vim: ft=sh:

--- a/package/common_init/overlay/etc/init.d/S83ifplugd
+++ b/package/common_init/overlay/etc/init.d/S83ifplugd
@@ -5,17 +5,4 @@ cmd="/etc/init.d/ifplugd.sh"
 dir="/"
 user="ifplugd"
 
-setup_permissions()
-{
-  cp /bin/busybox /bin/busybox.ifplugd
-
-  echo '#!/bin/ash'                        > /bin/ash.ifplugd
-  echo 'exec /bin/busybox.ifplugd ash $@' >> /bin/ash.ifplugd
-
-  chmod +x /bin/ash.ifplugd
-
-  # Add the network admin capability
-  setcap cap_net_admin+ep /bin/busybox.ifplugd
-}
-
 source /etc/init.d/template_runsv.inc.sh

--- a/package/common_init/overlay/etc/init.d/ifplugd.sh
+++ b/package/common_init/overlay/etc/init.d/ifplugd.sh
@@ -1,4 +1,4 @@
-#!/bin/ash.ifplugd
+#!/bin/ash
 
 log_tag=ifplugd_sh
 source /etc/init.d/logging.sh
@@ -17,6 +17,8 @@ cleanup()
 
   [[ -z "$pid" ]] || \
     kill -TERM $pid
+
+  sudo ifplugd -k
 }
 
 trap 'cleanup_loggers; cleanup; exit 0' HUP TERM STOP EXIT
@@ -26,8 +28,9 @@ run_ifplugd()
   local opts=
 
   opts="$opts -I "             # Don't exit on nonzero exit code from script
-#  opts="$opts -q "             # Don't run "down" script on exit
-#  opts="$opts -p "             # Don't run "up" script on start-up
+  opts="$opts -a "             # Don't up interface at each link probe
+  opts="$opts -q "             # Don't run "down" script on exit
+  opts="$opts -p "             # Don't run "up" script on start-up
   opts="$opts -n "             # Don't daemonize
   opts="$opts -i $interface "  # The interface to monitor
   opts="$opts -t $poll_delay " # How often to poll the device

--- a/package/common_init/overlay/etc/sudoers.d/ifplugd
+++ b/package/common_init/overlay/etc/sudoers.d/ifplugd
@@ -1,3 +1,1 @@
-ifplugd ALL=(ALL) NOPASSWD: /sbin/ifup
-ifplugd ALL=(ALL) NOPASSWD: /sbin/ifdown
 ifplugd ALL=(ALL) NOPASSWD: /usr/sbin/ifplugd

--- a/package/libnetwork/docs/about.md
+++ b/package/libnetwork/docs/about.md
@@ -19,7 +19,7 @@ remove the need for external, host-provided network connectivity.
 The `skylark_daemon` listens for Skylark configuration and starts and stops
 itself in upload and download mode as necessary. The upload and download daemons
 run independently for improved robustness and simplicity, pulling and pushing
-SBP data to two Skylark-specific ZeroMQ ports that are exposed on the Linux host
+SBP data to two Skylark-specific Nanomsg ports that are exposed on the Linux host
 are routed to the firmware: `tcp://127.0.0.1:43080` and `tcp://127.0.0.1:43081`,
 respectively. Taken together, these run with:
 

--- a/package/piksi_system_daemon/overlay/etc/init.d/update_eth0_config
+++ b/package/piksi_system_daemon/overlay/etc/init.d/update_eth0_config
@@ -14,36 +14,59 @@ if [[ "$mode" == "static" ]]; then
 fi
 
 interfaces=/etc/network/interfaces
+deny_interfaces="denyinterfaces eth0"
+dhcpcd_conf=/etc/dhcpcd.conf
 
 interfaces_tmp=$(mktemp)
 trap "rm -f $interfaces_tmp; cleanup_loggers; exit 0" EXIT TERM STOP HUP
 
-if [[ "$mode" == "dhcp" ]]; then
+config_dhcp()
+{
   echo "iface eth0 inet dhcp" >$interfaces_tmp
-elif [[ "$mode" == "static" ]]; then
+
+  if grep -q "$deny_interfaces" $dhcpcd_conf; then
+    sed -i -e '/denyinterfaces eth0/d' /etc/dhcpcd.conf
+  fi
+}
+
+config_static()
+{
   cat >$interfaces_tmp <<EOF
 iface eth0 inet static
 	address $ip_addr
 	netmask $netmask
 	gateway $gateway
 EOF
+
+  if ! grep -q "$deny_interfaces" $dhcpcd_conf; then
+    echo $deny_interfaces >>$dhcpcd_conf
+  fi
+}
+
+if [[ "$mode" == "dhcp" ]]; then
+  config_dhcp
+elif [[ "$mode" == "static" ]]; then
+  config_static
 else
   loge "Unknown network mode"
 fi
 
 if diff -q $interfaces_tmp $interfaces &>/dev/null; then
-
   logi "Interface config unchanged, exiting"
-
   exit 0
 fi
 
 logi "Interface config changed, reconfiguring..."
 
 /etc/init.d/S83ifplugd stop
+/etc/init.d/S41dhcpcd stop
+
 ifdown -f eth0
 
 mv $interfaces_tmp $interfaces
 chmod 0644 $interfaces
 
 /etc/init.d/S83ifplugd start
+/etc/init.d/S41dhcpcd start
+
+ifup -f eth0


### PR DESCRIPTION
+ There's a behavior change in dhcpcd that seems to cause it to grab
eth0 regardless of what's in `/etc/network/interfaces`-- fix this by
configuring `/etc/dhcpcd.conf` to ignore eth0 initially.

+ Give `template_runsv.sh` better quoting of arguments so it'll be more
likely to pass through a linter.

+ Make `template_runsv.sv` no try to remove the service directory after
it's been generated (which causes runsv to spit out errors).

+ Remove some of the setcap stuff from the ifplugd.sh script which isn't
needed since ifplugd is run with sudo now

+ Make ifplugd run less often with -a, -q, and -p

Related issues: DEVC-836, DEVC-780, DEVC-806, DEVC-733, DEVC-801, DEVC-784