### PR TITLE
[v16] DEVC954: Try using larger framer_rtcm3_state buffer

### DIFF
--- a/package/rtcm3_protocol/src/framer_rtcm3.c
+++ b/package/rtcm3_protocol/src/framer_rtcm3.c
@@ -132,10 +132,6 @@ uint32_t framer_process(void *state, const uint8_t *data, uint32_t data_length,
       if (count > available) {
         count = available;
       }
-      if (count > RTCM3_BUFFER_SIZE - s->buffer_length) {
-        piksi_log(LOG_INFO, "RTCM buffer full\n");
-        count = RTCM3_BUFFER_SIZE - s->buffer_length;
-      }
       memcpy(&s->buffer[s->buffer_length], &data[data_offset], count);
       s->buffer_length += count;
       data_offset += count;

--- a/package/rtcm3_protocol/src/framer_rtcm3.c
+++ b/package/rtcm3_protocol/src/framer_rtcm3.c
@@ -21,9 +21,10 @@
 #define RTCM3_HEADER_LENGTH 3
 #define RTCM3_FOOTER_LENGTH 3
 #define RTCM3_FRAME_SIZE_MAX 1029
+#define RTCM3_BUFFER_SIZE (2*RTCM3_FRAME_SIZE_MAX)
 
 typedef struct {
-  uint8_t buffer[RTCM3_FRAME_SIZE_MAX];
+  uint8_t buffer[RTCM3_BUFFER_SIZE];
   uint32_t buffer_length;
   uint32_t refill_count;
   uint32_t remove_count;
@@ -131,7 +132,10 @@ uint32_t framer_process(void *state, const uint8_t *data, uint32_t data_length,
       if (count > available) {
         count = available;
       }
-
+      if (count > RTCM3_BUFFER_SIZE - s->buffer_length) {
+        piksi_log(LOG_INFO, "RTCM buffer full\n");
+        count = RTCM3_BUFFER_SIZE - s->buffer_length;
+      }
       memcpy(&s->buffer[s->buffer_length], &data[data_offset], count);
       s->buffer_length += count;
       data_offset += count;


### PR DESCRIPTION
Bug https://swift-nav.atlassian.net/browse/EX-251 reports how the whole RTCM MSM Beidou message often is dropped because CRC if there are enough observations.

Increasing the RTCM framer buffer size seems to fix the bug, but we don't yet know why.

This PR also adds buffer bounds check and logging if it was about to be exceeded.