### PR TITLE
Add support for syncing into a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
-buildroot/
+buildroot
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/
 .vscode/
 .clang_complete
 .clang_stdin
+.docker-sync/
+.docker-sync.yml
+.docker-compose.yml

--- a/Makefile
+++ b/Makefile
@@ -174,26 +174,6 @@ docker-populate-volume:
 
 docker-setup: docker-build-image docker-populate-volume
 
-docker-sync-setup:
-	@./scripts/gen-docker-sync $(DOCKER_BUILD_VOLUME) $(UID) $(DOCKER_HOST)
-	@docker volume create --name=$(DOCKER_BUILD_VOLUME)-sync
-	@echo "Done, run: make docker-start-sync"
-
-docker-sync-start:
-	@docker-sync start -c .docker-sync.yml
-
-docker-sync-logs:
-	@docker-sync logs -c .docker-sync.yml
-
-docker-sync-stop:
-	@docker-sync stop -c .docker-sync.yml
-
-docker-sync-clean:
-	@docker-sync clean -c .docker-sync.yml
-
-docker-aws-google-auth:
-	@./scripts/run-aws-google-auth
-
 docker-rebuild-changed:
 	docker run $(DOCKER_ARGS) -e BUILD_TEMP=/host/tmp -e SINCE=$(SINCE) \
 		$(DOCKER_TAG) \
@@ -372,5 +352,27 @@ host-ccache-archive:
 docker-host-ccache-archive:
 	docker run $(DOCKER_RUN_ARGS) $(DOCKER_TAG) \
 		make host-ccache-archive
+
+docker-sync-setup:
+	@./scripts/check-docker-sync
+	@./scripts/gen-docker-sync $(DOCKER_BUILD_VOLUME) $(UID) $(DOCKER_HOST)
+	@docker volume create --name=$(DOCKER_BUILD_VOLUME)-sync
+	@echo "Done, run: make docker-start-sync"
+
+docker-sync-start:
+	@docker-sync start -c .docker-sync.yml
+
+docker-sync-logs:
+	@docker-sync logs -c .docker-sync.yml
+
+docker-sync-stop:
+	@docker-sync stop -c .docker-sync.yml
+
+docker-sync-clean:
+	@docker-sync clean -c .docker-sync.yml
+	@rm -f .docker-compose.yml .docker-sync.yml 
+
+docker-aws-google-auth:
+	@./scripts/run-aws-google-auth
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,26 @@ docker-populate-volume:
 
 docker-setup: docker-build-image docker-populate-volume
 
+docker-sync-setup:
+	@./scripts/gen-docker-sync $(DOCKER_BUILD_VOLUME) $(UID) $(DOCKER_HOST)
+	@docker volume create --name=$(DOCKER_BUILD_VOLUME)-sync
+	@echo "Done, run: make docker-start-sync"
+
+docker-sync-start:
+	@docker-sync start -c .docker-sync.yml
+
+docker-sync-logs:
+	@docker-sync logs -c .docker-sync.yml
+
+docker-sync-stop:
+	@docker-sync stop -c .docker-sync.yml
+
+docker-sync-clean:
+	@docker-sync clean -c .docker-sync.yml
+
+docker-aws-google-auth:
+	@./scripts/run-aws-google-auth
+
 docker-rebuild-changed:
 	docker run $(DOCKER_ARGS) -e BUILD_TEMP=/host/tmp -e SINCE=$(SINCE) \
 		$(DOCKER_TAG) \

--- a/scripts/check-docker-sync
+++ b/scripts/check-docker-sync
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v docker-sync &>/dev/null; then
+  gem install docker-sync || { echo "ERROR: failed to install docker-sync"; exit 1; }
+fi
+
+if ! command -v unison &>/dev/null; then
+  brew install unison || { echo "ERROR: failed to install unison"; exit 1; }
+fi

