### PR TITLE
Fix standalone logging permissions [DEVC-848]

### DIFF
--- a/board/piksiv3/user_tables
+++ b/board/piksiv3/user_tables
@@ -1,0 +1,1 @@
+extio -1 extio -1 = - /bin/sh  - User and Group for sdcard / usb flash access

--- a/configs/piksiv3_defconfig
+++ b/configs/piksiv3_defconfig
@@ -22,6 +22,7 @@ BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_MDEV=y
 BR2_ROOTFS_DEVICE_TABLE="$(BR2_EXTERNAL_piksi_buildroot_PATH)/board/piksiv3/device_table.txt"
 # BR2_TARGET_GENERIC_GETTY is not set
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_piksi_buildroot_PATH)/board/piksiv3/rootfs-overlay"
+BR2_ROOTFS_USERS_TABLES="$(BR2_EXTERNAL_piksi_buildroot_PATH)/board/piksiv3/user_tables"
 BR2_ROOTFS_POST_BUILD_SCRIPT="$(BR2_EXTERNAL_piksi_buildroot_PATH)/board/piksiv3/post_build.sh"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="$(BR2_EXTERNAL_piksi_buildroot_PATH)/board/piksiv3/post_image.sh"
 BR2_LINUX_KERNEL=y

--- a/package/common_init/overlay/etc/init.d/S83standalone_file_logger
+++ b/package/common_init/overlay/etc/init.d/S83standalone_file_logger
@@ -1,8 +1,14 @@
 #!/bin/sh
+source /etc/init.d/common.sh
 
 name="standalone_file_logger"
 cmd="standalone_file_logger -d /media/sda1/ -s 'ipc:///var/run/sockets/external.pub'"
 dir="/"
 user="stndfl"
+
+# put user into extio group that has access to external io like sdcard / usb thumbdrive
+setup_permissions() {
+  add_user_to_group "stndfl" "extio"
+}
 
 source /etc/init.d/template_runsv.inc.sh

--- a/package/common_init/overlay/etc/init.d/common.sh
+++ b/package/common_init/overlay/etc/init.d/common.sh
@@ -58,6 +58,22 @@ add_service_user()
   has_user $user || adduser -S -D -H -G $user $user
 }
 
+check_group()
+{
+  local user=$1; shift
+  local group=$1; shift
+
+  id -nG $user | grep -qw $group
+}
+
+add_user_to_group()
+{
+  local user=$1; shift
+  local group=$1; shift
+
+  check_group $user $group || adduser $user $group
+}
+
 _release_lockdown=/etc/release_lockdown
 
 lockdown()

--- a/package/common_init/overlay/etc/mdev.conf
+++ b/package/common_init/overlay/etc/mdev.conf
@@ -36,8 +36,8 @@ mouse[0-9]          root:root 640 =input/
 ts[0-9]             root:root 600 =input/
 
 # mmc
-sd[a-z]             root:root 660
-mmcblk[0-9]         root:root 660
-sd[a-z][0-9]        root:root 660 */lib/mdev/automount.sh
-mmcblk[0-9]p[0-9]   root:root 660 */lib/mdev/automount.sh
+sd[a-z]             root:extio 660
+mmcblk[0-9]         root:extio 660
+sd[a-z][0-9]        root:extio 660 */lib/mdev/automount.sh
+mmcblk[0-9]p[0-9]   root:extio 660 */lib/mdev/automount.sh
 

--- a/package/common_init/overlay/lib/mdev/automount.sh
+++ b/package/common_init/overlay/lib/mdev/automount.sh
@@ -44,6 +44,10 @@ do_mount()
     rmdir $mountpoint
     exit 1
   fi
+  if ! chgrp extio $mountpoint ; then
+    loge "Unable to change group of mountpoint..."
+    exit 1
+  fi
 }
 
 if [[ -f /var/run/automount_disabled ]]; then


### PR DESCRIPTION
I noticed that the standalone file logger didn't have write permission to the sdcard.   This is my attempt to fix while adding future capability to read and write from the sdcard and usb thumbdrive from other user accounts.

Once this looks good, I'll create a release equivalent