### PR TITLE
EX-245: update gnss_convertors and librtcm for week rollover fixes

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.53
+GNSS_CONVERTORS_VERSION = v0.3.54
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.25
+LIBRTCM_VERSION = v0.2.26
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/rtcm3_protocol/src/framer_rtcm3.c
+++ b/package/rtcm3_protocol/src/framer_rtcm3.c
@@ -10,6 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <libpiksi/logging.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -175,6 +176,7 @@ uint32_t framer_process(void *state, const uint8_t *data, uint32_t data_length,
                          (s->buffer[total_length - 1] <<  0);
     if (frame_crc != computed_crc) {
       s->remove_count = 1;
+      piksi_log(LOG_INFO, "RTCM CRC error, buffer length %u\n", total_length);
       continue;
     }
 

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -144,7 +144,6 @@ static void ephemeris_glo_callback(u16 sender_id, u8 len, u8 msg[], void *contex
   (void) len;
   msg_ephemeris_glo_t *e = (msg_ephemeris_glo_t*)msg;
 
-  piksi_log(LOG_INFO, "FCN %u for sat %u", e->fcn, e->common.sid.sat);
   /* extract just the FCN field */
   rtcm2sbp_set_glo_fcn(e->common.sid, e->fcn, &state);
 }


### PR DESCRIPTION
Pull in https://github.com/swift-nav/gnss-converters/pull/95 and https://github.com/swift-nav/librtcm/pull/49 that should fix missing observations at TOW=0.

Additionally log CRC errors in RTCM framer to get some visibility of possible problems there.