--- a/scripts/check-docker-sync
+++ b/scripts/check-docker-sync
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
+if [[ $(uname) != *Darwin* ]]; then
+  echo "ERROR: docker-sync not (yet) supported on non Mac OS X hosts" >&2
+  exit 1
+fi
+
 if ! command -v docker-sync &>/dev/null; then
-  gem install docker-sync || { echo "ERROR: failed to install docker-sync"; exit 1; }
+  gem install docker-sync || { echo "ERROR: failed to install docker-sync" >&2; exit 1; }
 fi
 
 if ! command -v unison &>/dev/null; then
-  brew install unison || { echo "ERROR: failed to install unison"; exit 1; }
+  brew install unison || { echo "ERROR: failed to install unison" >&2; exit 1; }
 fi

--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -61,7 +61,7 @@ else
 BUILD_VOLUME_ARGS := \
   -v $(DOCKER_BUILD_VOLUME)-sync:/piksi_buildroot
 
-RUN_VOLUME_ARGS := 
+RUN_VOLUME_ARGS :=
 
 endif
 
@@ -76,7 +76,7 @@ DOCKER_SETUP_ARGS :=                                                          \
 
 DOCKER_RUN_ARGS := \
   $(DOCKER_SETUP_ARGS) \
-	$(RUN_VOLUME_ARGS) \
+  $(RUN_VOLUME_ARGS) \
   --security-opt seccomp:unconfined --cap-add=SYS_PTRACE
 
 ifneq ($(SSH_AUTH_SOCK),)

--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -86,23 +86,6 @@ endif
 DOCKER_ARGS := --sig-proxy=false $(DOCKER_RUN_ARGS)
 
 docker-wipe:
-	@echo "WARNING: This will wipe all Piksi related Docker images, containers, and volumes!"
-	@read -p "Continue? (y/[n]) " x && { [[ "$$x" == "y" ]] || exit 0; } && \
-		echo -n "Wiping all Piksi related docker materials" && \
-		{ sleep 0.25; echo -n .; sleep 0.25; echo -n .; sleep 0.25; echo -n .; sleep 0.25; echo; } && \
-		{ \
-			echo "... stopping Piksi containers"; \
-			running_images=`docker ps --format '{{.Names}},{{.ID}}' | grep '^piksi_.*,.*$$' | cut -f2 -d,`; \
-			[[ -z "$$running_images" ]] || docker stop -t 1 $$running_images; \
-			echo "... removing Piksi containers"; \
-			stopped_images=`docker ps -a --format '{{.Names }},{{.ID}}' | grep '^piksi_.*,.*$$' | cut -f2 -d,`; \
-			[[ -z "$$stopped_images" ]] || docker rm -f $$stopped_images; \
-			echo "... removing Piksi images"; \
-			images=`docker images --format '{{.Repository}},{{.ID}}' | grep '^piksi_.*,.*$$' | cut -f2 -d,`; \
-			[[ -z "$$images" ]] || docker rmi -f $$images; \
-			echo "... removing Piksi volumes"; \
-			volumes=`docker volume ls --format '{{.Name}}' | grep '^piksi_.*$$'`; \
-			[[ -z "$$volumes" ]] || docker volume rm $$volumes; \
-		}
+	@./scripts/run-docker-wipe
 
 .PHONY: docker-wipe

--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -46,6 +46,25 @@ DOCKER_ENV_ARGS :=                                                            \
   $(DCKR_CCACHE_RO_VAR)                                                       \
   --user $(USER)                                                              \
 
+ifeq (,$(wildcard .docker-sync.yml))
+
+BUILD_VOLUME_ARGS := \
+  -v $(CURDIR):/piksi_buildroot \
+  -v $(DOCKER_BUILD_VOLUME):/piksi_buildroot/buildroot
+
+RUN_VOLUME_ARGS := \
+  -v $(CURDIR)/buildroot/output/images:/piksi_buildroot/buildroot/output/images \
+  -v $(CURDIR)/buildroot/nano_output/images:/piksi_buildroot/buildroot/nano_output/images
+
+else
+
+BUILD_VOLUME_ARGS := \
+  -v $(DOCKER_BUILD_VOLUME)-sync:/piksi_buildroot
+
+RUN_VOLUME_ARGS := 
+
+endif
+
 DOCKER_SETUP_ARGS :=                                                          \
   $(INTERACTIVE_ARGS)                                                         \
   $(DOCKER_ENV_ARGS)                                                          \
