### PR TITLE
[DEVC-570] mtd driver to support macronix flash

### DIFF
--- a/board/piksiv3/patches/linux/0004-mtd-spi-nor-macronix-ear-read-write-support.patch
+++ b/board/piksiv3/patches/linux/0004-mtd-spi-nor-macronix-ear-read-write-support.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
+index 0f2a7a56760e..599a8c06dd4f 100644
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -274,7 +274,7 @@ static int read_ear(struct spi_nor *nor, struct flash_info *info)
+ 	if (JEDEC_MFR(info) == CFI_MFR_AMD)
+ 		code = SPINOR_OP_BRRD;
+ 	/* This is actually Micron */
+-	else if (JEDEC_MFR(info) == CFI_MFR_ST)
++	else if (JEDEC_MFR(info) == CFI_MFR_ST || JEDEC_MFR(info) == CFI_MFR_MACRONIX)
+ 		code = SPINOR_OP_RDEAR;
+ 	else
+ 		return -EINVAL;
+@@ -381,7 +381,7 @@ static int write_ear(struct spi_nor *nor, u32 addr)
+ 
+ 	if (nor->jedec_id == CFI_MFR_AMD)
+ 		code = SPINOR_OP_BRWR;
+-	if (nor->jedec_id == CFI_MFR_ST) {
++	if (nor->jedec_id == CFI_MFR_ST || nor->jedec_id == CFI_MFR_MACRONIX) {
+ 		write_enable(nor);
+ 		code = SPINOR_OP_WREAR;
+ 	}


### PR DESCRIPTION
Patch to the mtd/spi-nor driver needed to get Macronix MX25L51245G sample board to boot with a production image as well as use the upgrade_tool without issues.

Reference findings:
https://swift-nav.atlassian.net/wiki/spaces/~42118676/pages/234717346/Macronix+Flash+Bring+Up+Findings