### PR TITLE
The magic USB file to clear settings wipes license and calibration files [DEVC-1102]

### DIFF
--- a/package/common_init/overlay/etc/init.d/reset2defaults.sh
+++ b/package/common_init/overlay/etc/init.d/reset2defaults.sh
@@ -28,7 +28,7 @@ fi
 
 echo "reset2defaults.txt file found on flashdrive.  Resetting Piksi to default settings" | sbp_log $LOGLEVEL
 echo "reset2defaults.txt file found on flashdrive.  Resetting Piksi to default settings" 
-rm -rf /persistent/*
+rm  /persistent/config.ini
 rm $RESETFILE
 echo "Rebooting Piksi." | sbp_log $LOGLEVEL
 echo "Rebooting Piksi." 

--- a/package/common_init/overlay/etc/init.d/reset2defaults.sh
+++ b/package/common_init/overlay/etc/init.d/reset2defaults.sh
@@ -28,7 +28,7 @@ fi
 
 echo "reset2defaults.txt file found on flashdrive.  Resetting Piksi to default settings" | sbp_log $LOGLEVEL
 echo "reset2defaults.txt file found on flashdrive.  Resetting Piksi to default settings" 
-rm  /persistent/config.ini
+rm /persistent/config.ini
 rm $RESETFILE
 echo "Rebooting Piksi." | sbp_log $LOGLEVEL
 echo "Rebooting Piksi." 


### PR DESCRIPTION
For DEVC-1102, remove config.ini only, instead of all the files and sub folders in the persistent directory.