### PR TITLE
NixOS build broken on master [DEVC-1122]

### DIFF
--- a/board/piksiv3/patches/grpc_custom/0002-fixup-nixos-compile.patch
+++ b/board/piksiv3/patches/grpc_custom/0002-fixup-nixos-compile.patch
@@ -1,0 +1,22 @@
+diff -ur old/Makefile new/Makefile
+--- old/Makefile	2018-09-25 21:22:48.907836717 -0700
++++ new/Makefile	2018-09-25 21:23:06.977310932 -0700
+@@ -2843,12 +2843,16 @@
+ install-headers_c:
+ 	$(E) "[INSTALL] Installing public C headers"
+ 	$(Q) $(foreach h, $(PUBLIC_HEADERS_C), $(INSTALL) -d $(prefix)/$(dir $(h)) && ) exit 0 || exit 1
+-	$(Q) $(foreach h, $(PUBLIC_HEADERS_C), $(INSTALL) $(h) $(prefix)/$(h) && ) exit 0 || exit 1
++	$(Q) ( for _H_FILE in $(foreach h, $(PUBLIC_HEADERS_C), $(h)); \
++		do $(INSTALL) $$_H_FILE $(prefix)/$$_H_FILE || exit 1; done ) \
++		&& exit 0 || exit 1
+ 
+ install-headers_cxx:
+ 	$(E) "[INSTALL] Installing public C++ headers"
+ 	$(Q) $(foreach h, $(PUBLIC_HEADERS_CXX), $(INSTALL) -d $(prefix)/$(dir $(h)) && ) exit 0 || exit 1
+-	$(Q) $(foreach h, $(PUBLIC_HEADERS_CXX), $(INSTALL) $(h) $(prefix)/$(h) && ) exit 0 || exit 1
++	$(Q) ( for _H_FILE in $(foreach h, $(PUBLIC_HEADERS_CXX), $(h)); \
++		do $(INSTALL) $$_H_FILE $(prefix)/$$_H_FILE || exit 1; done ) \
++		&& exit 0 || exit 1
+ 
+ install-static: install-static_c install-static_cxx
+ 

--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,7 @@ let
     gnused
     gnutar
     gdb
+    libcxx
     mercurial
     ncurses5
     ncurses5.dev

--- a/default.nix
+++ b/default.nix
@@ -22,8 +22,7 @@ let
     db
     file
     flex
-    gcc6
-    gcc-arm-embedded
+    gcc
     git
     glibc
     glibc.dev

--- a/package/orion_daemon/orion_daemon.mk
+++ b/package/orion_daemon/orion_daemon.mk
@@ -15,7 +15,8 @@ define ORION_DAEMON_USERS
 endef
 
 define ORION_DAEMON_BUILD_CMDS
-    $(MAKE) CC=$(TARGET_CC) LD=$(TARGET_LD) -C $(@D)/src all
+    $(MAKE) CROSS=$(TARGET_CROSS) CC=$(TARGET_CC) CFLAGS="$(TARGET_CFLAGS)" \
+			-C $(@D)/src all
 endef
 
 define ORION_DAEMON_INSTALL_TARGET_CMDS

--- a/package/orion_daemon/src/Makefile
+++ b/package/orion_daemon/src/Makefile
@@ -1,7 +1,7 @@
 TARGET=orion_daemon
 SOURCES=orion.pb.cc orion.grpc.pb.cc orion_daemon.cc
 LIBS=-luv -lnanomsg -lsbp -lstdc++ -lprotobuf -lgrpc++_unsecure -lpthread -lpiksi
-CFLAGS=-I. -std=c++14 -Werror -Wall
+CFLAGS+=-I. -std=c++14 -Werror -Wall
 
 CROSS=
 

--- a/package/protobuf_custom/protobuf_custom.mk
+++ b/package/protobuf_custom/protobuf_custom.mk
@@ -27,5 +27,18 @@ ifeq ($(BR2_PACKAGE_ZLIB),y)
 PROTOBUF_CUSTOM_DEPENDENCIES += zlib
 endif
 
+PROTOBUF_CUSTOM_SEARCHDIR_OLD := \
+	searchdirs="$$newlib_search_path $$lib_search_path $$sys_lib_search_path $$shlib_search_path"
+
+PROTOBUF_CUSTOM_SEARCHDIR_NEW := \
+	searchdirs="$$newlib_search_path $$lib_search_path $$compiler_lib_search_dirs $$sys_lib_search_path $$shlib_search_path"
+
+define PROTOBUF_CUSTOM_FIXUP_LIBTOOL
+	@$(call MESSAGE,"Fixing up libtool script")
+	$(Q)$(SED) 's@$(PROTOBUF_CUSTOM_SEARCHDIR_OLD)@$(PROTOBUF_CUSTOM_SEARCHDIR_NEW)@' $(@D)/libtool
+endef
+
+PROTOBUF_CUSTOM_POST_CONFIGURE_HOOKS += PROTOBUF_CUSTOM_FIXUP_LIBTOOL
+
 $(eval $(autotools-package))
 $(eval $(host-autotools-package))

--- a/scripts/wrappers/bin/aws
+++ b/scripts/wrappers/bin/aws
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+unset LD_LIBRARY_PATH
+exec /usr/bin/aws "$@"

--- a/scripts/wrappers/bin/c++
+++ b/scripts/wrappers/bin/c++
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Force buildroot to use g++ since clang++ has issues finding
+#   it's libraries (<map>, <iostream>, ..) under NixOS... see
+#   https://github.com/NixOS/nixpkgs/issues/30670.
+exec g++ $*


### PR DESCRIPTION
Add various fix-ups so master can build with NixOS:

+ The protobuf package's libtool script wouldn't search the correct dir to find the libatomic.so from the cross compiler, instead it was picking it up from the host

+ gRPC need some fix-ups to the generation of install commands for headers, otherwise this would fail because the command line generated was too large for `/bin/sh`

+ We forced buildroot to use g++ as the host c++ compiler (within gRPC) to avoid issues with clang++

+ Orion daemon needed to pick up flags from buildroot (apparently needed to pick-up the flto flag in order to link correctly, not sure on this, but the .mk change brings orion_daemon in-line with other packages)

