### PR TITLE
Initialize pid fields, SIGCHLD records process exit [DEVC-1033]

### DIFF
--- a/package/libpiksi/libpiksi/include/libpiksi/util.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/util.h
@@ -60,7 +60,9 @@ int device_uuid_get(char *str, size_t str_size);
  */
 bool device_is_duro(void);
 
-void reap_children(bool debug);
+typedef void (*child_exit_fn_t)(pid_t pid);
+
+void reap_children(bool debug, child_exit_fn_t exit_handler);
 
 void setup_sigchild_handler(void (*handler)(int));
 

--- a/package/libpiksi/libpiksi/src/util.c
+++ b/package/libpiksi/libpiksi/src/util.c
@@ -97,7 +97,7 @@ bool device_is_duro(void)
                  strlen(DEVICE_DURO_ID_STRING)) == 0);
 }
 
-void reap_children(bool debug)
+void reap_children(bool debug, child_exit_fn_t exit_handler)
 {
   int errno_saved = errno;
   int status;
@@ -105,17 +105,25 @@ void reap_children(bool debug)
   pid_t child_pid;
 
   while ((child_pid = waitpid(-1, &status, WNOHANG)) > 0) {
-    if (debug) {
-      if (WIFEXITED(status)) {
+    if (WIFEXITED(status)) {
+      if (exit_handler != NULL) exit_handler(child_pid);
+      if (debug) {
         piksi_log(LOG_DEBUG, "%s: child (pid: %d) exit status: %d",
                   __FUNCTION__, child_pid, WEXITSTATUS(status));
-      } else if (WIFSIGNALED(status)) {
+      }
+    } else if (WIFSIGNALED(status)) {
+      if (exit_handler != NULL) exit_handler(child_pid);
+      if (debug) {
         piksi_log(LOG_DEBUG, "%s: child (pid: %d) term signal: %d",
                   __FUNCTION__, child_pid, WTERMSIG(status));
-      } else if (WIFSTOPPED(status)) {
+      }
+    } else if (WIFSTOPPED(status)) {
+      if (debug) {
         piksi_log(LOG_DEBUG, "%s: child (pid: %d) stop signal: %d",
                   __FUNCTION__, child_pid, WSTOPSIG(status));
-      } else {
+      }
+    } else {
+      if (debug) {
         piksi_log(LOG_DEBUG, "%s: child (pid: %d) unknown status: %d",
                   __FUNCTION__, child_pid, status);
       }

--- a/package/ntrip_daemon/src/ntrip_daemon.c
+++ b/package/ntrip_daemon/src/ntrip_daemon.c
@@ -285,16 +285,17 @@ static int ntrip_client_loop(void)
 
 static void sigchild_handler(int signum)
 {
-  (void) signum;
-
-  if (debug) piksi_log(LOG_DEBUG, "%s: received SIGCHILD", __FUNCTION__);
-  reap_children(debug);
+  if (debug) {
+    piksi_log(LOG_DEBUG, "%s: received signal %s(%d)",
+              __FUNCTION__, signum == SIGCHLD ? "SIGCHLD " : "", signum);
+  }
+  reap_children(debug, ntrip_record_exit);
 }
 
 static void settings_loop_terminate()
 {
   ntrip_stop_processes();
-  reap_children(debug);
+  reap_children(debug, NULL);
 }
 
 static int ntrip_settings_loop(void)

--- a/package/ntrip_daemon/src/ntrip_settings.h
+++ b/package/ntrip_daemon/src/ntrip_settings.h
@@ -18,5 +18,6 @@
 void ntrip_init(settings_ctx_t *settings_ctx);
 bool ntrip_reconnect(void);
 void ntrip_stop_processes(void);
+void ntrip_record_exit(pid_t pid);
 
 #endif

--- a/package/skylark_daemon/src/skylark_daemon.c
+++ b/package/skylark_daemon/src/skylark_daemon.c
@@ -181,8 +181,11 @@ static void terminate_handler(int signum, siginfo_t *info, void *ucontext)
 
 static void sigchild_handler(int signum)
 {
-  piksi_log(LOG_DEBUG, "%s: received signal: %d", __FUNCTION__, signum);
-  reap_children(debug);
+  if (debug) {
+    piksi_log(LOG_DEBUG, "%s: received signal %s(%d)",
+              __FUNCTION__, signum == SIGCHLD ? "SIGCHLD " : "", signum);
+  }
+  reap_children(debug, skylark_record_exit);
 }
 
 static void cycle_connection(int signum)
@@ -302,7 +305,7 @@ static void skylark_download_mode()
 static void settings_loop_terminate()
 {
   skylark_stop_processes();
-  reap_children(debug);
+  reap_children(debug, NULL);
 }
 
 static void skylark_settings_loop(void)

--- a/package/skylark_daemon/src/skylark_settings.c
+++ b/package/skylark_daemon/src/skylark_settings.c
@@ -91,10 +91,10 @@ static int skylark_download_adapter_execfn(void) {
 }
 
 static skylark_process_t skylark_processes[] = {
-  { .execfn = skylark_upload_daemon_execfn },
-  { .execfn = skylark_upload_adapter_execfn },
-  { .execfn = skylark_download_adapter_execfn },
-  { .execfn = skylark_download_daemon_execfn },
+  { .pid = 0, .execfn = skylark_upload_daemon_execfn },
+  { .pid = 0, .execfn = skylark_upload_adapter_execfn },
+  { .pid = 0, .execfn = skylark_download_adapter_execfn },
+  { .pid = 0, .execfn = skylark_download_daemon_execfn },
 };
 
 static const size_t skylark_processes_count = COUNT_OF(skylark_processes);
@@ -108,6 +108,7 @@ static void skylark_stop_process(size_t i)
       piksi_log(LOG_ERR, "kill pid %d error (%d) \"%s\"",
                 process->pid, errno, strerror(errno));
     }
+    sleep(0.1); // allow us to receive sigchild
     process->pid = 0;
   }
 }
@@ -116,6 +117,18 @@ void skylark_stop_processes()
 {
   for (size_t i = 0; i < skylark_processes_count; i++) {
     skylark_stop_process(i);
+  }
+}
+
+void skylark_record_exit(pid_t pid)
+{
+  for (size_t i = 0; i < skylark_processes_count; i++) {
+    skylark_process_t *process = &skylark_processes[i];
+    if (process->pid != 0 && process->pid == pid) {
+      piksi_log(LOG_DEBUG, "known child process pid %d exitted", process->pid);
+      process->pid = 0;
+      return;
+    }
   }
 }
 

--- a/package/skylark_daemon/src/skylark_settings.h
+++ b/package/skylark_daemon/src/skylark_settings.h
@@ -18,5 +18,6 @@
 void skylark_init(settings_ctx_t *settings_ctx);
 bool skylark_reconnect_dl(void);
 void skylark_stop_processes(void);
+void skylark_record_exit(pid_t pid);
 
 #endif


### PR DESCRIPTION
+ Prevent potentially sending kill to an un-initialized value by
initializing the fields that track child processes.

+ Allow SIGCHLD handler to record a process's exit