### PR TITLE
Add new sbp_router_smoothpose_debug.yml to replace LC+GNSS configuration with a new DEBUG configuration

### DIFF
--- a/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
+++ b/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
@@ -10,8 +10,11 @@ setup_permissions()
   add_service_user $user
 }
 
-if grep -q "output_mode=Loosely Coupled" /persistent/config.ini; then
+port_mode="$(query_config --section ins --key output_mode)"
+if [[ "$port_mode" == "Loosely Coupled" ]]; then
   router_config="/etc/endpoint_router/sbp_router_smoothpose.yml"
+elif [[ "$port_mode" == "Debug" ]]; then
+  router_config="/etc/endpoint_router/sbp_router_smoothpose_debug.yml"
 else
   router_config="/etc/endpoint_router/sbp_router.yml"
 fi

--- a/package/sbp_protocol/src/sbp_router_smoothpose_debug.yml
+++ b/package/sbp_protocol/src/sbp_router_smoothpose_debug.yml
@@ -1,0 +1,230 @@
+# This file is a variant the stock sbp_router.yml With it, the router sends the
+# "best position" and "best velocity" estimates through a new nav_daemon port
+# before going to the external interfaces.  It can be used to allow a process
+# like a loosely coupled INS filter to intercept and transform the best GNSS
+# position and velocity estimates they go on the wire The key changes to the
+# stock config are highlihged with the string **Smoothpose Change**
+
+name: SBP_ROUTER
+ports:
+  - name: SBP_PORT_FIRMWARE
+    pub_addr: "ipc:///var/run/sockets/firmware.pub"
+    sub_addr: "ipc:///var/run/sockets/firmware.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_SETTINGS_DAEMON
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   **Smoothpose DEBUG Change**
+          - { action: ACCEPT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   **Smoothpose DEBUG Change**
+          - { action: ACCEPT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  **Smoothpose DEBUG Change**
+          - { action: ACCEPT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  **Smoothpose DEBUG Change**
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_FILEIO_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: ACCEPT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: ACCEPT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: ACCEPT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_INTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SKYLARK
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # Publish: SBP MSG_POS_LLH
+          - { action: ACCEPT, prefix: [0x55, 0xFF, 0xFF] } # Publish: SBP MSG_HEARTBEAT
+          - { action: REJECT }
+      - dst_port: SBP_PORT_NAV_DAEMON # This list sends only what Smoothpose needs at present.
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x00, 0x09] } # MSG_IMU_RAW  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x09] } # MSG_IMU_AUX  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0x09] } # MSG_ODOMETRY **Smoothpose Change**
+          - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: ACCEPT, prefix: [0x55, 0x02, 0x01] } # MSG_GPS_TIME
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0x01] } # MSG_UTC_TIME
+          - { action: ACCEPT, prefix: [0x55, 0x08, 0x02] } # MSG_DOPS
+          - { action: ACCEPT, prefix: [0x55, 0x0F, 0x02] } # MSG_BASELINE_HEADING
+          - { action: ACCEPT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
+          - { action: REJECT }
+
+  - name: SBP_PORT_SETTINGS_DAEMON
+    pub_addr: "ipc:///var/run/sockets/settings_daemon.pub"
+    sub_addr: "ipc:///var/run/sockets/settings_daemon.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: REJECT }
+
+  - name: SBP_PORT_EXTERNAL
+    pub_addr: "ipc:///var/run/sockets/external.pub"
+    sub_addr: "ipc:///var/run/sockets/external.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_DAEMON
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT, prefix: [0x55, 0xAE, 0x00] } # Settings register
+          - { action: REJECT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_FILEIO_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: ACCEPT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: ACCEPT, prefix: [0x55, 0xAC, 0x00] } # File reamove
+          - { action: ACCEPT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_INTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
+          - { action: REJECT, prefix: [0x55, 0xA9, 0x00] } # File read dir
+          - { action: REJECT, prefix: [0x55, 0xAC, 0x00] } # File remove
+          - { action: REJECT, prefix: [0x55, 0xAD, 0x00] } # File write
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
+          - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: REJECT }
+
+  - name: SBP_PORT_FILEIO_FIRMWARE
+    pub_addr: "ipc:///var/run/sockets/fileio_firmware.pub"
+    sub_addr: "ipc:///var/run/sockets/fileio_firmware.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_FILEIO_EXTERNAL
+    pub_addr: "ipc:///var/run/sockets/fileio_external.pub"
+    sub_addr: "ipc:///var/run/sockets/fileio_external.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_INTERNAL
+    pub_addr: "ipc:///var/run/sockets/internal.pub"
+    sub_addr: "ipc:///var/run/sockets/internal.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_SETTINGS_CLIENT
+    pub_addr: "ipc:///var/run/sockets/settings_client.pub"
+    sub_addr: "ipc:///var/run/sockets/settings_client.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_SETTINGS_DAEMON
+        filters:
+          - { action: ACCEPT }
+      # As long as no receivers echo this message back, then this is not a loop!  This is were
+      #  we actually need a 'bus' style socket.
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
+          - { action: REJECT }
+
+  - name: SBP_PORT_SKYLARK
+    pub_addr: "ipc:///var/run/sockets/skylark.pub"
+    sub_addr: "ipc:///var/run/sockets/skylark.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x44, 0x00] } # SBP_MSG_BASE_POS_LLH
+          - { action: ACCEPT, prefix: [0x55, 0x48, 0x00] } # SBP_MSG_BASE_POS_ECEF
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: ACCEPT, prefix: [0x55, 0x86, 0x00] } # SBP_MSG_EPHEMERIS_GPS
+          - { action: ACCEPT, prefix: [0x55, 0x88, 0x00] } # SBP_MSG_EPHEMERIS_GLO
+          - { action: ACCEPT, prefix: [0x55, 0x84, 0x00] } # SBP_MSG_EPHEMERIS_SBAS
+          - { action: ACCEPT, prefix: [0x55, 0x75, 0x00] } # SBP_MSG_GLO_BIASES
+          - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: REJECT }
+
+  - name: SBP_PORT_NAV_DAEMON  # Entire Section Smoothpose Change**
+    pub_addr: "ipc:///var/run/sockets/nav_daemon.pub"
+    sub_addr: "ipc:///var/run/sockets/nav_daemon.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x09, 0x02] } # MSG_POS_ECEF      **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH       **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0D, 0x02] } # MSG_VEL_ECEF      **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED       **Smoothpose Change**
+          - { action: REJECT, prefix: [0x55, 0x11, 0x02] } # MSG_POS_LLH_COV   **Smoothpose DEBUG Change**
+          - { action: REJECT, prefix: [0x55, 0x12, 0x02] } # MSG_VEL_NED_COV   **Smoothpose DEBUG Change**
+          - { action: REJECT, prefix: [0x55, 0x14, 0x02] } # MSG_POS_ECEF_COV  **Smoothpose DEBUG Change**
+          - { action: REJECT, prefix: [0x55, 0x15, 0x02] } # MSG_VEL_ECEF_COV  **Smoothpose DEBUG Change**
+          - { action: ACCEPT, prefix: [0x55, 0x13, 0x02] } # MSG_VEL_BODY      **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x20, 0x02] } # MSG_ORIENT_QUAT   **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x21, 0x02] } # MSG_ORIENT_EULER  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x22, 0x02] } # MSG_ANGULAR_RATE  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0xFF] } # MSG_INS_STATUS    **Smoothpose Change**
+          - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH
+          - { action: ACCEPT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED
+          - { action: REJECT }
+
+  - name: SBP_PORT_NMEA_BRIDGE
+    pub_addr: "ipc:///var/run/sockets/nmea_bridge.pub"
+    sub_addr: "ipc:///var/run/sockets/nmea_bridge.sub"


### PR DESCRIPTION
This PR is designed to provide a customer friendly way to achieve a GNSS and INS debugging mode on the device.  It expects that we replace with "LC +GNSS" mode with a new "DEBUG" mode.  If this mode is enabled, the following 4 messages come from GNSS-only:

- MSG_POS_LLH_COV 
- MSG_VEL_NED_COV 
- MSG_POS_ECEF_COV
- MSG_VEL_ECEF_COV

The rest of the navigation output comes from normal Smoothpose Daemon.

In this way, customers can enable a debug mode when working with our support team that is unlikely to affect our downstream software (console, SBP2REPORT), their downstream software (unknown), or the NMEA output.  Long term, we can plan to have new GNSS only navigation outputs and a receiver concept of "Best Pos", but this is a low-risk way to address this issue without having to spend a few days adding SBP messages or changing our GNSS firmware: https://github.com/swift-nav/pose_daemon/issues/19

It will require that the INS playback software in use at CRL and any analysis tools we have to compare GNSS only to INS output be updated.  

I offer this only as a proposal and welcome comments or feedback.

/cc @s-landers @jkretzmer @nicolekelley @switanis 