### PR TITLE
MAP-652: Update gnss_convertors for NMEA empty timestamp fix

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.67
+GNSS_CONVERTORS_VERSION = b3ed01d775c859d9755b0f0c904557567d1f2405
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES


### PR DESCRIPTION
Pulls in https://github.com/swift-nav/gnss-converters/pull/147