### PR TITLE
Revert removal of upgrade_data folder [DEVC-1263]

### DIFF
--- a/board/piksiv3/device_table.txt
+++ b/board/piksiv3/device_table.txt
@@ -11,6 +11,7 @@
 /etc					d	755	0	0	-	-	-	-	-
 /persistent				d	755	0	0	-	-	-	-	-
 /data					d	755	0	0	-	-	-	-	-
+/upgrade_data				d	755	0	0	-	-	-	-	-
 /root					d	700	0	0	-	-	-	-	-
 /var/www				d	755	33	33	-	-	-	-	-
 /etc/shadow				f	600	0	0	-	-	-	-	-

--- a/package/common_init/overlay/etc/fstab
+++ b/package/common_init/overlay/etc/fstab
@@ -5,7 +5,7 @@ devpts		/dev/pts	devpts	defaults,gid=5,mode=620	0	0
 tmpfs		/dev/shm	tmpfs	mode=0777	0	0
 tmpfs		/tmp		tmpfs	mode=1777	0	0
 tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
-tmpfs		/data		tmpfs	mode=0755,nodev,size=30M	0	0
-tmpfs		/upgrade_data	tmpfs	mode=0755,nodev,size=30M	0	0
+tmpfs		/data		tmpfs	mode=0755,nodev,size=32M	0	0
+tmpfs		/upgrade_data	tmpfs	mode=0755,nodev,size=32M	0	0
 sysfs		/sys		sysfs	defaults	0	0
 configfs	/sys/kernel/config	configfs	defaults	0	0

--- a/package/common_init/overlay/etc/fstab
+++ b/package/common_init/overlay/etc/fstab
@@ -5,6 +5,7 @@ devpts		/dev/pts	devpts	defaults,gid=5,mode=620	0	0
 tmpfs		/dev/shm	tmpfs	mode=0777	0	0
 tmpfs		/tmp		tmpfs	mode=1777	0	0
 tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
-tmpfs		/data		tmpfs	mode=0755,nodev,size=75M	0	0
+tmpfs		/data		tmpfs	mode=0755,nodev,size=30M	0	0
+tmpfs		/upgrade_data	tmpfs	mode=0755,nodev,size=30M	0	0
 sysfs		/sys		sysfs	defaults	0	0
 configfs	/sys/kernel/config	configfs	defaults	0	0


### PR DESCRIPTION
As of #941 upgrade tool isn’t able to unpack encrypted downloads.

Reverting removal of `/upgrade_data` and upping the tmpfs sizes to accommodate downloads of >15Mb