### PR TITLE
Downgrading standalone logger daemon startup message [DEVC-1165]

### DIFF
--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -413,7 +413,7 @@ int main(int argc, char *argv[])
                     &copy_system_logs_notify,
                     nullptr);
 
-  process_log_callback(LOG_INFO, "Starting");
+  process_log_callback(LOG_DEBUG, "Starting");
 
   pk_loop_run_simple(loop);
 


### PR DESCRIPTION
Clarify that this is not important to the user.