### PR TITLE
Use SA_SIGINFO so we can know who sent a signal

### DIFF
--- a/package/libnetwork/src/libnetwork.c
+++ b/package/libnetwork/src/libnetwork.c
@@ -879,7 +879,7 @@ static void log_with_rate_limit(network_context_t* ctx, int priority, const char
 
 static void network_request(network_context_t* ctx, CURL *curl)
 {
-  char error_buf[CURL_ERROR_SIZE];
+  char error_buf[CURL_ERROR_SIZE] = {0};
 
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER,       error_buf);
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 15000L);

--- a/package/skylark_daemon/src/skylark_daemon.c
+++ b/package/skylark_daemon/src/skylark_daemon.c
@@ -171,9 +171,11 @@ static int parse_options(int argc, char *argv[])
   return 0;
 }
 
-static void terminate_handler(int signum)
+static void terminate_handler(int signum, siginfo_t *info, void *ucontext)
 {
-  piksi_log(LOG_DEBUG, "terminate_handler: received signal: %d", signum);
+  (void)ucontext;
+
+  piksi_log(LOG_DEBUG, "terminate_handler: received signal: %d, sender: %d", signum, info->si_pid);
   libnetwork_shutdown();
 }
 
@@ -217,15 +219,18 @@ static void setup_terminate_handler()
 {
   /* Set up handler for signals which should terminate the program */
 
-  if (signal(SIGINT, terminate_handler) == SIG_ERR) goto error;
-  if (signal(SIGTERM, terminate_handler) == SIG_ERR) goto error;
-  if (signal(SIGQUIT, terminate_handler) == SIG_ERR) goto error;
+  struct sigaction terminate_sa;
+  terminate_sa.sa_sigaction = terminate_handler;
+  sigemptyset(&terminate_sa.sa_mask);
+  terminate_sa.sa_flags = SA_SIGINFO;
 
-  return;
-
-error:
-  piksi_log(LOG_ERR, "error setting up terminate handler: %s", strerror(errno));
-  exit(-1);
+  if ((sigaction(SIGINT, &terminate_sa, NULL) != 0) ||
+      (sigaction(SIGTERM, &terminate_sa, NULL) != 0) ||
+      (sigaction(SIGQUIT, &terminate_sa, NULL) != 0))
+  {
+    piksi_log(LOG_ERR, "error setting up terminate handler: %s", strerror(errno));
+    exit(-1);
+  }
 }
 
 static void skylark_upload_mode()


### PR DESCRIPTION
+ Don't use `signal()` since the man page says not to use it.

+ Use SA_SIGACTION flag so that we can get info on who sent use a terminate signal

+ Initialize curl error buffer so we don't log garbage