### PR TITLE
Docs, fixup clang-complete, and docker-sync [DEVC-1087]

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,9 +1,22 @@
-let s:path = resolve(expand('<sfile>:p:h'))
+""" To use this you need to have the following plugins installed
+"""   with your favorite plugin manager:
+"""
+"""     Plugin 'justmao945/vim-clang'
+"""     Plugin 'w0rp/ale'
+"""
+""" And also have the following lines in your ~/.vimrc, so that
+"""   the project specific .vimrc will get evaluated:
+"""     
+"""      set exrc
+"""      set secure
+"""
+""" Then run the clang-complete-config target:
+"""
+"""     make docker-clang-complete-config
+"""       (or without docker- if not using docker)
+"""
 
-"let g:syntastic_clang_tidy_config_file = s:path . '/.clang_complete'
-"let g:syntastic_cpp_config_file = s:path . '/.clang_complete'
-"let g:syntastic_c_clang_tidy_exec = s:path . '/scripts/vim-clang-tidy'
-"let g:syntastic_cpp_clang_tidy_exec = s:path . '/scripts/vim-clang-tidy'
+let s:path = resolve(expand('<sfile>:p:h'))
 
 let g:clang_dotfile = s:path . '/.clang_complete'
 let g:clang_exec = s:path . '/scripts/vim-clang'

--- a/scripts/gen-clang-complete
+++ b/scripts/gen-clang-complete
@@ -18,5 +18,4 @@ cat >$D/../.clang_complete <<EOF
 -isysroot$D/../buildroot/output/host/usr/arm-buildroot-linux-gnueabihf/sysroot
 -arch armv7
 -fblocks
--std=gnu11
 EOF

--- a/scripts/gen-docker-sync
+++ b/scripts/gen-docker-sync
@@ -4,6 +4,13 @@ docker_build_volume=$1; shift
 docker_sync_uid=$1; shift
 docker_host=$1; shift
 
+die_usage() {
+  echo "$(basename "$0"): <DOCKER_BUILD_VOLUME> <DOCKER_SYNC_UID> <DOCKER_HOST>"
+  exit 1
+}
+
+[[ -n "$docker_host" ]] || { echo $'ERROR: no <DOCKER_HOST> specifid\n' >&2; die_usage; }
+
 cat >.docker-sync.yml <<EOF
 version: "2"
 options:


### PR DESCRIPTION
+ Add docs for the project specific .vimrc

+ Remove -std=gnu11 from clang-complete since it doesn't work for c++
code (and gnu11 should be the default for C code in clang-tidy).

+ Make docker-sync config generation error out if DOCKER_HOST isn't set