@@ -53,14 +72,12 @@ DOCKER_SETUP_ARGS :=                                                          \
   --hostname piksi-buildroot$(_DOCKER_SUFFIX)                                 \
   -v $(HOME):/host/home:ro                                                    \
   -v /tmp:/host/tmp:rw                                                        \
-  -v $(CURDIR):/piksi_buildroot                                               \
-  -v $(DOCKER_BUILD_VOLUME):/piksi_buildroot/buildroot
+  $(BUILD_VOLUME_ARGS)
 
 DOCKER_RUN_ARGS := \
   $(DOCKER_SETUP_ARGS) \
-  --security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
-  -v $(CURDIR)/buildroot/output/images:/piksi_buildroot/buildroot/output/images \
-  -v $(CURDIR)/buildroot/nano_output/images:/piksi_buildroot/buildroot/nano_output/images
+	$(RUN_VOLUME_ARGS) \
+  --security-opt seccomp:unconfined --cap-add=SYS_PTRACE
 
 ifneq ($(SSH_AUTH_SOCK),)
 DOCKER_RUN_ARGS := $(DOCKER_RUN_ARGS) -v $(shell python -c "print(__import__('os').path.realpath('$(SSH_AUTH_SOCK)'))"):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -41,6 +41,9 @@ sudo find /root -type f -exec chmod g+rw {} \;
     sudo chown $USER:$GID /home/$USER/.bash_history;
   }
 
+[ -d "/piksi_buildroot" ] && \
+  sudo chown "$USER:$GID" "/piksi_buildroot"
+
 [ -d "/piksi_buildroot/buildroot" ] && \
   sudo chown "$USER:$GID" "/piksi_buildroot/buildroot"
 

--- a/scripts/gen-docker-sync
+++ b/scripts/gen-docker-sync
@@ -17,13 +17,21 @@ syncs:
     sync_strategy: 'unison'
     sync_userid: '${docker_sync_uid}'
     sync_args:
-      - "-ignorenot='Path buildroot/output/images/*'"
-      - "-ignore='Path buildroot/output/*'"
+      - "-ignore='Path buildroot/output/build'"
+      - "-ignore='Path buildroot/output/ccache'"
+      - "-ignore='Path buildroot/output/target'"
+      - "-ignore='Path buildroot/output/host'"
+      - "-ignore='Path buildroot/output/staging'"
+      - "-ignore='Path buildroot/dl'"
       - "-ignore='Path .docker-sync*'"
       - "-ignore='Path .docker-compose.yml'"
       - "-ignore='Name .*.sw?'"
     watch_excludes:
-      - 'buildroot/output'
+      - 'buildroot/output/build'
+      - 'buildroot/output/ccache'
+      - 'buildroot/output/target'
+      - 'buildroot/output/host'
+      - 'buildroot/output/staging'
       - 'buildroot/dl'
 EOF
 

