### PR TITLE
EX-345 Suppress unsupported codes in gnss-converters [v2.1]

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.60
+GNSS_CONVERTORS_VERSION = ec3f756e22d89f2ec4dec67805046bb0f3bef50e
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = ec3f756e22d89f2ec4dec67805046bb0f3bef50e
+GNSS_CONVERTORS_VERSION = v0.3.61
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.30
+LIBRTCM_VERSION = v0.2.31
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -12,6 +12,7 @@
 
 #include <assert.h>
 #include <getopt.h>
+#include <gnss-converters/sbp_nmea.h>
 #include <libpiksi/logging.h>
 #include <libpiksi/util.h>
 #include <libsbp/navigation.h>
@@ -20,7 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sbp_nmea.h>
 #include "sbp.h"
 
 #define PROGRAM_NAME "sbp_nmea_bridge"

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -12,6 +12,7 @@
 
 #include <assert.h>
 #include <getopt.h>
+#include <gnss-converters/rtcm3_sbp.h>
 #include <libpiksi/logging.h>
 #include <libsbp/navigation.h>
 #include <libsbp/sbp.h>
@@ -19,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <rtcm3_sbp.h>
 #include "sbp.h"
 
 #define PROGRAM_NAME "sbp_rtcm3_bridge"


### PR DESCRIPTION
Pull in https://github.com/swift-nav/gnss-converters/pull/123

## Testing

Fixes the issue https://swift-nav.atlassian.net/projects/EX/issues/EX-345 on bench.

The buildroot PR does better than 2.1 on HITL msm4 scenario: https://gnss-analysis.swiftnav.com/summary_type=q50&metrics_preset=pass_fail&scenario=live-roof-650-townsend-msm4&build_type=release&firmware_versions=v2.1.1-5-g89aaee46,v2.1.1&groupby_key=firmware&display_type=table
(one run failed RTK because of no base observations)
