### PR TITLE
Handle unix seqpacket sockets, clean-up more output [DEVC-1254]

### DIFF
--- a/package/resource_monitor/resource_monitor/src/query_sockets.c
+++ b/package/resource_monitor/resource_monitor/src/query_sockets.c
@@ -44,7 +44,8 @@ typedef enum {
   ST_UDP       = 0x0002,
   ST_UNIX_STR  = 0x0004,
   ST_UNIX_DGR  = 0x0008,
-  ST_NETLINK   = 0x0010,
+  ST_UNIX_SEQ  = 0x0010,
+  ST_NETLINK   = 0x0020,
   ST_UNKNOWN   = 0x8000,
 } socket_types_t;
 /* clang-format on */
@@ -260,12 +261,15 @@ static void process_ss_entry(resq_state_t *state,
     entry->socket_types |= ST_UNIX_STR;
   } else if (strcmp(socket_type_str, "u_dgr") == 0) {
     entry->socket_types |= ST_UNIX_DGR;
+  } else if (strcmp(socket_type_str, "u_seq") == 0) {
+    entry->socket_types |= ST_UNIX_SEQ;
   } else if (strcmp(socket_type_str, "tcp") == 0) {
     entry->socket_types |= ST_TCP;
   } else if (strcmp(socket_type_str, "udp") == 0) {
     entry->socket_types |= ST_UDP;
   } else {
     entry->socket_types |= ST_UNKNOWN;
+    /* TODO: only report once per socket type */
     PK_LOG_ANNO(LOG_WARNING, "unknown socket type: %s", socket_type_str);
   }
 
@@ -599,7 +603,7 @@ static void run_resource_query(void *context)
       return true;
     }
 
-    if (strstr(line, "u_str") == line || strstr(line, "u_dgr")) {
+    if (strstr(line, "u_str") == line || strstr(line, "u_dgr") == line || strstr(line, "u_seq") == line) {
       if (!parse_uds_socket_line(state, line)) {
         PK_LOG_ANNO(LOG_WARNING, "failed to parse uds 'ss' line: %s", line);
       }

--- a/package/resource_monitor/resource_monitor/src/query_sockets.c
+++ b/package/resource_monitor/resource_monitor/src/query_sockets.c
@@ -603,7 +603,8 @@ static void run_resource_query(void *context)
       return true;
     }
 
-    if (strstr(line, "u_str") == line || strstr(line, "u_dgr") == line || strstr(line, "u_seq") == line) {
+    if (strstr(line, "u_str") == line || strstr(line, "u_dgr") == line
+        || strstr(line, "u_seq") == line) {
       if (!parse_uds_socket_line(state, line)) {
         PK_LOG_ANNO(LOG_WARNING, "failed to parse uds 'ss' line: %s", line);
       }

--- a/package/resource_monitor/resource_monitor/src/query_sys_state.c
+++ b/package/resource_monitor/resource_monitor/src/query_sys_state.c
@@ -28,7 +28,7 @@
 
 #include "query_sys_state.h"
 
-#define EXTRACE_LOG "/var/log/extrace.log"
+#define EXTRACE_LOG "/var/run/resource_monitor/extrace.log"
 
 typedef struct {
 

--- a/package/resource_monitor/resource_monitor/src/resource_query.c
+++ b/package/resource_monitor/resource_monitor/src/resource_query.c
@@ -19,6 +19,7 @@
 
 #include "sbp.h"
 
+//#ifdef DEBUG_RESOURCE_QUERY
 
 typedef struct resq_node {
   bool init_success;
@@ -70,7 +71,9 @@ void resq_run_all(void)
     if (!node->init_success) continue;
     node->query->run_query(node->context);
     while (node->query->prepare_sbp(&msg_type, &msg_len, buf, node->context)) {
-      fprintf(stderr, "%s: sending sbp, type=%d, len=%d\n", __FUNCTION__, msg_type, msg_len);
+#ifdef DEBUG_RESOURCE_QUERY
+      PK_LOG_ANNO(LOG_DEBUG, "%s: sending sbp, type=%d, len=%d\n", __FUNCTION__, msg_type, msg_len);
+#endif
       sbp_tx_send(sbp_get_tx_ctx(), msg_type, msg_len, buf);
     }
   }


### PR DESCRIPTION
+ Unix socket seqpackets follow the same line format as all other unix sockets, so parse accordingly

+ Move the `extrace.log` so that it doesn't get picked up as a system log in `/var/log`-- the output file is cycled every N seconds (according to the interval for the resource monitor) so we shouldn't have issues with it filling up the drive (unless the resource monitor interval is set to be huge).

+ Squelch some misc. debugging output