### PR TITLE
EX-388: RTCM output mode selection and MSM out

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.66
+GNSS_CONVERTORS_VERSION = v0.3.67
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.33
+LIBRTCM_VERSION = v0.2.34
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/libswiftnav/libswiftnav.mk
+++ b/package/libswiftnav/libswiftnav.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSWIFTNAV_VERSION = v0.1.2
+LIBSWIFTNAV_VERSION = v0.1.3
 LIBSWIFTNAV_SITE = https://github.com/swift-nav/libswiftnav
 LIBSWIFTNAV_SITE_METHOD = git
 LIBSWIFTNAV_INSTALL_STAGING = YES

--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -161,16 +161,6 @@ static void baseline_heading_callback(u16 sender_id, u8 len, u8 msg[], void *con
   sbp2nmea_baseline_heading(baseline_hdg, &state);
 }
 
-static void baseline_heading_callback(u16 sender_id, u8 len, u8 msg[], void *context)
-{
-  (void)context;
-  (void)sender_id;
-  (void)len;
-  msg_baseline_heading_t *baseline_hdg = (msg_baseline_heading_t *)msg;
-  sbp2nmea_baseline_heading(baseline_hdg, &state);
-}
-
-
 static void msg_obs_callback(u16 sender_id, u8 len, u8 msg[], void *context)
 {
   (void)len;


### PR DESCRIPTION
Pulls in https://github.com/swift-nav/librtcm/pull/66 and https://github.com/swift-nav/gnss-converters/pull/143 to add support for MSM messages in addition to legacy 1004/1012.

Add configuration options for selecting RTCM out mode, defaulting to MSM5.

## Testing

### Bench tests
Some tens of hours of running on bench in zero-baseline configuration, one Piksi sending RTCM and the other receiving, with 1Hz and 5Hz observation rates without glitch. Tested both over UART and TCP. When setting obs rate to 10Hz, the device's LEDs look like it's working but the console chokes so no way of verifying the output.

Tested switching RTCM output type between the different choices while connection is open, works without a glitch. (note the 60s delay though when switching from legacy obs back to MSM)

### Over-the-night stability test
Worked nicely, RTK baseline within 3cm the whole time (except for one drop to SPP because base position could not be computed from 5 GPS satellites for some minutes)

### Testing with a 3rd party receiver as a rover

uBlox M8P goes into fixed RTK with accuracy within 2cm using Piksi base sending RTCMv3 legacy obs:
![image](https://user-images.githubusercontent.com/18000866/47096011-0264e100-d237-11e8-88b5-94c68d1f6467.png)

