### PR TITLE
Fix core dump on fileio [DEVC-1138]

### DIFF
--- a/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.c
+++ b/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.c
@@ -188,11 +188,12 @@ static void read_dir_cb(u16 sender_id, u8 len, u8 msg_[], void *context)
               path_validator_base_paths(g_pv_ctx));
     len = 0;
 
-  /* Check that directory exists */
+    /* Check that directory exists */
   } else if ((dir = opendir(msg->dirname)) == NULL) {
-    piksi_log(LOG_WARNING, "Received FILEIO_READ_DIR request for path (%s) "
-      "which does not exist, ignoring...",
-      msg->dirname);
+    piksi_log(LOG_WARNING,
+              "Received FILEIO_READ_DIR request for path (%s) "
+              "which does not exist, ignoring...",
+              msg->dirname);
     len = 0;
 
   } else {

--- a/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.c
+++ b/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.c
@@ -169,6 +169,7 @@ static void read_dir_cb(u16 sender_id, u8 len, u8 msg_[], void *context)
   /* Add a null termination to dirname */
   msg_[len] = 0;
 
+  DIR *dir;
   struct dirent *dirent;
   u32 offset = msg->offset;
   msg_fileio_read_dir_resp_t *reply = alloca(SBP_FRAMING_MAX_PAYLOAD_SIZE);
@@ -187,9 +188,14 @@ static void read_dir_cb(u16 sender_id, u8 len, u8 msg_[], void *context)
               path_validator_base_paths(g_pv_ctx));
     len = 0;
 
-  } else {
+  /* Check that directory exists */
+  } else if ((dir = opendir(msg->dirname)) == NULL) {
+    piksi_log(LOG_WARNING, "Received FILEIO_READ_DIR request for path (%s) "
+      "which does not exist, ignoring...",
+      msg->dirname);
+    len = 0;
 
-    DIR *dir = opendir(msg->dirname);
+  } else {
     while (offset && (dirent = readdir(dir)))
       offset--;
 


### PR DESCRIPTION
Attempting to list a directory that does not exist results in a
readdir(NULL) call. This causes a core dump.
We now ignore any requests on non-existing directories