### PR TITLE
Relative CCACHE_DIR

### DIFF
--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -23,7 +23,7 @@ LOWER_USER = $(shell echo $(USER) | tr A-Z a-z)
 DOCKER_BUILD_VOLUME = piksi_buildroot-$(LOWER_USER)$(_DOCKER_SUFFIX)
 DOCKER_TAG = piksi_buildroot-$(LOWER_USER)$(_DOCKER_SUFFIX)
 
-CCACHE_DIR := /piksi_buildroot/buildroot/output/ccache
+CCACHE_DIR := piksi_buildroot/buildroot/output/ccache
 
 DOCKER_ENV_ARGS :=                                                            \
   -e USER=$(USER)                                                             \


### PR DESCRIPTION
This change killed my local build as it was trying to create a directory to root `mkdir -p /piksi_buildroot/buildroot/output/ccache`

https://github.com/swift-nav/piksi_buildroot/pull/786/files#diff-c50bda1dfb8b16e7cea87c1c238d6b3dR26

Let's see if Travis would be agreeable with a relative path?