### PR TITLE
revert Smoothpose pointer to 2.1.3

### DIFF
--- a/package/piksi_ins/piksi_ins.mk
+++ b/package/piksi_ins/piksi_ins.mk
@@ -13,7 +13,7 @@ endif # ! ($(BR2_BUILD_RELEASE_PROTECTED),y)
 
 $(info >>> Piksi INS is enabled, packaging with current image)
 
-PIKSI_INS_VERSION = v2.1.4 # Version 2.1.4 branch on September 17th, 2018
+PIKSI_INS_VERSION = v2.1.3 # Version 2.1.4 branch on September 17th, 2018
 PIKSI_INS_SITE = git@github.com:carnegieroboticsllc/piksi_ins.git
 PIKSI_INS_SITE_METHOD = git
 PIKSI_INS_INSTALL_STAGING = YES


### PR DESCRIPTION
2.1.4 pointer did not have updated libnanomsg and is not working - need 2.1.5 fix from CRL