### PR TITLE
EX-408: Only update non-zero sender id

### DIFF
--- a/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
+++ b/package/sbp_nmea_bridge/src/sbp_nmea_bridge.c
@@ -170,7 +170,7 @@ static void msg_obs_callback(u16 sender_id, u8 len, u8 msg[], void *context)
   if (sbp_sender_id_get() == sender_id) {
     uint8_t num_obs = (len - sizeof(observation_header_t)) / sizeof(packed_obs_content_t);
     sbp2nmea_obs((msg_obs_t *)msg, num_obs, &state);
-  } else {
+  } else if (sender_id > 0) {
     sbp2nmea_set_base_id(sender_id, &state);
   }
 }


### PR DESCRIPTION
The sender id in NMEA GGA messages currently switches between 0 and the correct value (see https://swift-nav.atlassian.net/projects/EX/issues/EX-408). 

Fixed by not overwriting sender ID with zero (apparently we get also the forwarded base station observations here).

## Testing

master 20181031 outputs sender ID only occasionally:
```
$GPVTG,,T,,M,0.01,N,0.02,K,D*25
$GPGGA,090056.40,6126.8177524,N,02351.5087202,E,4,22,0.6,184.07,M,0.0,M,2.4,0000*45
$GPVTG,,T,,M,0.00,N,0.01,K,D*27
$GPGGA,090056.60,6126.8177512,N,02351.5087208,E,4,22,0.6,184.07,M,0.0,M,0.6,0000*48
$GPVTG,,T,,M,0.01,N,0.02,K,D*25
$GPGGA,090056.80,6126.8177506,N,02351.5087214,E,4,22,0.6,184.07,M,0.0,M,0.8,0000*40
$GPVTG,,T,,M,0.01,N,0.01,K,D*26
$GPGGA,090057.00,6126.8177512,N,02351.5087220,E,4,22,0.6,184.07,M,0.0,M,1.0,0057*40
$GPVTG,,T,,M,0.01,N,0.03,K,D*24
$GPGGA,090057.20,6126.8177518,N,02351.5087214,E,4,22,0.6,184.07,M,0.0,M,1.2,0000*4F
$GPVTG,,T,,M,0.02,N,0.04,K,D*20
$GPGGA,090057.40,6126.8177512,N,02351.5087208,E,4,22,0.6,184.07,M,0.0,M,1.4,0000*48
$GPVTG,,T,,M,0.01,N,0.03,K,D*24
$GPGGA,090057.60,6126.8177506,N,02351.5087220,E,4,22,0.6,184.07,M,0.0,M,1.6,0000*47
$GPVTG,,T,,M,0.01,N,0.01,K,D*26
$GPGGA,090057.80,6126.8177512,N,02351.5087214,E,4,22,0.6,184.07,M,0.0,M,1.8,0000*45
```
 
With this PR the id is set correctly on every message
```
$GPGGA,090500.00,6126.8177512,N,02351.5087238,E,4,22,0.6,184.06,M,0.0,M,1.0,0057*4F
$GPVTG,,T,,M,0.01,N,0.02,K,D*25
$GPGGA,090500.20,6126.8177518,N,02351.5087226,E,4,22,0.6,184.07,M,0.0,M,1.2,0057*4B
$GPVTG,,T,,M,0.02,N,0.03,K,D*27
$GPGGA,090500.40,6126.8177512,N,02351.5087244,E,4,22,0.6,184.07,M,0.0,M,1.4,0057*45
$GPVTG,,T,,M,0.00,N,0.01,K,D*27
$GPGGA,090500.60,6126.8177512,N,02351.5087238,E,4,22,0.6,184.06,M,0.0,M,1.6,0057*4F
$GPVTG,,T,,M,0.01,N,0.03,K,D*24
$GPGGA,090500.80,6126.8177512,N,02351.5087250,E,4,22,0.6,184.06,M,0.0,M,1.8,0057*41
$GPVTG,,T,,M,0.02,N,0.03,K,D*27
$GPGGA,090501.00,6126.8177518,N,02351.5087238,E,4,22,0.6,184.06,M,0.0,M,2.0,0057*47
$GPVTG,,T,,M,0.02,N,0.03,K,D*27
$GPGGA,090501.20,6126.8177518,N,02351.5087256,E,4,22,0.6,184.06,M,0.0,M,2.2,0057*4F
$GPVTG,,T,,M,0.00,N,0.00,K,D*26
$GPGGA,090501.40,6126.8177518,N,02351.5087250,E,4,22,0.6,184.06,M,0.0,M,2.4,0057*49
$GPVTG,,T,,M,0.02,N,0.04,K,D*20
$GPGGA,090501.60,6126.8177506,N,02351.5087250,E,4,22,0.6,184.06,M,0.0,M,0.6,0057*44
```
Tested also that it updates when changing base station.