### PR TITLE
EX-415: MSM 5s timeout

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.69
+GNSS_CONVERTORS_VERSION = 028914634d133d821a7a33e4cf2d3c687bfbfbf9
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = 028914634d133d821a7a33e4cf2d3c687bfbfbf9
+GNSS_CONVERTORS_VERSION = v0.3.70
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES


### PR DESCRIPTION
Pull in https://github.com/swift-nav/gnss-converters/pull/154/ (lower MSM timeout from 60 s to 5 s, so when switching to legacy stream the observations come back faster).
