### PR TITLE
Fix piksi_multitool upgrade path for removal of fio_ex user [DEVC-1121] [release]

### DIFF
--- a/package/piksi_system_daemon/overlay/etc/sudoers.d/piksi_system_daemon
+++ b/package/piksi_system_daemon/overlay/etc/sudoers.d/piksi_system_daemon
@@ -2,4 +2,4 @@ piksi_sys ALL=(ALL) NOPASSWD: /usr/bin/upgrade_tool --debug /data/upgrade.image_
 piksi_sys ALL=(ALL) NOPASSWD: /etc/init.d/update_eth0_config
 piksi_sys ALL=(ALL) NOPASSWD: /etc/init.d/update_ntp_config
 piksi_sys ALL=(ALL) NOPASSWD: /etc/init.d/do_sbp_msg_reset
-piksi_sys ALL=(fio_ex) NOPASSWD: /usr/bin/spawn_nc
+piksi_sys ALL=(fileio) NOPASSWD: /usr/bin/spawn_nc

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -153,7 +153,7 @@ static void sbp_command(u16 sender_id, u8 len, u8 msg_[], void* context)
     char spawn_nc[1024];
 
     size_t count = snprintf(spawn_nc, sizeof(spawn_nc),
-                            "sudo -u fio_ex /usr/bin/spawn_nc; "
+                            "sudo -u fileio /usr/bin/spawn_nc; "
                             "sbp_cmd_resp --sequence %u --status $?",
                             msg->sequence);
     assert( count < sizeof(spawn_nc) );


### PR DESCRIPTION
Correct spawn_nc for rename of fio_ex -> fileio [DEVC-1121].