### PR TITLE
Update gnss converters to pull release branch

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.54.1
+GNSS_CONVERTORS_VERSION = v2.1.0-release
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES


### PR DESCRIPTION
Since gnss converters now has changes not compatible with master, a release branch was created - need to now point buildroot at it