### PR TITLE
Updated command line argument in  endpoint adapter [DEVC-1052]

### DIFF
--- a/package/endpoint_adapter/src/endpoint_adapter.c
+++ b/package/endpoint_adapter/src/endpoint_adapter.c
@@ -99,7 +99,6 @@ typedef ssize_t (*write_fn_t)(handle_t *handle, const void *buffer,
                               size_t count);
 
 bool debug = false;
-static bool name_set = false;
 static io_mode_t io_mode = IO_INVALID;
 static endpoint_mode_t endpoint_mode = ENDPOINT_INVALID;
 static const char *framer_name = FRAMER_NONE_NAME;
@@ -113,7 +112,7 @@ static int outq;
 
 static const char *pub_addr = NULL;
 static const char *sub_addr = NULL;
-static const char *port_name = "<unknown>";
+static const char *port_name = NULL;
 static char file_path[PATH_MAX] = "";
 static int tcp_listen_port = -1;
 static const char *tcp_connect_addr = NULL;
@@ -219,7 +218,6 @@ static int parse_options(int argc, char *argv[])
 
       case OPT_ID_NAME: {
         port_name = optarg;
-        name_set = true;
       }
       break;
 
@@ -347,7 +345,7 @@ static int parse_options(int argc, char *argv[])
     return -1;
   }
 
-  if(!name_set)
+  if(port_name == NULL)
   {
     fprintf(stderr, "adapter name not set\n");
     return -1;

--- a/package/endpoint_adapter/src/endpoint_adapter.c
+++ b/package/endpoint_adapter/src/endpoint_adapter.c
@@ -347,7 +347,7 @@ static int parse_options(int argc, char *argv[])
     return -1;
   }
 
-  if(name_set == false)
+  if(!name_set)
   {
     fprintf(stderr, "adapter name not set\n");
     return -1;

--- a/package/endpoint_adapter/src/endpoint_adapter.c
+++ b/package/endpoint_adapter/src/endpoint_adapter.c
@@ -99,6 +99,7 @@ typedef ssize_t (*write_fn_t)(handle_t *handle, const void *buffer,
                               size_t count);
 
 bool debug = false;
+static bool name_set = false;
 static io_mode_t io_mode = IO_INVALID;
 static endpoint_mode_t endpoint_mode = ENDPOINT_INVALID;
 static const char *framer_name = FRAMER_NONE_NAME;
@@ -218,6 +219,7 @@ static int parse_options(int argc, char *argv[])
 
       case OPT_ID_NAME: {
         port_name = optarg;
+        name_set = true;
       }
       break;
 
@@ -342,6 +344,12 @@ static int parse_options(int argc, char *argv[])
 
   if (endpoint_mode == ENDPOINT_INVALID) {
     fprintf(stderr, "endpoint address(es) not specified\n");
+    return -1;
+  }
+
+  if(name_set == false)
+  {
+    fprintf(stderr, "adapter name not set\n");
     return -1;
   }
 

--- a/package/ntrip_daemon/src/ntrip_settings.c
+++ b/package/ntrip_daemon/src/ntrip_settings.c
@@ -88,6 +88,7 @@ static int ntrip_daemon_execfn(void) {
 static int ntrip_adapter_execfn(void) {
   char *argv[] = {
     "endpoint_adapter",
+    "--name", "ntrip_daemon",
     "-f", "rtcm3",
     "--file", FIFO_FILE_PATH,
     "-p", "ipc:///var/run/sockets/rtcm3_external.sub",


### PR DESCRIPTION
* update enpoint_adapter.c to check of --name is set, return -1 otherwise

* update ntrip_daemonm.c to add the --name argument when invoke enpoint_adapter.