### PR TITLE
Fix versioning of clang-format for automated format checks [DEVC-1106]

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ rubric via `clang-format` to validate any style related changes that might be re
 (see [nits](https://stackoverflow.com/questions/27810522/what-does-nit-mean-in-hacker-speak)). This
 is in an effort to keep review focused on the functionality of the changes, and not on nits.
 
-Use the following target to format your changes before submitting (must have `clang-format<=5.0.1` installed):
+Use the following target to format your changes before submitting (must have `clang-format==5.0.1` installed):
 
 ```
 make clang-format

--- a/README.md
+++ b/README.md
@@ -189,3 +189,19 @@ To copy data out of docker, use the following make rule:
 ```
 make docker-cp SRC=/piksi_buildroot/buildroot/output/target/usr/bin/nap_linux DST=/tmp/nap_linux
 ```
+
+## Development
+
+### Formatting
+
+When submitting pull requests, automated build infrastructure will apply a standardized formatting
+rubric via `clang-format` to validate any style related changes that might be requested during review
+(see [nits](https://stackoverflow.com/questions/27810522/what-does-nit-mean-in-hacker-speak)). This
+is in an effort to keep review focused on the functionality of the changes, and not on nits.
+
+Use the following target to format your changes before submitting (must have `clang-format<=5.0.1` installed):
+
+```
+make clang-format
+```
+

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ rubric via `clang-format` to validate any style related changes that might be re
 (see [nits](https://stackoverflow.com/questions/27810522/what-does-nit-mean-in-hacker-speak)). This
 is in an effort to keep review focused on the functionality of the changes, and not on nits.
 
-Use the following target to format your changes before submitting (must have `clang-format==5.0.1` installed):
+Use the following target to format your changes before submitting (must have `clang-format==5.0` installed):
 
 ```
 make clang-format

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ let
     bzip2
     cacert
     ccache
-    clang_38
+    clang
     clang-tools
     cmake
     coreutils

--- a/scripts/run-clang-format
+++ b/scripts/run-clang-format
@@ -7,6 +7,12 @@ if [ -z "$CLANG_FORMAT_BINARY" ] ; then
   echo "Failed to find clang-format binary in path: $PATH"
   exit 1
 fi
+CLANG_FORMAT_VERSION=$($CLANG_FORMAT_BINARY --version)
+if [[ "$CLANG_FORMAT_VERSION" == *"5.0.1"* ]]; then
+  echo "Formatting C/C++ Sources with $CLANG_FORMAT_VERSION"
+else
+  echo "Incorrect formatter version ($CLANG_FORMAT_VERSION), expected 5.0.1"
+fi
 
 FIND_COMMAND=$(command -v find)
 FIND_BASE_DIR="package"

--- a/scripts/run-clang-format
+++ b/scripts/run-clang-format
@@ -8,10 +8,11 @@ if [ -z "$CLANG_FORMAT_BINARY" ] ; then
   exit 1
 fi
 CLANG_FORMAT_VERSION=$($CLANG_FORMAT_BINARY --version)
-if [[ "$CLANG_FORMAT_VERSION" == *"5.0.1"* ]]; then
+if [[ "$CLANG_FORMAT_VERSION" == *"5.0"* ]]; then
   echo "Formatting C/C++ Sources with $CLANG_FORMAT_VERSION"
 else
-  echo "Incorrect formatter version ($CLANG_FORMAT_VERSION), expected 5.0.1"
+  echo "Incorrect formatter version ($CLANG_FORMAT_VERSION), expected 5.0"
+  exit 1
 fi
 
 FIND_COMMAND=$(command -v find)


### PR DESCRIPTION
Trying to get a handle on the version of clang-format being used. Nixpkgs tells me 5.0.1 but I've heard reports that 6.0 is what works on Ubuntu.

According to the [this](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/clang-tools/default.nix), `clang-tools` should pull its version from the `clang` version but that does seem to be working so I have removed the 3.8 specifier in `default.nix`.

Also adding a blurb around the new automated formatting checks in readme in hopes of capturing the correct process for obtaining the version you need in the readme. Open to comments on a more appropriate place to put that.