### PR TITLE
Update libsbp to 2.4.1

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.64
+GNSS_CONVERTORS_VERSION = v0.3.65
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.32
+LIBRTCM_VERSION = v0.2.33
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/libsbp/libsbp.mk
+++ b/package/libsbp/libsbp.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSBP_VERSION = v2.3.17
+LIBSBP_VERSION = v2.4.1
 LIBSBP_SITE = https://github.com/swift-nav/libsbp
 LIBSBP_SITE_METHOD = git
 LIBSBP_INSTALL_STAGING = YES

--- a/package/sample_daemon/src/udp_socket.c
+++ b/package/sample_daemon/src/udp_socket.c
@@ -118,7 +118,7 @@ void close_udp_broadcast_socket(udp_broadcast_context *udp_context)
   udp_context->sock = -1;
 }
 
-u32 udp_write_callback(u8 *buf, u32 len, void *context)
+ssize_t udp_write_callback(u8 *buf, u32 len, void *context)
 {
   udp_broadcast_context *udp_context = (udp_broadcast_context *)context;
 

--- a/package/sample_daemon/src/udp_socket.h
+++ b/package/sample_daemon/src/udp_socket.h
@@ -28,7 +28,7 @@ void open_udp_broadcast_socket(udp_broadcast_context *udp_context,
 
 void close_udp_broadcast_socket(udp_broadcast_context *udp_context);
 
-u32 udp_write_callback(u8 *buf, u32 len, void *context);
+ssize_t udp_write_callback(u8 *buf, u32 len, void *context);
 void udp_flush_buffer(udp_broadcast_context *udp_context);
 
 #endif //_SWIFT_UDP_SOCKET_H

--- a/package/sbp_protocol/src/framer_sbp.c
+++ b/package/sbp_protocol/src/framer_sbp.c
@@ -34,11 +34,11 @@ typedef struct {
   uint8_t send_buffer[SBP_MSG_LEN_MAX];
 } framer_sbp_state_t;
 
-static u32 sbp_read(u8 *buff, u32 n, void *context)
+static ssize_t sbp_read(u8 *buff, u32 n, void *context)
 {
   sbp_io_context_t *c = (sbp_io_context_t *)context;
 
-  u32 count = c->read_length - c->read_offset;
+  ssize_t count = c->read_length - c->read_offset;
   if (count > n) {
     count = n;
   }
@@ -48,11 +48,11 @@ static u32 sbp_read(u8 *buff, u32 n, void *context)
   return count;
 }
 
-static u32 sbp_write(u8 *buff, u32 n, void *context)
+static ssize_t sbp_write(u8 *buff, u32 n, void *context)
 {
   sbp_io_context_t *c = (sbp_io_context_t *)context;
 
-  u32 count = c->write_length - c->write_offset;
+  ssize_t count = c->write_length - c->write_offset;
   if (count > n) {
     count = n;
   }


### PR DESCRIPTION
Move also gnss-convertors and librtcm pointers to master version.

Feel free to merge once all is green, these have already been through bench and HITL tests in https://github.com/swift-nav/piksi_buildroot/pull/886, https://github.com/swift-nav/piksi_buildroot/pull/883, and https://github.com/swift-nav/piksi_buildroot/pull/879