### PR TITLE
Remove BR2_CCACHE_DIR for docker.mk

### DIFF
--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -23,8 +23,6 @@ LOWER_USER = $(shell echo $(USER) | tr A-Z a-z)
 DOCKER_BUILD_VOLUME = piksi_buildroot-$(LOWER_USER)$(_DOCKER_SUFFIX)
 DOCKER_TAG = piksi_buildroot-$(LOWER_USER)$(_DOCKER_SUFFIX)
 
-CCACHE_DIR := $(CURDIR)/buildroot/output/ccache
-
 DOCKER_ENV_ARGS :=                                                            \
   -e USER=$(USER)                                                             \
   -e GID=$(GID)                                                               \
@@ -34,7 +32,6 @@ DOCKER_ENV_ARGS :=                                                            \
   -e BR2_HAS_PIKSI_INS=$(BR2_HAS_PIKSI_INS)                                   \
   -e BR2_BUILD_SAMPLE_DAEMON=$(BR2_BUILD_SAMPLE_DAEMON)                       \
   -e BR2_BUILD_RELEASE_PROTECTED=$(BR2_BUILD_RELEASE_PROTECTED)               \
-  -e BR2_CCACHE_DIR=$(CCACHE_DIR)                                             \
   -e GITHUB_TOKEN=$(GITHUB_TOKEN)                                             \
   -e DISABLE_NIXOS_SUPPORT=$(DISABLE_NIXOS_SUPPORT)                           \
   -e CCACHE_READONLY=$(CCACHE_READONLY)                                       \


### PR DESCRIPTION
This is set inside of the buildroot config, so there's no reason to set
it in the environment.