### PR TITLE
Fixup typo in sbp_router_smoothpose.yml

### DIFF
--- a/package/sbp_protocol/src/sbp_router_smoothpose.yml
+++ b/package/sbp_protocol/src/sbp_router_smoothpose.yml
@@ -110,7 +110,7 @@ ports:
 
   - name: SBP_PORT_FILEIO_FIRMWARE
     pub_addr: "ipc:///var/run/sockets/fileio_firmware.pub"
-    sub_addr: "var/run/sockets/fileio_firmware.sub"
+    sub_addr: "ipc:///var/run/sockets/fileio_firmware.sub"
     forwarding_rules:
       - dst_port: SBP_PORT_FIRMWARE
         filters:
@@ -144,7 +144,7 @@ ports:
         filters:
           - { action: ACCEPT }
       # As long as no receivers echo this message back, then this is not a loop!  This is were
-      #  we actually need a 'bus' style socket
+      #  we actually need a 'bus' style socket.
       - dst_port: SBP_PORT_SETTINGS_CLIENT
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response


### PR DESCRIPTION
~/s/p/p/s/src ❯❯❯ diff sbp_router.yml sbp_router_smoothpose.yml
diff --git a/sbp_router.yml b/sbp_router_smoothpose.yml
index d426f850..e6250097 100644
--- a/sbp_router.yml
+++ b/sbp_router_smoothpose.yml
@@ -1,3 +1,10 @@
+# This file is a variant the stock sbp_router.yml With it, the router sends the
+# "best position" and "best velocity" estimates through a new nav_daemon port
+# before going to the external interfaces.  It can be used to allow a process
+# like a loosely coupled INS filter to intercept and transform the best GNSS
+# position and velocity estimates they go on the wire The key changes to the
+# stock config are highlihged with the string **Smoothpose Change**
+
 name: SBP_ROUTER
 ports:
   - name: SBP_PORT_FIRMWARE
@@ -21,6 +28,14 @@ ports:
           - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
           - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
           - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  **Smoothpose Change**
           - { action: ACCEPT }
       - dst_port: SBP_PORT_FILEIO_FIRMWARE
         filters:
