### PR TITLE
Fix handle leak in health_daemon [DEVC-1260]

### DIFF
--- a/package/health_daemon/src/skylark_monitor.c
+++ b/package/health_daemon/src/skylark_monitor.c
@@ -16,6 +16,7 @@
 #include <libnetwork.h>
 
 #include <libpiksi/logging.h>
+#include <libpiksi/util.h>
 
 #include <libsbp/sbp.h>
 #include <libsbp/navigation.h>
@@ -37,24 +38,6 @@
 
 static health_monitor_t *skylark_monitor;
 static bool no_fix = true;
-
-static bool skylark_enabled()
-{
-
-  FILE *fp = fopen(SKYLARK_ENABLED_FILE_PATH, "r");
-  if (fp == NULL) {
-    piksi_log(LOG_ERR, "error opening %s", SKYLARK_ENABLED_FILE_PATH);
-    return false;
-  }
-
-  char buf[1] = {0};
-
-  (void)fread(buf, sizeof(buf), 1, fp);
-
-  if (buf[0] != '1') return false;
-
-  return true;
-}
 
 static int sbp_msg_pos_llh_callback(health_monitor_t *monitor,
                                     u16 sender_id,
@@ -86,7 +69,7 @@ static int skylark_timer_callback(health_monitor_t *monitor, void *context)
     return 0;
   }
 
-  if (!skylark_enabled()) {
+  if (!file_read_value(SKYLARK_ENABLED_FILE_PATH)) {
     DEBUG_LOG("%s: skylark is not enabled", __FUNCTION__);
     return 0;
   }

--- a/package/libpiksi/libpiksi/src/util.c
+++ b/package/libpiksi/libpiksi/src/util.c
@@ -132,8 +132,8 @@ int file_read_string(const char *filename, char *str, size_t str_size)
 
 bool file_read_value(char *file_path)
 {
-  /* Accommodate also the terminating null char fgets always adds */
-  char val_char[2];
+  /* Accommodate the terminating null char fgets always adds and a newline */
+  char val_char[3];
   if (file_read_string(file_path, val_char, sizeof(val_char)) != 0) {
     return false;
   }


### PR DESCRIPTION
Seeing the following from health daemon:
```
Nov 2 04:09:11 piksi local0.err health_daemon[2198]: error opening /var/run/skylark/enabled
Nov 2 04:09:21 piksi local0.err health_daemon[2198]: error opening /var/run/skylark/enabled
Nov 2 04:09:31 piksi local0.err health_daemon[2198]: error opening /var/run/skylark/enabled
Nov 2 04:09:41 piksi local0.err health_daemon[2198]: error opening /var/run/skylark/enabled
Nov 2 04:09:51 piksi local0.err health_daemon[2198]: error opening /var/run/skylark/enabled

root@piksi:~ # lsof|grep health_daemon|grep skylark/enabled|wc -l
1010
```