### PR TITLE
Add rx_attach to network_daemon and cell_modem_daemon [DEVC-850]

### DIFF
--- a/package/cell_modem_daemon/src/cell_modem_daemon.c
+++ b/package/cell_modem_daemon/src/cell_modem_daemon.c
@@ -203,6 +203,10 @@ int main(int argc, char *argv[])
 
     cell_modem_init(loop, settings_ctx);
 
+    if (sbp_rx_attach(sbp_pubsub_rx_ctx_get(ctx), loop) != 0) {
+      exit(cleanup(&loop, &settings_ctx, &ctx, &port, EXIT_FAILURE));
+    }
+
     pk_loop_run_simple(loop);
   }
 

--- a/package/network_daemon/src/network_daemon.c
+++ b/package/network_daemon/src/network_daemon.c
@@ -160,6 +160,10 @@ int main(int argc, char *argv[])
     return cleanup(&loop, &ctx, EXIT_FAILURE);
   }
 
+  if (sbp_rx_attach(sbp_pubsub_rx_ctx_get(ctx), loop) != 0) {
+    return cleanup(&loop, &ctx, EXIT_FAILURE);
+  }
+
   pk_loop_run_simple(loop);
   piksi_log(LOG_DEBUG, "Network Daemon: Normal Exit");
 


### PR DESCRIPTION
Partial solution for DEVC-850, which adds sbp_rx_attach for the network_daemon and cell_modem_daemon to their respective rx/tx queues will be emptied.