### PR TITLE
Add additional settings update error codes [DEVC-1225] [DEVC-1219]

### DIFF
--- a/package/cell_modem_daemon/src/cell_modem_settings.c
+++ b/package/cell_modem_daemon/src/cell_modem_settings.c
@@ -95,7 +95,7 @@ static int cell_modem_notify(void *context)
   stop_runit_service(&cfg_stop);
 
   if ((!cell_modem_enabled_) || (cell_modem_dev == NULL) || (modem_type == MODEM_TYPE_INVALID)) {
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
 
   char chatcmd[256];
@@ -129,7 +129,10 @@ static int cell_modem_notify(void *context)
     .restart = true,
   };
 
-  return start_runit_service(&cfg_start);
+  if (start_runit_service(&cfg_start) != 0) {
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
+  }
+  return SBP_WRITE_STATUS_OK;
 }
 
 void override_probe_retry(pk_loop_t *loop, void *timer_handle, void *context)
@@ -155,12 +158,12 @@ static int cell_modem_notify_dev_override(void *context)
 {
   inotify_ctx_t *ctx = *((inotify_ctx_t **)context);
   if (ctx == NULL) {
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
   // Don't allow changes if cell modem is enabled
   if (cell_modem_enabled_) {
     sbp_log(LOG_WARNING, "Modem must be disabled to modify device override");
-    return 1;
+    return SBP_WRITE_STATUS_MODIFY_DISABLED;
   }
 
   // override updated
@@ -174,7 +177,7 @@ static int cell_modem_notify_dev_override(void *context)
   cell_modem_set_dev_to_invalid(ctx);
   cell_modem_notify(NULL);
   cell_modem_scan_for_modem(ctx);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 int cell_modem_init(pk_loop_t *loop, settings_ctx_t *settings_ctx)

--- a/package/cell_modem_daemon/src/cell_modem_settings.c
+++ b/package/cell_modem_daemon/src/cell_modem_settings.c
@@ -95,7 +95,7 @@ static int cell_modem_notify(void *context)
   stop_runit_service(&cfg_stop);
 
   if ((!cell_modem_enabled_) || (cell_modem_dev == NULL) || (modem_type == MODEM_TYPE_INVALID)) {
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
 
   char chatcmd[256];
@@ -130,9 +130,9 @@ static int cell_modem_notify(void *context)
   };
 
   if (start_runit_service(&cfg_start) != 0) {
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 void override_probe_retry(pk_loop_t *loop, void *timer_handle, void *context)
@@ -158,12 +158,12 @@ static int cell_modem_notify_dev_override(void *context)
 {
   inotify_ctx_t *ctx = *((inotify_ctx_t **)context);
   if (ctx == NULL) {
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
   // Don't allow changes if cell modem is enabled
   if (cell_modem_enabled_) {
     sbp_log(LOG_WARNING, "Modem must be disabled to modify device override");
-    return SBP_WRITE_STATUS_MODIFY_DISABLED;
+    return SBP_SETTINGS_WRITE_STATUS_MODIFY_DISABLED;
   }
 
   // override updated
@@ -177,7 +177,7 @@ static int cell_modem_notify_dev_override(void *context)
   cell_modem_set_dev_to_invalid(ctx);
   cell_modem_notify(NULL);
   cell_modem_scan_for_modem(ctx);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 int cell_modem_init(pk_loop_t *loop, settings_ctx_t *settings_ctx)

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -52,7 +52,9 @@ enum {
   SBP_WRITE_STATUS_VALUE_REJECTED   = 1,/**< Setting value invalid         */
   SBP_WRITE_STATUS_SETTING_REJECTED = 2,/**< Setting does not exist        */
   SBP_WRITE_STATUS_PARSE_FAILED     = 3,/**< Could not parse setting value */
+  // READ_ONLY:MODIFY_DISABLED ~= Permanent:Temporary
   SBP_WRITE_STATUS_READ_ONLY        = 4,/**< Setting is read only          */
+  SBP_WRITE_STATUS_MODIFY_DISABLED  = 5,/**< Setting is is not modifiable  */
 };
 
 /**

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -55,6 +55,7 @@ enum {
   // READ_ONLY:MODIFY_DISABLED ~= Permanent:Temporary
   SBP_WRITE_STATUS_READ_ONLY        = 4,/**< Setting is read only          */
   SBP_WRITE_STATUS_MODIFY_DISABLED  = 5,/**< Setting is is not modifiable  */
+  SBP_WRITE_STATUS_SERVICE_FAILED   = 6,/**< System failure during setting */
 };
 
 /**

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -48,14 +48,14 @@ enum {
  * @brief Settings error codes
  */
 enum {
-  SBP_WRITE_STATUS_OK = 0,               /**< Setting written               */
-  SBP_WRITE_STATUS_VALUE_REJECTED = 1,   /**< Setting value invalid         */
-  SBP_WRITE_STATUS_SETTING_REJECTED = 2, /**< Setting does not exist        */
-  SBP_WRITE_STATUS_PARSE_FAILED = 3,     /**< Could not parse setting value */
+  SBP_SETTINGS_WRITE_STATUS_OK = 0,               /**< Setting written               */
+  SBP_SETTINGS_WRITE_STATUS_VALUE_REJECTED = 1,   /**< Setting value invalid         */
+  SBP_SETTINGS_WRITE_STATUS_SETTING_REJECTED = 2, /**< Setting does not exist        */
+  SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED = 3,     /**< Could not parse setting value */
   // READ_ONLY:MODIFY_DISABLED ~= Permanent:Temporary
-  SBP_WRITE_STATUS_READ_ONLY = 4,       /**< Setting is read only          */
-  SBP_WRITE_STATUS_MODIFY_DISABLED = 5, /**< Setting is not modifiable     */
-  SBP_WRITE_STATUS_SERVICE_FAILED = 6,  /**< System failure during setting */
+  SBP_SETTINGS_WRITE_STATUS_READ_ONLY = 4,       /**< Setting is read only          */
+  SBP_SETTINGS_WRITE_STATUS_MODIFY_DISABLED = 5, /**< Setting is not modifiable     */
+  SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED = 6,  /**< System failure during setting */
 };
 
 /**

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -48,11 +48,11 @@ enum {
  * @brief Settings error codes
  */
 enum {
-  SBP_WRITE_STATUS_OK,                /**< Setting written                               */
-  SBP_WRITE_STATUS_VALUE_REJECTED,    /**< Setting value invalid                         */
-  SBP_WRITE_STATUS_SETTING_REJECTED,  /**< Setting does not exist                        */
-  SBP_WRITE_STATUS_PARSE_FAILED,      /**< Could not parse setting value                 */
-  SBP_WRITE_STATUS_VALUE_READ_ONLY,   /**< Setting is read only                          */
+  SBP_WRITE_STATUS_OK               = 0,/**< Setting written               */
+  SBP_WRITE_STATUS_VALUE_REJECTED   = 1,/**< Setting value invalid         */
+  SBP_WRITE_STATUS_SETTING_REJECTED = 2,/**< Setting does not exist        */
+  SBP_WRITE_STATUS_PARSE_FAILED     = 3,/**< Could not parse setting value */
+  SBP_WRITE_STATUS_READ_ONLY        = 4,/**< Setting is read only          */
 };
 
 /**

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -41,7 +41,18 @@ enum {
   SETTINGS_TYPE_INT,    /**< Integer. 8, 16, or 32 bits.                   */
   SETTINGS_TYPE_FLOAT,  /**< Float. Single or double precision.            */
   SETTINGS_TYPE_STRING, /**< String.                                       */
-  SETTINGS_TYPE_BOOL    /**< Boolean.                                      */
+  SETTINGS_TYPE_BOOL,   /**< Boolean.                                      */
+};
+
+/**
+ * @brief Settings error codes
+ */
+enum {
+  SBP_WRITE_STATUS_OK,                /**< Setting written                               */
+  SBP_WRITE_STATUS_VALUE_REJECTED,    /**< Setting value invalid                         */
+  SBP_WRITE_STATUS_SETTING_REJECTED,  /**< Setting does not exist                        */
+  SBP_WRITE_STATUS_PARSE_FAILED,      /**< Could not parse setting value                 */
+  SBP_WRITE_STATUS_VALUE_READ_ONLY,   /**< Setting is read only                          */
 };
 
 /**

--- a/package/libpiksi/libpiksi/include/libpiksi/settings.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/settings.h
@@ -48,14 +48,14 @@ enum {
  * @brief Settings error codes
  */
 enum {
-  SBP_WRITE_STATUS_OK               = 0,/**< Setting written               */
-  SBP_WRITE_STATUS_VALUE_REJECTED   = 1,/**< Setting value invalid         */
-  SBP_WRITE_STATUS_SETTING_REJECTED = 2,/**< Setting does not exist        */
-  SBP_WRITE_STATUS_PARSE_FAILED     = 3,/**< Could not parse setting value */
+  SBP_WRITE_STATUS_OK = 0,               /**< Setting written               */
+  SBP_WRITE_STATUS_VALUE_REJECTED = 1,   /**< Setting value invalid         */
+  SBP_WRITE_STATUS_SETTING_REJECTED = 2, /**< Setting does not exist        */
+  SBP_WRITE_STATUS_PARSE_FAILED = 3,     /**< Could not parse setting value */
   // READ_ONLY:MODIFY_DISABLED ~= Permanent:Temporary
-  SBP_WRITE_STATUS_READ_ONLY        = 4,/**< Setting is read only          */
-  SBP_WRITE_STATUS_MODIFY_DISABLED  = 5,/**< Setting is is not modifiable  */
-  SBP_WRITE_STATUS_SERVICE_FAILED   = 6,/**< System failure during setting */
+  SBP_WRITE_STATUS_READ_ONLY = 4,       /**< Setting is read only          */
+  SBP_WRITE_STATUS_MODIFY_DISABLED = 5, /**< Setting is not modifiable     */
+  SBP_WRITE_STATUS_SERVICE_FAILED = 6,  /**< System failure during setting */
 };
 
 /**

--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -890,7 +890,7 @@ static void setting_update_value(setting_data_t *setting_data, const char *value
     } else if (setting_data->notify != NULL) {
       /* Call notify function */
       int notify_response = setting_data->notify(setting_data->notify_context);
-      if ( notify_response != SBP_WRITE_STATUS_OK) {
+      if (notify_response != SBP_WRITE_STATUS_OK) {
         if (!setting_data->watchonly) {
           /* Revert value if notify returns error */
           memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);

--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -875,7 +875,7 @@ static int setting_format_setting(setting_data_t *setting_data, char *buf, int l
 static void setting_update_value(setting_data_t *setting_data, const char *value, u8 *write_result)
 {
   if (setting_data->readonly) {
-    *write_result = SBP_WRITE_STATUS_VALUE_READ_ONLY;
+    *write_result = SBP_WRITE_STATUS_READ_ONLY;
   } else {
     *write_result = SBP_WRITE_STATUS_OK;
     /* Store copy and update value */
@@ -886,11 +886,11 @@ static void setting_update_value(setting_data_t *setting_data, const char *value
                                               value)) {
       /* Revert value if conversion fails */
       memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
-      *write_result = SBP_WRITE_STATUS_VALUE_REJECTED;
+      *write_result = SBP_WRITE_STATUS_PARSE_FAILED;
     } else if (setting_data->notify != NULL) {
       /* Call notify function */
       int notify_response = setting_data->notify(setting_data->notify_context);
-      if ( notify_response != 0) {
+      if ( notify_response != SBP_WRITE_STATUS_OK) {
         if (!setting_data->watchonly) {
           /* Revert value if notify returns error */
           memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);

--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -875,9 +875,9 @@ static int setting_format_setting(setting_data_t *setting_data, char *buf, int l
 static void setting_update_value(setting_data_t *setting_data, const char *value, u8 *write_result)
 {
   if (setting_data->readonly) {
-    *write_result = SBP_WRITE_STATUS_READ_ONLY;
+    *write_result = SBP_SETTINGS_WRITE_STATUS_READ_ONLY;
   } else {
-    *write_result = SBP_WRITE_STATUS_OK;
+    *write_result = SBP_SETTINGS_WRITE_STATUS_OK;
     /* Store copy and update value */
     memcpy(setting_data->var_copy, setting_data->var, setting_data->var_len);
     if (!setting_data->type_data->from_string(setting_data->type_data->priv,
@@ -886,11 +886,11 @@ static void setting_update_value(setting_data_t *setting_data, const char *value
                                               value)) {
       /* Revert value if conversion fails */
       memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
-      *write_result = SBP_WRITE_STATUS_PARSE_FAILED;
+      *write_result = SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
     } else if (setting_data->notify != NULL) {
       /* Call notify function */
       int notify_response = setting_data->notify(setting_data->notify_context);
-      if (notify_response != SBP_WRITE_STATUS_OK) {
+      if (notify_response != SBP_SETTINGS_WRITE_STATUS_OK) {
         if (!setting_data->watchonly) {
           /* Revert value if notify returns error */
           memcpy(setting_data->var, setting_data->var_copy, setting_data->var_len);
@@ -981,7 +981,7 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[], void *conte
     return;
   }
 
-  u8 write_result = SBP_WRITE_STATUS_OK;
+  u8 write_result = SBP_SETTINGS_WRITE_STATUS_OK;
   setting_update_value(setting_data, value, &write_result);
 
   u8 resp[SBP_PAYLOAD_SIZE_MAX];
@@ -1022,9 +1022,9 @@ static int settings_update_watch_only(settings_ctx_t *ctx, u8 *msg, u8 len)
     return 0;
   }
 
-  u8 write_result = SBP_WRITE_STATUS_OK;
+  u8 write_result = SBP_SETTINGS_WRITE_STATUS_OK;
   setting_update_value(setting_data, value, &write_result);
-  if (write_result != SBP_WRITE_STATUS_OK) {
+  if (write_result != SBP_SETTINGS_WRITE_STATUS_OK) {
     return -1;
   }
   return 0;

--- a/package/metrics_daemon/metrics_daemon/src/metrics_daemon.c
+++ b/package/metrics_daemon/metrics_daemon/src/metrics_daemon.c
@@ -333,7 +333,7 @@ static int notify_log_settings_changed(void *context)
             enable_log_to_file,
             metrics_update_interval);
   sbp_update_timer_interval(TO_MILLISECONDS(metrics_update_interval), run_routine_function);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 int main(int argc, char *argv[])

--- a/package/metrics_daemon/metrics_daemon/src/metrics_daemon.c
+++ b/package/metrics_daemon/metrics_daemon/src/metrics_daemon.c
@@ -333,7 +333,7 @@ static int notify_log_settings_changed(void *context)
             enable_log_to_file,
             metrics_update_interval);
   sbp_update_timer_interval(TO_MILLISECONDS(metrics_update_interval), run_routine_function);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 int main(int argc, char *argv[])

--- a/package/ntrip_daemon/src/ntrip_settings.c
+++ b/package/ntrip_daemon/src/ntrip_settings.c
@@ -202,10 +202,10 @@ static int ntrip_notify_generic(void *context)
    * is triggered by read from persistent config file during boot */
   if (ntrip_enabled && ntrip_settings_initialized) {
     sbp_log(LOG_WARNING, "NTRIP must be disabled to modify settings");
-    return SBP_WRITE_STATUS_MODIFY_DISABLED;
+    return SBP_SETTINGS_WRITE_STATUS_MODIFY_DISABLED;
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int ntrip_notify_enable(void *context)

--- a/package/ntrip_daemon/src/ntrip_settings.c
+++ b/package/ntrip_daemon/src/ntrip_settings.c
@@ -202,7 +202,7 @@ static int ntrip_notify_generic(void *context)
    * is triggered by read from persistent config file during boot */
   if (ntrip_enabled && ntrip_settings_initialized) {
     sbp_log(LOG_WARNING, "NTRIP must be disabled to modify settings");
-    return SBP_WRITE_STATUS_MODIFY_ONLY;
+    return SBP_WRITE_STATUS_MODIFY_DISABLED;
   }
 
   return SBP_WRITE_STATUS_OK;

--- a/package/ntrip_daemon/src/ntrip_settings.c
+++ b/package/ntrip_daemon/src/ntrip_settings.c
@@ -202,7 +202,7 @@ static int ntrip_notify_generic(void *context)
    * is triggered by read from persistent config file during boot */
   if (ntrip_enabled && ntrip_settings_initialized) {
     sbp_log(LOG_WARNING, "NTRIP must be disabled to modify settings");
-    return SBP_WRITE_STATUS_VALUE_READ_ONLY;
+    return SBP_WRITE_STATUS_MODIFY_ONLY;
   }
 
   return SBP_WRITE_STATUS_OK;

--- a/package/ntrip_daemon/src/ntrip_settings.c
+++ b/package/ntrip_daemon/src/ntrip_settings.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 
 #include <libpiksi/logging.h>
+#include <libpiksi/settings.h>
 #include <libpiksi/util.h>
 
 #include "ntrip_settings.h"
@@ -201,10 +202,10 @@ static int ntrip_notify_generic(void *context)
    * is triggered by read from persistent config file during boot */
   if (ntrip_enabled && ntrip_settings_initialized) {
     sbp_log(LOG_WARNING, "NTRIP must be disabled to modify settings");
-    return 1;
+    return SBP_WRITE_STATUS_VALUE_READ_ONLY;
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int ntrip_notify_enable(void *context)

--- a/package/orion_daemon/src/orion_daemon.cc
+++ b/package/orion_daemon/src/orion_daemon.cc
@@ -66,7 +66,7 @@ static int settings_callback(void *context)
   enabled = enable && strlen(port) != 0;
   changed = true;
   condition.notify_all();
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static void pos_llh_callback(uint16_t sender, uint8_t length, uint8_t *payload, void *context)

--- a/package/orion_daemon/src/orion_daemon.cc
+++ b/package/orion_daemon/src/orion_daemon.cc
@@ -66,7 +66,7 @@ static int settings_callback(void *context)
   enabled = enable && strlen(port) != 0;
   changed = true;
   condition.notify_all();
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static void pos_llh_callback(uint16_t sender, uint8_t length, uint8_t *payload, void *context)

--- a/package/ota_daemon/src/ota_settings.c
+++ b/package/ota_daemon/src/ota_settings.c
@@ -62,9 +62,9 @@ static int ota_notify_enable(void *context)
   runit_cfg.command_line = NULL;
 
   if (ret != 0) {
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int ota_notify_generic(void *context)
@@ -73,10 +73,10 @@ static int ota_notify_generic(void *context)
 
   if (stat_runit_service(&runit_cfg) == RUNIT_RUNNING) {
     sbp_log(LOG_WARNING, "OTA must be disabled to modify settings");
-    return SBP_WRITE_STATUS_MODIFY_DISABLED;
+    return SBP_SETTINGS_WRITE_STATUS_MODIFY_DISABLED;
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 void ota_settings(settings_ctx_t *ctx)

--- a/package/ota_daemon/src/ota_settings.c
+++ b/package/ota_daemon/src/ota_settings.c
@@ -11,6 +11,7 @@
  */
 
 #include <libpiksi/logging.h>
+#include <libpiksi/settings.h>
 #include <libpiksi/runit.h>
 
 #include "ota_settings.h"
@@ -60,7 +61,10 @@ static int ota_notify_enable(void *context)
   /* Clear the pointer because it points to local char array */
   runit_cfg.command_line = NULL;
 
-  return ret;
+  if (ret != 0) {
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
+  }
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int ota_notify_generic(void *context)
@@ -69,10 +73,10 @@ static int ota_notify_generic(void *context)
 
   if (stat_runit_service(&runit_cfg) == RUNIT_RUNNING) {
     sbp_log(LOG_WARNING, "OTA must be disabled to modify settings");
-    return 1;
+    return SBP_WRITE_STATUS_MODIFY_DISABLED;
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 void ota_settings(settings_ctx_t *ctx)

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -83,7 +83,7 @@ static int eth_ip_mode_notify(void *context)
 {
   (void)context;
   eth_update_config();
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int eth_ip_config_notify(void *context)
@@ -91,11 +91,11 @@ static int eth_ip_config_notify(void *context)
   char *ip = (char *)context;
 
   if (inet_addr(ip) == INADDR_NONE) {
-    return -1;
+    return SBP_WRITE_STATUS_VALUE_REJECTED;
   }
 
   eth_update_config();
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static void sbp_network_req(u16 sender_id, u8 len, u8 msg_[], void *context)
@@ -433,14 +433,14 @@ static int system_time_src_notify(void *context)
 
   if (oldsrc == system_time_src) {
     /* Avoid restarting ntpd if config hasn't changed */
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
 
   switch (system_time_src) {
   case SYSTEM_TIME_GPS_NTP: ntpconf = "/etc/ntp.conf.gpsntp"; break;
   case SYSTEM_TIME_GPS: ntpconf = "/etc/ntp.conf.gps"; break;
   case SYSTEM_TIME_NTP: ntpconf = "/etc/ntp.conf.ntp"; break;
-  default: return -1;
+  default: return SBP_WRITE_STATUS_VALUE_REJECTED;
   }
 
   char command[1024] = {0};
@@ -448,7 +448,10 @@ static int system_time_src_notify(void *context)
     snprintf(command, sizeof(command), "sudo /etc/init.d/update_ntp_config %s", ntpconf);
   assert(count < sizeof(command));
 
-  return system(command);
+  if (system(command) != 0) {
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
+  }
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int network_polling_notify(void *context)
@@ -488,7 +491,7 @@ static int network_polling_notify(void *context)
       piksi_log(LOG_ERR | LOG_SBP,
                 "buffer overflow while formatting setting '%s'",
                 formatters[x].name);
-      return 0;
+      return SBP_WRITE_STATUS_PARSE_FAILED;
     }
   }
 
@@ -519,7 +522,7 @@ static int network_polling_notify(void *context)
     fclose(fp);
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 int main(void)

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -83,7 +83,7 @@ static int eth_ip_mode_notify(void *context)
 {
   (void)context;
   eth_update_config();
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int eth_ip_config_notify(void *context)
@@ -91,11 +91,11 @@ static int eth_ip_config_notify(void *context)
   char *ip = (char *)context;
 
   if (inet_addr(ip) == INADDR_NONE) {
-    return SBP_WRITE_STATUS_VALUE_REJECTED;
+    return SBP_SETTINGS_WRITE_STATUS_VALUE_REJECTED;
   }
 
   eth_update_config();
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static void sbp_network_req(u16 sender_id, u8 len, u8 msg_[], void *context)
@@ -433,14 +433,14 @@ static int system_time_src_notify(void *context)
 
   if (oldsrc == system_time_src) {
     /* Avoid restarting ntpd if config hasn't changed */
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
 
   switch (system_time_src) {
   case SYSTEM_TIME_GPS_NTP: ntpconf = "/etc/ntp.conf.gpsntp"; break;
   case SYSTEM_TIME_GPS: ntpconf = "/etc/ntp.conf.gps"; break;
   case SYSTEM_TIME_NTP: ntpconf = "/etc/ntp.conf.ntp"; break;
-  default: return SBP_WRITE_STATUS_VALUE_REJECTED;
+  default: return SBP_SETTINGS_WRITE_STATUS_VALUE_REJECTED;
   }
 
   char command[1024] = {0};
@@ -449,9 +449,9 @@ static int system_time_src_notify(void *context)
   assert(count < sizeof(command));
 
   if (system(command) != 0) {
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int network_polling_notify(void *context)
@@ -491,7 +491,7 @@ static int network_polling_notify(void *context)
       piksi_log(LOG_ERR | LOG_SBP,
                 "buffer overflow while formatting setting '%s'",
                 formatters[x].name);
-      return SBP_WRITE_STATUS_VALUE_REJECTED;
+      return SBP_SETTINGS_WRITE_STATUS_VALUE_REJECTED;
     }
   }
 
@@ -522,7 +522,7 @@ static int network_polling_notify(void *context)
     fclose(fp);
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 int main(void)

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -491,7 +491,7 @@ static int network_polling_notify(void *context)
       piksi_log(LOG_ERR | LOG_SBP,
                 "buffer overflow while formatting setting '%s'",
                 formatters[x].name);
-      return SBP_WRITE_STATUS_PARSE_FAILED;
+      return SBP_WRITE_STATUS_VALUE_REJECTED;
     }
   }
 

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -312,13 +312,13 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
   }
 
   if (port_config->mode == MODE_DISABLED) {
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
 
   int protocol_index = mode_to_protocol_index(port_config->mode);
   const protocol_t *protocol = protocols_get(protocol_index);
   if (protocol == NULL) {
-    return -1;
+    return SBP_WRITE_STATUS_VALUE_REJECTED;
   }
 
   /* Prepare the command used to launch endpoint_adapter. */
@@ -334,7 +334,10 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
 
   piksi_log(LOG_DEBUG, "Starting endpoint_adapter: %s", cmd);
 
-  return start_runit_service(&cfg);
+  if (start_runit_service(&cfg) != 0) {
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
+  }
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int setting_mode_notify(void *context)

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -295,7 +295,7 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
   if (!updating_mode && port_config->first_start) {
     // Wait for mode settings to be updated before launching the port, the
     //   'mode' setting should be sent last because it's registered last.
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
 
   if (port_config->first_start) {

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -295,7 +295,7 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
   if (!updating_mode && port_config->first_start) {
     // Wait for mode settings to be updated before launching the port, the
     //   'mode' setting should be sent last because it's registered last.
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
 
   if (port_config->first_start) {
@@ -312,13 +312,13 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
   }
 
   if (port_config->mode == MODE_DISABLED) {
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
 
   int protocol_index = mode_to_protocol_index(port_config->mode);
   const protocol_t *protocol = protocols_get(protocol_index);
   if (protocol == NULL) {
-    return SBP_WRITE_STATUS_VALUE_REJECTED;
+    return SBP_SETTINGS_WRITE_STATUS_VALUE_REJECTED;
   }
 
   /* Prepare the command used to launch endpoint_adapter. */
@@ -335,9 +335,9 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
   piksi_log(LOG_DEBUG, "Starting endpoint_adapter: %s", cmd);
 
   if (start_runit_service(&cfg) != 0) {
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int setting_mode_notify(void *context)

--- a/package/ports_daemon/ports_daemon/src/serial.c
+++ b/package/ports_daemon/ports_daemon/src/serial.c
@@ -90,14 +90,14 @@ static int uart_configure(const uart_t *uart)
   int fd = open(uart->tty_path, O_RDONLY | O_NONBLOCK);
   if (fd < 0) {
     piksi_log(LOG_ERR, "error opening tty device");
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
 
   struct termios tio;
   if (tcgetattr(fd, &tio) != 0) {
     piksi_log(LOG_ERR, "error in tcgetattr()");
     close(fd);
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
 
   cfmakeraw(&tio);
@@ -113,7 +113,7 @@ static int uart_configure(const uart_t *uart)
   if (tcgetattr(fd, &tio) != 0) {
     piksi_log(LOG_ERR, "error in tcgetattr()");
     close(fd);
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
 
   close(fd);
@@ -123,10 +123,10 @@ static int uart_configure(const uart_t *uart)
       || ((tio.c_cflag & CRTSCTS) ? (uart->flow_control != FLOW_CONTROL_RTS_CTS)
                                   : (uart->flow_control != FLOW_CONTROL_NONE))) {
     piksi_log(LOG_ERR, "error configuring tty");
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int baudrate_notify(void *context)

--- a/package/ports_daemon/ports_daemon/src/serial.c
+++ b/package/ports_daemon/ports_daemon/src/serial.c
@@ -90,14 +90,14 @@ static int uart_configure(const uart_t *uart)
   int fd = open(uart->tty_path, O_RDONLY | O_NONBLOCK);
   if (fd < 0) {
     piksi_log(LOG_ERR, "error opening tty device");
-    return -1;
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
   }
 
   struct termios tio;
   if (tcgetattr(fd, &tio) != 0) {
     piksi_log(LOG_ERR, "error in tcgetattr()");
     close(fd);
-    return -1;
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
   }
 
   cfmakeraw(&tio);
@@ -113,7 +113,7 @@ static int uart_configure(const uart_t *uart)
   if (tcgetattr(fd, &tio) != 0) {
     piksi_log(LOG_ERR, "error in tcgetattr()");
     close(fd);
-    return -1;
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
   }
 
   close(fd);
@@ -123,10 +123,10 @@ static int uart_configure(const uart_t *uart)
       || ((tio.c_cflag & CRTSCTS) ? (uart->flow_control != FLOW_CONTROL_RTS_CTS)
                                   : (uart->flow_control != FLOW_CONTROL_NONE))) {
     piksi_log(LOG_ERR, "error configuring tty");
-    return -1;
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int baudrate_notify(void *context)

--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -463,7 +463,7 @@ int whitelist_notify(void *context)
         break;
       case PARSE_AFTER_DIV:
       case PARSE_AFTER_ID:
-      default: return SBP_WRITE_STATUS_PARSE_FAILED;
+      default: return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
       }
       break;
 
@@ -473,7 +473,7 @@ int whitelist_notify(void *context)
         state = PARSE_DIV;
         c++;
       } else {
-        return SBP_WRITE_STATUS_PARSE_FAILED;
+        return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
       }
       break;
 
@@ -483,7 +483,7 @@ int whitelist_notify(void *context)
         state = PARSE_ID;
         c++;
       } else {
-        return SBP_WRITE_STATUS_PARSE_FAILED;
+        return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
       }
       break;
 
@@ -497,7 +497,7 @@ int whitelist_notify(void *context)
       break;
 
     /* Invalid token, parse error */
-    default: return SBP_WRITE_STATUS_PARSE_FAILED;
+    default: return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
     }
   }
 
@@ -507,14 +507,14 @@ int whitelist_notify(void *context)
   FILE *cfg = fopen(fn, "w");
   if (cfg == NULL) {
     piksi_log(LOG_ERR, "Error opening file: %s (error: %s)", fn, strerror(errno));
-    return SBP_WRITE_STATUS_SERVICE_FAILED;
+    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
   }
   for (int i = 0; i < entries; i++) {
     fprintf(cfg, "%x %x\n", whitelist[i].id, whitelist[i].div);
   }
   fclose(cfg);
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 int whitelists_init(settings_ctx_t *settings_ctx)

--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -463,7 +463,7 @@ int whitelist_notify(void *context)
         break;
       case PARSE_AFTER_DIV:
       case PARSE_AFTER_ID:
-      default: return -1;
+      default: return SBP_WRITE_STATUS_PARSE_FAILED;
       }
       break;
 
@@ -473,7 +473,7 @@ int whitelist_notify(void *context)
         state = PARSE_DIV;
         c++;
       } else {
-        return -1;
+        return SBP_WRITE_STATUS_PARSE_FAILED;
       }
       break;
 
@@ -483,7 +483,7 @@ int whitelist_notify(void *context)
         state = PARSE_ID;
         c++;
       } else {
-        return -1;
+        return SBP_WRITE_STATUS_PARSE_FAILED;
       }
       break;
 
@@ -497,7 +497,7 @@ int whitelist_notify(void *context)
       break;
 
     /* Invalid token, parse error */
-    default: return -1;
+    default: return SBP_WRITE_STATUS_PARSE_FAILED;
     }
   }
 
@@ -507,14 +507,14 @@ int whitelist_notify(void *context)
   FILE *cfg = fopen(fn, "w");
   if (cfg == NULL) {
     piksi_log(LOG_ERR, "Error opening file: %s (error: %s)", fn, strerror(errno));
-    return -1;
+    return SBP_WRITE_STATUS_SERVICE_FAILED;
   }
   for (int i = 0; i < entries; i++) {
     fprintf(cfg, "%x %x\n", whitelist[i].id, whitelist[i].div);
   }
   fclose(cfg);
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 int whitelists_init(settings_ctx_t *settings_ctx)

--- a/package/sample_daemon/src/sample_daemon.c
+++ b/package/sample_daemon/src/sample_daemon.c
@@ -146,7 +146,7 @@ static int notify_settings_changed(void *context)
 
   if (enable_broadcast) open_udp_broadcast_socket(&udp_context, broadcast_hostname, broadcast_port);
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 int main(int argc, char *argv[])

--- a/package/sample_daemon/src/sample_daemon.c
+++ b/package/sample_daemon/src/sample_daemon.c
@@ -146,7 +146,7 @@ static int notify_settings_changed(void *context)
 
   if (enable_broadcast) open_udp_broadcast_socket(&udp_context, broadcast_hostname, broadcast_port);
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 int main(int argc, char *argv[])

--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -91,56 +91,56 @@ static int notify_gpgga_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpgga_rate(gpgga_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_gprmc_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gprmc_rate(gprmc_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_gpvtg_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpvtg_rate(gpvtg_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_gphdt_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gphdt_rate(gphdt_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_gpgll_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpgll_rate(gpgll_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_gpzda_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpzda_rate(gpzda_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_gsa_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gsa_rate(gsa_rate, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int notify_soln_freq_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_soln_freq(soln_freq, &state);
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static void gps_time_callback(u16 sender_id, u8 len, u8 msg[], void *context)

--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -91,56 +91,56 @@ static int notify_gpgga_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpgga_rate(gpgga_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_gprmc_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gprmc_rate(gprmc_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_gpvtg_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpvtg_rate(gpvtg_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_gphdt_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gphdt_rate(gphdt_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_gpgll_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpgll_rate(gpgll_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_gpzda_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gpzda_rate(gpzda_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_gsa_rate_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_gsa_rate(gsa_rate, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int notify_soln_freq_changed(void *context)
 {
   (void)context;
   sbp2nmea_set_soln_freq(soln_freq, &state);
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static void gps_time_callback(u16 sender_id, u8 len, u8 msg[], void *context)

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -15,6 +15,7 @@
 #include <getopt.h>
 #include <gnss-converters/rtcm3_sbp.h>
 #include <libpiksi/logging.h>
+#include <libpiksi/settings.h>
 #include <libsbp/navigation.h>
 #include <libsbp/sbp.h>
 #include <stdint.h>
@@ -202,10 +203,10 @@ static int notify_rtcm_out_output_mode_changed(void *context)
   case RTCM_OUT_MODE_LEGACY: sbp2rtcm_set_rtcm_out_mode(MSM_UNKNOWN, &sbp_to_rtcm3_state); break;
   case RTCM_OUT_MODE_MSM4: sbp2rtcm_set_rtcm_out_mode(MSM4, &sbp_to_rtcm3_state); break;
   case RTCM_OUT_MODE_MSM5: sbp2rtcm_set_rtcm_out_mode(MSM5, &sbp_to_rtcm3_state); break;
-  default: return -1;
+  default: return SBP_WRITE_STATUS_VALUE_REJECTED;
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int cleanup(pk_endpoint_t **rtcm_ept_loc, int status);

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -203,10 +203,10 @@ static int notify_rtcm_out_output_mode_changed(void *context)
   case RTCM_OUT_MODE_LEGACY: sbp2rtcm_set_rtcm_out_mode(MSM_UNKNOWN, &sbp_to_rtcm3_state); break;
   case RTCM_OUT_MODE_MSM4: sbp2rtcm_set_rtcm_out_mode(MSM4, &sbp_to_rtcm3_state); break;
   case RTCM_OUT_MODE_MSM5: sbp2rtcm_set_rtcm_out_mode(MSM5, &sbp_to_rtcm3_state); break;
-  default: return SBP_WRITE_STATUS_VALUE_REJECTED;
+  default: return SBP_SETTINGS_WRITE_STATUS_VALUE_REJECTED;
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int cleanup(pk_endpoint_t **rtcm_ept_loc, int status);

--- a/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
+++ b/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
@@ -342,7 +342,7 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[], void *conte
     return;
   }
 
-  u8 resp[] = {SBP_WRITE_STATUS_SETTING_REJECTED};
+  u8 resp[] = {SBP_SETTINGS_WRITE_STATUS_SETTING_REJECTED};
   /* Reply with write response rejecting this setting */
   sbp_tx_send_from(tx_ctx, SBP_MSG_SETTINGS_WRITE_RESP, sizeof(resp), resp, SBP_SENDER_ID);
 }

--- a/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
+++ b/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
@@ -11,6 +11,7 @@
  */
 
 #include <libpiksi/logging.h>
+#include <libpiksi/settings.h>
 #include <libsbp/settings.h>
 
 #include <string.h>
@@ -34,16 +35,10 @@ struct setting {
   bool dirty;
 };
 
-enum {
-  SBP_WRITE_STATUS_OK,
-  SBP_WRITE_STATUS_VALUE_REJECTED,
-  SBP_WRITE_STATUS_SETTING_REJECTED,
-};
-
 static struct setting *settings_head;
 
 /* Register a new setting in our linked list */
-void settings_register(struct setting *setting)
+void setting_register(struct setting *setting)
 {
   struct setting *s;
 
@@ -149,7 +144,7 @@ static bool settings_parse_setting(u8 len,
   return true;
 }
 
-static void settings_register_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+static void setting_register_callback(u16 sender_id, u8 len, u8 msg[], void *context)
 {
   (void)sender_id;
 
@@ -168,7 +163,7 @@ static void settings_register_callback(u16 sender_id, u8 len, u8 msg[], void *co
     strncpy(s->value, value, BUFSIZE);
     if (type != NULL) strncpy(s->type, type, BUFSIZE);
 
-    settings_register(s);
+    setting_register(s);
   }
 
   /* Reply with write message with our value */
@@ -369,7 +364,7 @@ void settings_setup(sbp_rx_ctx_t *rx_ctx, sbp_tx_ctx_t *tx_ctx)
                            NULL);
   sbp_rx_callback_register(rx_ctx,
                            SBP_MSG_SETTINGS_REGISTER,
-                           settings_register_callback,
+                           setting_register_callback,
                            tx_ctx,
                            NULL);
 }

--- a/package/sbp_settings_daemon/sbp_settings_daemon/test/run_sbp_settings_daemon_test.cc
+++ b/package/sbp_settings_daemon/sbp_settings_daemon/test/run_sbp_settings_daemon_test.cc
@@ -28,7 +28,7 @@ struct setting {
   bool dirty;
 };
 
-extern "C" void settings_register(struct setting *setting);
+extern "C" void setting_register(struct setting *setting);
 
 // clang-format off
 static setting setting_empty_uart0 = {
@@ -52,7 +52,7 @@ TEST_F(SbpSettingsDaemonTests, empty_ini_field)
   config_ini << config_ini_content;
   config_ini.close();
 
-  settings_register(&setting_empty_uart0);
+  setting_register(&setting_empty_uart0);
 
   ASSERT_TRUE(setting_empty_uart0.dirty);
   ASSERT_STREQ("", setting_empty_uart0.value);

--- a/package/skylark_daemon/src/skylark_settings.c
+++ b/package/skylark_daemon/src/skylark_settings.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 
 #include <libpiksi/logging.h>
+#include <libpiksi/settings.h>
 #include <libpiksi/util.h>
 
 #include "skylark_settings.h"
@@ -176,7 +177,7 @@ static int skylark_notify(void *context)
     }
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 bool skylark_reconnect_dl(void)

--- a/package/skylark_daemon/src/skylark_settings.c
+++ b/package/skylark_daemon/src/skylark_settings.c
@@ -177,7 +177,7 @@ static int skylark_notify(void *context)
     }
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 bool skylark_reconnect_dl(void)

--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -173,12 +173,12 @@ static int logging_filesystem_notify(void *context)
 
   if (logging_fs_type != LOGGING_FILESYSTEM_F2FS) {
     save_prev_logging_fs_type_value();
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
 
   if (!logging_fs_type_prev.is_set || logging_fs_type_prev.value != LOGGING_FILESYSTEM_FAT) {
     save_prev_logging_fs_type_value();
-    return SBP_WRITE_STATUS_OK;
+    return SBP_SETTINGS_WRITE_STATUS_OK;
   }
 
   save_prev_logging_fs_type_value();
@@ -200,7 +200,7 @@ static int logging_filesystem_notify(void *context)
   for (size_t x = 0; x < str_count; ++x)
     piksi_log(LOG_WARNING, warning_strs[x]);
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int copy_system_logs_notify(void *context)
@@ -211,7 +211,7 @@ static int copy_system_logs_notify(void *context)
     system("COPY_SYS_LOGS= sudo /etc/init.d/S98copy_sys_logs stop");
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int setting_usb_logging_notify(void *context)
@@ -235,7 +235,7 @@ static int setting_usb_logging_notify(void *context)
     stop_logging();
   }
 
-  return SBP_WRITE_STATUS_OK;
+  return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
 static int log_frame_callback(const u8 *data, const size_t length, void *context)

--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -173,12 +173,12 @@ static int logging_filesystem_notify(void *context)
 
   if (logging_fs_type != LOGGING_FILESYSTEM_F2FS) {
     save_prev_logging_fs_type_value();
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
 
   if (!logging_fs_type_prev.is_set || logging_fs_type_prev.value != LOGGING_FILESYSTEM_FAT) {
     save_prev_logging_fs_type_value();
-    return 0;
+    return SBP_WRITE_STATUS_OK;
   }
 
   save_prev_logging_fs_type_value();
@@ -200,7 +200,7 @@ static int logging_filesystem_notify(void *context)
   for (size_t x = 0; x < str_count; ++x)
     piksi_log(LOG_WARNING, warning_strs[x]);
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int copy_system_logs_notify(void *context)
@@ -211,7 +211,7 @@ static int copy_system_logs_notify(void *context)
     system("COPY_SYS_LOGS= sudo /etc/init.d/S98copy_sys_logs stop");
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int setting_usb_logging_notify(void *context)
@@ -235,7 +235,7 @@ static int setting_usb_logging_notify(void *context)
     stop_logging();
   }
 
-  return 0;
+  return SBP_WRITE_STATUS_OK;
 }
 
 static int log_frame_callback(const u8 *data, const size_t length, void *context)


### PR DESCRIPTION
This feature lets the Piksi return more detailed error codes to describe why a setting failed to update.
An enum defining the various codes will be moved into libpiksi.h, exposing the values for every package.

The errors defined will be:
  Setting Does Not Exist
  Setting Did Not Parse
  Setting Value Invalid
  Setting is read-only
  Setting is not currently modifiable

One callback in ntrip_daemon has been modified to use these new codes.
Ideally, all settings callbacks everywhere would be updated.

settings_daemon/settings.c: /s/settings_update/setting_update to resolve
a name conflict with libpiksi/setting.h

See also:
https://github.com/swift-nav/piksi_tools/pull/914