--- a/scripts/gen-docker-sync
+++ b/scripts/gen-docker-sync
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+docker_build_volume=$1; shift
+docker_sync_uid=$1; shift
+docker_host=$1; shift
+
+cat >.docker-sync.yml <<EOF
+version: "2"
+options:
+  verbose: True
+  compose-file-path: .docker-compose.yml
+syncs:
+  ${docker_build_volume}-sync:
+    notify_terminal: true
+    src: '.'
+    sync_host_ip: '$(echo "${docker_host}" | cut -d: -f1)'
+    sync_strategy: 'unison'
+    sync_userid: '${docker_sync_uid}'
+    sync_args:
+      - "-ignorenot='Path buildroot/output/images/*'"
+      - "-ignore='Path buildroot/output/*'"
+      - "-ignore='Path .docker-sync*'"
+      - "-ignore='Path .docker-compose.yml'"
+      - "-ignore='Name .*.sw?'"
+    watch_excludes:
+      - 'buildroot/output'
+      - 'buildroot/dl'
+EOF
+
+cat >.docker-compose.yml <<EOF
+version: "2"
+services:
+  ${docker_build_volume}-sync:
+    image: alpine
+    container_name: '${docker_build_volume}-sync'
+    command: ['watch', '-n1', '-t', 'date']
+    user: ${docker_sync_uid}
+    volumes:
+      - ${docker_build_volume}-sync:/piksi_buildroot:nocopy # nocopy is important
+volumes:
+  piksi-buildroot-955ff503d411-sync:
+    external: true
+EOF

--- a/scripts/gen-docker-sync
+++ b/scripts/gen-docker-sync
@@ -46,6 +46,6 @@ services:
     volumes:
       - ${docker_build_volume}-sync:/piksi_buildroot:nocopy # nocopy is important
 volumes:
-  piksi-buildroot-955ff503d411-sync:
+  ${docker_build_volume}-sync:
     external: true
 EOF

--- a/scripts/make_help.txt
+++ b/scripts/make_help.txt
@@ -50,10 +50,14 @@ Docker utility targets:
 
 docker-cp         - Copies files out of the docker container, uses the
                     following syntax:
+
                       make docker-cp SRC=<docker-path> DST=<local-path>
+
+docker-shell
 docker-run        - Launches a shell inside the docker container for
                     running commands and inspecting the contents of
                     the container.
+
 docker-make-clean-volume
                   - Wipes the docker volume (`<root>/buildroot` inside
                     of the docker container) that's  used to build the
@@ -61,3 +65,37 @@ docker-make-clean-volume
 docker-make-clean-all
                   - Wipes the docker volume and cleans all build
                     artifacts.
+
+The `docker-run` target can be used to run arbitrary commands inside the
+container as follows:
+
+  make docker-run ARGS="scp README.md root@192.168.0.222:"
+
+## DOCKER SYNC TARGETS ##
+
+The `docker-sync-*` targets are used to configure the repostiory for use with
+docker-sync, which moves all of the source files and build materials into a
+container volume.  Normally only the build materials are captured in a
+container.
+
+The `docker-sync` configuration can be used to build with a remote DOCKER_HOST
+and to avoid data sync issues/delays with non-native docker hosts (like OS X).
+
+The follow targets are used to setup this environment:
+
+docker-sync-setup - Sets up the `docker-compose.yml` and `docker-sync.yml`
+                    files for the docker-sync daemon.
+
+docker-sync-start - Starts the docker-sync daemon.
+
+docker-sync-logs  - The logs from the docker-sync daemon.
+
+docker-sync-stop  - Stop the docker-sync daemon
+
+docker-sync-clean - Cleans and wipes the docker-sync config
+
+## MISC. TARGETS ##
+
+docker-aws-google-auth - used to acquire AWS credentials, requires that
+                         GOOGLE_IDP_ID, GOOGLE_SP_ID, and GOOGLE_USERNAME
+                         to be set in the environement.

--- a/scripts/run-aws-google-auth
+++ b/scripts/run-aws-google-auth
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Touch these files prior to running so they'll have
+#   the correct owner/group (otherwise docker will create them as root)
 touch "$HOME/.aws/credentials"
 touch "$HOME/.aws/config"
 touch "$HOME/.aws/saml_cache.xml"

