### PR TITLE
Starling daemon.

### DIFF
--- a/package/starling_daemon/overlay/etc/init.d/S96starling_daemon
+++ b/package/starling_daemon/overlay/etc/init.d/S96starling_daemon
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+name="starling_daemon"
+cmd="piksi-multi-linux-starling"
+dir="/"
+user=""
+
+source /etc/init.d/template_runsv.inc.sh

--- a/package/starling_daemon/starling_daemon.mk
+++ b/package/starling_daemon/starling_daemon.mk
@@ -1,0 +1,29 @@
+################################################################################
+#
+# starling_daemon
+#
+################################################################################
+
+ifeq    ($(BR2_BUILD_STARLING_DAEMON),y)
+
+STARLING_DAEMON_VERSION = 0.1.0
+STARLING_DAEMON_SITE = "${BR2_EXTERNAL_piksi_buildroot_PATH}/package/starling_daemon"
+STARLING_DAEMON_SITE_METHOD = local
+STARLING_DAEMON_DEPENDENCIES = libuv libsbp libpiksi
+
+# KEVIN NEEDS HELP
+define SAMPLE_DAEMON_INSTALL_TARGET_CMDS
+	$(INSTALL) *.so /usr/lib/
+	$(INSTALL) piksi-multi-linux-starling /usr/bin
+endef
+
+# KEVIN NEEDS HELP
+define SAMPLE_DAEMON_BUILD_CMDS
+	${STARLING_DAEMON_SITE}/fetch_and_extract_tarball_from_github_releases.sh
+endef
+
+BR2_ROOTFS_OVERLAY += "${STARLING_DAEMON_SITE}/overlay"
+
+$(eval $(generic-package))
+
+endif # ($(BR2_BUILD_STARLING_DAEMON),y)


### PR DESCRIPTION
This PR attempts to set up the machinery for fetching the starling binaries (piksi-multi-linux-starling and various *.so) from github releases.

As we had discussed in the recent meeting, we would like to use common tools for fetching from github releases, so that part remains unimplemented here. I would definitely appreciate some advice on how we want to proceed.

Binaries can be fetched from here: https://github.com/swift-nav/starling-integrations/releases