### PR TITLE
Update uboot to 60s watchdog

### DIFF
--- a/package/uboot_custom/uboot_custom.mk
+++ b/package/uboot_custom/uboot_custom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UBOOT_CUSTOM_VERSION = 91cd8d8ac2a41b2fb627139be9341624b93eeecc
+UBOOT_CUSTOM_VERSION = 19c7bfee543704c1476b0239657df0bbc390d27e
 UBOOT_CUSTOM_SITE = https://github.com/swift-nav/u-boot-xlnx.git
 UBOOT_CUSTOM_SITE_METHOD = git
 UBOOT_CUSTOM_DEPENDENCIES = host-dtc host-uboot-tools host-openssl


### PR DESCRIPTION
This is a patch to issues seen in [DEVC-862](https://swift-nav.atlassian.net/browse/DEVC-862) with devices rebooting multiple times during starts tests. Long term solution is to understand why the boot time has increased and define a proper limit for the watchdog