### PR TITLE
DEVC-1232 Fix info_nmea

### DIFF
--- a/package/nmea_protocol/src/info_nmea.c
+++ b/package/nmea_protocol/src/info_nmea.c
@@ -23,7 +23,7 @@ int port_adapter_opts_get(char *buf, size_t buf_size, const char *port_name)
 {
   return snprintf(buf,
                   buf_size,
-                  "-p 'ipc:///var/run/sockets/nmea_external.sub'"
+                  "-p 'ipc:///var/run/sockets/nmea_external.sub' "
                   "-s 'ipc:///var/run/sockets/nmea_external.pub'",
                   port_name);
 }


### PR DESCRIPTION
Revert the whitespace change from DEVC-1232 which might explain broken NMEA output