### PR TITLE
Grab the firmware implementation of logging over SBP.

### DIFF
--- a/package/libpiksi/libpiksi/src/logging.c
+++ b/package/libpiksi/libpiksi/src/logging.c
@@ -83,7 +83,8 @@ void sbp_log(int priority, const char *msg_text, ...)
   va_end(ap);
 }
 
-void sbp_vlog(int priority, const char *msg, ...) {
+void sbp_vlog(int priority, const char *msg, ...)
+{
   msg_log_t *log;
   va_list ap;
   char buf[SBP_FRAMING_MAX_PAYLOAD_SIZE];
@@ -107,7 +108,7 @@ void sbp_vlog(int priority, const char *msg, ...) {
 
   if (n < 0) return;
 
-  if (0 != sbp_tx_send(sbp_tx, SBP_MSG_LOG, n + sizeof(msg_log_t), (uint8_t*)buf)) {
-    piksi_log(LOG_ERR, "unable to transmit SBP message.");    
+  if (0 != sbp_tx_send(sbp_tx, SBP_MSG_LOG, n + sizeof(msg_log_t), (uint8_t *)buf)) {
+    piksi_log(LOG_ERR, "unable to transmit SBP message.");
   }
 }

--- a/package/libpiksi/libpiksi/src/logging.c
+++ b/package/libpiksi/libpiksi/src/logging.c
@@ -31,7 +31,7 @@ int logging_init(const char *identity)
   openlog(identity, OPTIONS, FACILITY);
 
   sbp_tx = sbp_tx_create(SBP_TX_ENDPOINT);
-  if (NULL == s->sbp_tx) {
+  if (NULL == sbp_tx) {
     piksi_log(LOG_ERR, "unable to initialize SBP tx endpoint.");
     return -1;
   }
@@ -79,14 +79,13 @@ void sbp_log(int priority, const char *msg_text, ...)
 {
   va_list ap;
   va_start(ap, msg_text);
-  sbp_vlog(level, msg_text, ap);
+  sbp_vlog(priority, msg_text, ap);
   va_end(ap);
 }
 
-void sbp_vlog(int priority, const char *msg, ...)
+void sbp_vlog(int priority, const char *msg, va_list ap)
 {
   msg_log_t *log;
-  va_list ap;
   char buf[SBP_FRAMING_MAX_PAYLOAD_SIZE];
 
   if (!sbp_tx) {
@@ -102,9 +101,7 @@ void sbp_vlog(int priority, const char *msg, ...)
   log = (msg_log_t *)buf;
   log->level = (uint8_t)priority;
 
-  va_start(ap, msg);
   int n = vsnprintf(log->text, SBP_FRAMING_MAX_PAYLOAD_SIZE - sizeof(msg_log_t), msg, ap);
-  va_end(ap);
 
   if (n < 0) return;
 

--- a/package/libpiksi/libpiksi/src/sbp_rx.c
+++ b/package/libpiksi/libpiksi/src/sbp_rx.c
@@ -19,12 +19,12 @@ struct sbp_rx_ctx_s {
   pk_endpoint_t *pk_ept;
   sbp_state_t sbp_state;
   const u8 *receive_buffer;
-  u32 receive_buffer_length;
+  s32 receive_buffer_length;
   bool reader_interrupt;
   void *reader_handle;
 };
 
-static u32 receive_buffer_read(u8 *buff, u32 n, void *context)
+static s32 receive_buffer_read(u8 *buff, u32 n, void *context)
 {
   sbp_rx_ctx_t *ctx = (sbp_rx_ctx_t *)context;
   u32 len = SWFT_MIN(n, ctx->receive_buffer_length);

--- a/package/libpiksi/libpiksi/src/sbp_tx.c
+++ b/package/libpiksi/libpiksi/src/sbp_tx.c
@@ -30,10 +30,10 @@ static void send_buffer_reset(sbp_tx_ctx_t *ctx)
   ctx->send_buffer_length = 0;
 }
 
-static u32 send_buffer_write(u8 *buff, u32 n, void *context)
+static s32 send_buffer_write(u8 *buff, u32 n, void *context)
 {
   sbp_tx_ctx_t *ctx = (sbp_tx_ctx_t *)context;
-  u32 len = SWFT_MIN(sizeof(ctx->send_buffer) - ctx->send_buffer_length, n);
+  s32 len = SWFT_MIN(sizeof(ctx->send_buffer) - ctx->send_buffer_length, n);
   memcpy(&ctx->send_buffer[ctx->send_buffer_length], buff, len);
   ctx->send_buffer_length += len;
   return len;

--- a/package/libpiksi/libpiksi/src/util.c
+++ b/package/libpiksi/libpiksi/src/util.c
@@ -149,7 +149,7 @@ bool file_write_string(const char *filename, const char *str)
     return false;
   }
 
-  bool success = (fputs(str, fp) != NULL);
+  bool success = (fputs(str, fp) != EOF);
 
   fclose(fp);
 

--- a/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
+++ b/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
@@ -16,23 +16,6 @@ ports:
           - { action: REJECT }
       - dst_port: SBP_PORT_EXTERNAL
         filters:
-          # Filter navigation messages, they are supplied by Linux Starling.
-          - { action: REJECT, prefix: [0x55, 0x02, 0x01] } # MSG_GPS_TIME
-          - { action: REJECT, prefix: [0x55, 0x03, 0x01] } # MSG_UTC_TIME
-          - { action: REJECT, prefix: [0x55, 0x08, 0x02] } # MSG_DOPS
-          - { action: REJECT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      
-          - { action: REJECT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  
-          - { action: REJECT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       
-          - { action: REJECT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   
-          - { action: REJECT, prefix: [0x55, 0x0B, 0x02] } # MSG_BASELINE_ECEF      
-          - { action: REJECT, prefix: [0x55, 0x0C, 0x02] } # MSG_BASELINE_NED       
-          - { action: REJECT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      
-          - { action: REJECT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  
-          - { action: REJECT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       
-          - { action: REJECT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   
-          - { action: REJECT, prefix: [0x55, 0x13, 0x02] } # MSG_VEL_BODY
-          - { action: REJECT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
-          - { action: REJECT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           
           # These are not for external messaging.
           - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
           - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
@@ -69,6 +52,12 @@ ports:
           - { action: REJECT }
       - dst_port: SBP_PORT_STARLING_DAEMON 
         filters:
+          # Reject anything related to settings or FILEIO.
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
           - {action: ACCEPT}
 
   - name: SBP_PORT_SETTINGS_DAEMON
@@ -76,6 +65,10 @@ ports:
     sub_addr: "ipc:///var/run/sockets/settings_daemon.sub"
     forwarding_rules:
       - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_STARLING_DAEMON
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
           - { action: REJECT }
@@ -242,7 +235,10 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x13, 0x02] } # MSG_VEL_BODY
           - { action: ACCEPT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
           - { action: ACCEPT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           
-          # All settings messages.
+          # All messages for client of SBP settings daemon.
+          - { action: ACCEPT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
           # Reject everything else.
           - { action: REJECT }
 

--- a/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
+++ b/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
@@ -16,6 +16,23 @@ ports:
           - { action: REJECT }
       - dst_port: SBP_PORT_EXTERNAL
         filters:
+          # Filter navigation messages, they are supplied by Linux Starling.
+          - { action: REJECT, prefix: [0x55, 0x02, 0x01] } # MSG_GPS_TIME
+          - { action: REJECT, prefix: [0x55, 0x03, 0x01] } # MSG_UTC_TIME
+          - { action: REJECT, prefix: [0x55, 0x08, 0x02] } # MSG_DOPS
+          - { action: REJECT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      
+          - { action: REJECT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  
+          - { action: REJECT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       
+          - { action: REJECT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   
+          - { action: REJECT, prefix: [0x55, 0x0B, 0x02] } # MSG_BASELINE_ECEF      
+          - { action: REJECT, prefix: [0x55, 0x0C, 0x02] } # MSG_BASELINE_NED       
+          - { action: REJECT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      
+          - { action: REJECT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  
+          - { action: REJECT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       
+          - { action: REJECT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   
+          - { action: REJECT, prefix: [0x55, 0x13, 0x02] } # MSG_VEL_BODY
+          - { action: REJECT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
+          - { action: REJECT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           
           # These are not for external messaging.
           - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
           - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
@@ -52,12 +69,6 @@ ports:
           - { action: REJECT }
       - dst_port: SBP_PORT_STARLING_DAEMON 
         filters:
-          # Reject anything related to settings or FILEIO.
-          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
-          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
-          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
-          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
-          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
           - {action: ACCEPT}
 
   - name: SBP_PORT_SETTINGS_DAEMON
@@ -65,10 +76,6 @@ ports:
     sub_addr: "ipc:///var/run/sockets/settings_daemon.sub"
     forwarding_rules:
       - dst_port: SBP_PORT_FIRMWARE
-        filters:
-          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
-          - { action: REJECT }
-      - dst_port: SBP_PORT_STARLING_DAEMON
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
           - { action: REJECT }
@@ -235,10 +242,7 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x13, 0x02] } # MSG_VEL_BODY
           - { action: ACCEPT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
           - { action: ACCEPT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           
-          # All messages for client of SBP settings daemon.
-          - { action: ACCEPT, prefix: [0x55, 0xAE, 0x00] } # Settings register
-          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
-          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          # All settings messages.
           # Reject everything else.
           - { action: REJECT }
 


### PR DESCRIPTION
This replaces the previous behavior of using `popen` with the `sbp_log` application for every log.