### PR TITLE
Update gnss-convertors for rtcm1045 / code un-suppression

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.61
+GNSS_CONVERTORS_VERSION = v0.3.62
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.31
+LIBRTCM_VERSION = v0.2.32
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES


### PR DESCRIPTION
Pull in https://github.com/swift-nav/gnss-converters/pull/125 (RTCM1045 and bring back code enums from 23 onwards) and https://github.com/swift-nav/librtcm/pull/63 (GAL/BDS ephe placeholder size fixes)

/cc @mbavaro 