--- a/scripts/run-aws-google-auth
+++ b/scripts/run-aws-google-auth
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+touch "$HOME/.aws/credentials"
+touch "$HOME/.aws/config"
+touch "$HOME/.aws/saml_cache.xml"
+
+[[ -n "$GOOGLE_USERNAME" ]] || GOOGLE_USERNAME=$USER@swift-nav.com
+
+[[ -n "$GOOGLE_IDP_ID" ]] || \
+  { echo "ERROR: Environment variable GOOGLE_IDP_ID not defined"; exit 1; }
+
+[[ -n "$GOOGLE_SP_ID" ]] || \
+  { echo "ERROR: Environment variable GOOGLE_SP_ID not defined"; exit 1; }
+
+docker run -v "$HOME/.aws:/root/.aws" \
+  --rm \
+  --interactive \
+  --tty \
+  -e "GOOGLE_USERNAME=$GOOGLE_USERNAME" \
+  -e "GOOGLE_IDP_ID=$GOOGLE_IDP_ID" \
+  -e "GOOGLE_SP_ID=$GOOGLE_SP_ID" \
+  -e AWS_DEFAULT_REGION=us-west-2 \
+  -e AWS_PROFILE=default \
+  cevoaustralia/aws-google-auth

--- a/scripts/run-aws-google-auth
+++ b/scripts/run-aws-google-auth
@@ -7,10 +7,10 @@ touch "$HOME/.aws/saml_cache.xml"
 [[ -n "$GOOGLE_USERNAME" ]] || GOOGLE_USERNAME=$USER@swift-nav.com
 
 [[ -n "$GOOGLE_IDP_ID" ]] || \
-  { echo "ERROR: Environment variable GOOGLE_IDP_ID not defined"; exit 1; }
+  { echo "ERROR: Environment variable GOOGLE_IDP_ID not defined" >&2; exit 1; }
 
 [[ -n "$GOOGLE_SP_ID" ]] || \
-  { echo "ERROR: Environment variable GOOGLE_SP_ID not defined"; exit 1; }
+  { echo "ERROR: Environment variable GOOGLE_SP_ID not defined" >&2; exit 1; }
 
 docker run -v "$HOME/.aws:/root/.aws" \
   --rm \

--- a/scripts/run-docker-wipe
+++ b/scripts/run-docker-wipe
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/scripts/run-docker-wipe
+++ b/scripts/run-docker-wipe
@@ -1,1 +1,33 @@
 #!/usr/bin/env bash
+
+set -e
+
+echo "WARNING: This will wipe all Piksi related Docker images, containers, and volumes!"
+
+read -r -p "Continue? (y/[n]) " x && { [[ "$x" == "y" ]] || exit 0; }
+echo -n "Wiping all Piksi related docker materials"
+
+for _ in $(seq 4); do
+  sleep 0.25
+  echo -n .
+done
+
+echo "... stopping Piksi containers"
+
+running_images=$(docker ps --format '{{.Names}},{{.ID}}' | grep '^piksi_.*,.*$' | cut -f2 -d, || echo)
+[[ -z "$running_images" ]] || docker stop -t 1 "$running_images"
+
+echo "... removing Piksi containers"
+
+stopped_images=$(docker ps -a --format '{{.Names }},{{.ID}}' | grep '^piksi_.*,.*$' | cut -f2 -d, || echo)
+[[ -z "$stopped_images" ]] || docker rm -f "$stopped_images"
+
+echo "... removing Piksi images"
+
+images=$(docker images --format '{{.Repository}},{{.ID}}' | grep '^piksi_.*,.*$' | cut -f2 -d, || echo)
+[[ -z "$images" ]] || docker rmi -f "$images"
+
+echo "... removing Piksi volumes"
+
+volumes=$(docker volume ls --format '{{.Name}}' | grep '^piksi_.*$' || echo)
+[[ -z "$volumes" ]] || docker volume rm "$volumes"


### PR DESCRIPTION
+ Use the docker-sync tool to sync everything in `/piksi_buildroot` into a container volume-- the primary use-case of this is to support building on a remote `$DOCKER_HOST`.

+ Add the new targets: `docker-sync-setup`, `docker-sync-start`, `docker-sync-stop`, `docker-sync-logs`, and `docker-sync-cleanup`

+ Add `docker-aws-google-auth` to facilitate getting fresh AWS credentials