### PR TITLE
Remove IMU_RAW from UART1 default whitelist

### DIFF
--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -74,7 +74,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UART1] = {
     .name = "uart1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2305,2306,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23


### PR DESCRIPTION
For Duro inertial, I think it is a good idea to remove raw IMU data from the UART1 default whitelist.  100Hz raw IMU data will start to eat a bit of the port per HITL graphs: (edited)

![image 2](https://user-images.githubusercontent.com/11276774/45648166-82532c00-ba7c-11e8-8798-4a8b146c5bcc.png)

It’s about 2kB/sec
Pasted image at 2018-09-14, 2:46 PM 
16,000 bits per second / 115200 is about 14% of overall bandwidth
![image 3](https://user-images.githubusercontent.com/11276774/45648173-85e6b300-ba7c-11e8-811a-0b5c3ca9cb1e.png)

I decided to leave AUX msg and Magnetometer messages since they are lower bandwidth.

requires corresponding piksi_tools PRs below to document as well