### PR TITLE
Add some checks to keep from sending out bad frames to orion.

### DIFF
--- a/package/orion_daemon/src/orion.proto
+++ b/package/orion_daemon/src/orion.proto
@@ -22,6 +22,7 @@ message Header {
   Timestamp timestamp = 1;
   Uuid service_uid = 2;
   Uuid message_uid = 3;
+  string version = 4;
 }
 
 // SBP Frame representation.

--- a/package/orion_daemon/src/orion_daemon.cc
+++ b/package/orion_daemon/src/orion_daemon.cc
@@ -221,6 +221,8 @@ int main(int argc, char *argv[])
 
         uint8_t uuid[16];
 
+        std::string version;
+
         orion_proto::SbpFrame sbp_frame;
         while (!inactive() && streamer->Read(&sbp_frame)) {
           sbp_ctx.send(sbp_frame);
@@ -250,6 +252,12 @@ int main(int argc, char *argv[])
               uuid[13],
               uuid[14],
               uuid[15]);
+          }
+
+          if (version != sbp_frame.header().version()) {
+            version = sbp_frame.header().version();
+
+            piksi_log(LOG_INFO | LOG_SBP, "Version %s", version.c_str());
           }
         }
 


### PR DESCRIPTION
Orion needs to see positions at most every second. Send only positions out when the previous recorded tow is different, hopefully the start of a new 1s tow. Also, don't send up invalid positions.