### PR TITLE
Revert "Move skylark.enable registration to PFWP and add watch trigger (#790)"

### DIFF
--- a/package/skylark_daemon/src/skylark_settings.c
+++ b/package/skylark_daemon/src/skylark_settings.c
@@ -193,10 +193,10 @@ void skylark_init(settings_ctx_t *settings_ctx)
 
   mkfifo(DOWNLOAD_FIFO_FILE_PATH, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
-  settings_add_watch(settings_ctx, "skylark", "enable",
-                     &skylark_enabled, sizeof(skylark_enabled),
-                     SETTINGS_TYPE_BOOL,
-                     skylark_notify, NULL);
+  settings_register(settings_ctx, "skylark", "enable",
+                    &skylark_enabled, sizeof(skylark_enabled),
+                    SETTINGS_TYPE_BOOL,
+                    skylark_notify, NULL);
 
   settings_register(settings_ctx, "skylark", "url",
                     &skylark_url, sizeof(skylark_url),


### PR DESCRIPTION
This reverts commit 97b8bad284487d222ffc337313aee443cbd9475a which brought in the klobuchar change slated for master only, so we're taking it out of v2.1