### PR TITLE
EX-347: Fix duplicate GLO MSM obs on first fix [master]

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.63
+GNSS_CONVERTORS_VERSION = d7e07599a16815eabfeca98d45f18f5cac9bec86
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = d7e07599a16815eabfeca98d45f18f5cac9bec86
+GNSS_CONVERTORS_VERSION = v0.3.64
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES


### PR DESCRIPTION
Pull in https://github.com/swift-nav/gnss-converters/pull/132

## Testing

No more duplicate OBS errors in HITL:

https://gnss-analysis.swiftnav.com/summary_type=q50&metrics_preset=pass_fail&scenario=live-roof-650-townsend-msm7&build_type=master&firmware_versions=v2.0.0-develop-2018092118-10-g04de7b44&groupby_key=firmware&display_type=table

Couple of runs did not have any base observations, but that's in line with current master.
