### PR TITLE
Manually set the system time from the RTC [DEVC-1000]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S98rtc_load
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S98rtc_load
@@ -5,6 +5,7 @@ name="rtc_load"
 start()
 {
   modprobe rtc-m41t80
+  hwclock -s
 }
 
 stop()


### PR DESCRIPTION
Manually loading the rtc module doesn't seem to actually set the system
time using the value stored in the RTC.  Correct this by manually
calling the hwclock utility to set the Linux system time from the RTC.