### PR TITLE
Fix for nmea hdt message not being sent [MAP-691]

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.61.4
+GNSS_CONVERTORS_VERSION = v0.3.61.5
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
                     notify_gpgll_rate_changed, NULL);
 
   settings_register(settings_ctx, "nmea", "gpzda_msg_rate",
-                    &gpzda_rate, sizeof(gphdt_rate),
+                    &gpzda_rate, sizeof(gpzda_rate),
                     SETTINGS_TYPE_INT,
                     notify_gpzda_rate_changed, NULL);
 

--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -16,6 +16,7 @@
 #include <libpiksi/logging.h>
 #include <libpiksi/util.h>
 #include <libsbp/navigation.h>
+#include <libsbp/orientation.h>
 #include <libsbp/sbp.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -141,6 +142,14 @@ static void gps_time_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
   sbp2nmea_gps_time(gps_time, &state);
 }
 
+static void baseline_heading_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
+  (void) context;
+  (void) sender_id;
+  (void) len;
+  msg_baseline_heading_t *baseline_hdg = (msg_baseline_heading_t*)msg;
+  sbp2nmea_baseline_heading(baseline_hdg, &state);
+}
+
 
 static void msg_obs_callback(u16 sender_id, u8 len, u8 msg[], void* context) {
   (void) len;
@@ -260,6 +269,11 @@ int main(int argc, char *argv[])
 
   if (sbp_callback_register(SBP_MSG_VEL_NED, vel_ned_callback, NULL) != 0) {
     piksi_log(LOG_ERR, "error setting vel NED callback");
+    return cleanup(EXIT_FAILURE);
+  }
+
+  if (sbp_callback_register(SBP_MSG_BASELINE_HEADING, baseline_heading_callback, NULL) != 0) {
+    piksi_log(LOG_ERR, "error setting baseline heading callback");
     return cleanup(EXIT_FAILURE);
   }
 

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -57,6 +57,7 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x02, 0x01] } # MSG_GPS_TIME
           - { action: ACCEPT, prefix: [0x55, 0x03, 0x01] } # MSG_UTC_TIME
           - { action: ACCEPT, prefix: [0x55, 0x08, 0x02] } # MSG_DOPS
+          - { action: ACCEPT, prefix: [0x55, 0x0F, 0x02] } # MSG_BASELINE_HEADING
           - { action: ACCEPT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
           - { action: REJECT }
 

--- a/package/sbp_protocol/src/sbp_router_smoothpose.yml
+++ b/package/sbp_protocol/src/sbp_router_smoothpose.yml
@@ -70,6 +70,7 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x02, 0x01] } # MSG_GPS_TIME
           - { action: ACCEPT, prefix: [0x55, 0x03, 0x01] } # MSG_UTC_TIME
           - { action: ACCEPT, prefix: [0x55, 0x08, 0x02] } # MSG_DOPS
+          - { action: ACCEPT, prefix: [0x55, 0x0F, 0x02] } # MSG_BASELINE_HEADING
           - { action: ACCEPT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
           - { action: REJECT }
 


### PR DESCRIPTION
The SBP baseline heading message was not being routed and supported in the nmea convertor correctly.