### PR TITLE
Configure UART0 and UART1 to be restarted by runit

### DIFF
--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -130,7 +130,7 @@ static port_config_t port_configs[] = {
     .mode_name_default = MODE_NAME_DEFAULT,
     .mode = MODE_DISABLED,
     .adapter_pid = PID_INVALID,
-    .restart = DO_NOT_RESTART,
+    .restart = RESTART,
     .first_start = true,
   },
   {
@@ -141,7 +141,7 @@ static port_config_t port_configs[] = {
     .mode_name_default = MODE_NAME_DEFAULT,
     .mode = MODE_DISABLED,
     .adapter_pid = PID_INVALID,
-    .restart = DO_NOT_RESTART,
+    .restart = RESTART,
     .first_start = true,
   },
   {


### PR DESCRIPTION
This is the potential hotfix candidate to get piksi_firmware up and running in the event that a uart adapater sputters out on boot.