### PR TITLE
Increase piksi_firmware init UART timeout past watchdog

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S85piksi_firmware
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S85piksi_firmware
@@ -11,8 +11,8 @@ setup_loggers
 
 settings_ini=/persistent/config.ini
 
-uart_wait_count_limit=20 # wait 2s
-uart_check_interval=0.1
+uart_wait_count_limit=200 # wait 200s
+uart_check_interval=1
 
 svc_path()
 {

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S85piksi_firmware
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S85piksi_firmware
@@ -11,8 +11,8 @@ setup_loggers
 
 settings_ini=/persistent/config.ini
 
-uart_wait_count_limit=200 # wait 200s
-uart_check_interval=1
+uart_wait_count_limit=2000 # wait 200s
+uart_check_interval=0.1
 
 svc_path()
 {

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S85piksi_firmware
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S85piksi_firmware
@@ -2,6 +2,13 @@
 
 name="piksi_firmware"
 
+source /etc/init.d/common.sh
+
+log_tag=$name # required by logging.sh
+source /etc/init.d/logging.sh
+
+setup_loggers
+
 settings_ini=/persistent/config.ini
 
 uart_wait_count_limit=20 # wait 2s
@@ -57,7 +64,7 @@ wait_services()
 
     if [[ $uart_wait_count -ge $uart_wait_count_limit ]]; then
 
-      echo "Timeout expired while waiting for UARTs" | sbp_log --err
+      loge --sbp "Timeout expired while waiting for UARTs" 
       break;
     fi
 
@@ -72,8 +79,9 @@ start()
 
   if [ -f "/lib/firmware/piksi_firmware.elf" ]; then
     modprobe zynq_remoteproc
+    logi "Remoteproc modprobe complete: $?"
   else
-    echo "ERROR: firmware not found"
+    loge "ERROR: firmware not found"
   fi
 }
 


### PR DESCRIPTION
Minimal bench testing here, but I have added logging facility to allow these activities to be caught in `syslog` while increasing the timeout on waiting for uarts to come up.