### PR TITLE
Update readme to reflect current limitations in building from source [DEVC-1186][master]

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,33 @@ make image
 
 Images will be in the `buildroot/output/images` folder.
 
+### Build Outputs
+
+A successfull build should finish with the following output visible:
+
+``` sh
+>>>   Executing post-image script /piksi_buildroot/board/piksiv3/post_image.sh
+>>> Generating FAILSAFE firmware image... done.
+>>> Generating DEV firmware image... done.
+>>> Generating PROD firmware image... done.
+>>> INTERNAL firmware image located at:
+        buildroot/output/images/piksiv3_prod/PiksiMulti-INTERNAL-<version_tag>.bin
+>>> DEV firmware image located at:
+        buildroot/output/images/piksiv3_prod/PiksiMulti-DEV-<version_tag>.bin
+>>> FAILSAFE firmware image located at:
+        buildroot/output/images/piksiv3_prod/PiksiMulti-FAILSAFE-<version_tag>.bin
+```
+
+The build variants are as follows:
+ * `INTERNAL` is a complete image with the firmware and FPGA binaries included.
+ * `DEV` is a minimal u-boot image that is configured for loading development artifacts.
+ * `FAILSAFE` is an even more minimal u-boot image that allows for manual recovery.
+
+Without prior experience and instructions, it is recommended that the `DEV` and `FAILSAFE`
+images be ignored.
+
+A `PiksiMulti-*.bin` binary can be loaded onto the device using the console, or via
+usb thumbdrive auto-upgrade feature.
 
 ## Incremental Builds
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
   - Board-specific files (rootfs overlay, device trees, scripts, etc.) in `board/piksiv3`
 
 ## Building
+<u>Note:</u>
+Images built from source are no longer compatible with official releases. In order to
+upgrade to the latest official release you must install the pre-built
+[v2.0.2](https://github.com/swift-nav/piksi_buildroot/releases/tag/v2.0.2) binary.
 
 ### Docker
 
@@ -110,7 +114,7 @@ export BR2_BUILD_SAMPLE_DAEMON=y
 ```
 
 Then build normally:
-```
+``` sh
 # Docker
 make docker-make-image
 
@@ -120,7 +124,7 @@ make image
 
 ## Fetching firmware binaries
 
-To build a production system image, the build process expects the following
+To build a whole system image, the build process expects the following
 firmware and FPGA binaries to be present:
 
 ```
@@ -144,9 +148,16 @@ make firmware
 
 Check `fetch-firmware.sh` to see which image versions are being used.
 
-Note that these binaries are only used by the production system image. In the
+<u>Note:</u>
+These binaries are only used when building a whole system image. In the
 development system image they are instead read from the network or SD
 card.
+
+<u>Note:</u>
+Only [tagged releases](https://github.com/swift-nav/piksi_buildroot/releases)
+are made publicly available for download for use in building from source. Running
+`make firmware` on the last tagged release in relation to an untagged branch or
+commit may not always produce a functionial build, and therefore is not supported.
 
 ## Copying data out of docker
 
@@ -201,7 +212,10 @@ is in an effort to keep review focused on the functionality of the changes, and 
 
 Use the following target to format your changes before submitting (must have `clang-format==5.0` installed):
 
-```
+``` sh
+# Docker
+make docker-clang-format
+
+# Linux native
 make clang-format
 ```
-


### PR DESCRIPTION
Snuck in a command instruction showing the new docker support for `clang-format` too. Can't wait for `clang-tidy` to make it's way in there 😄 