### PR TITLE
Update upgrade_tool to v2.2.6

### DIFF
--- a/package/upgrade_tool/upgrade_tool.mk
+++ b/package/upgrade_tool/upgrade_tool.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UPGRADE_TOOL_VERSION = v2.2.4
+UPGRADE_TOOL_VERSION = v2.2.6
 UPGRADE_TOOL_PREFIX = piksi_upgrade_tool
 UPGRADE_TOOL_ASSET = piksi_upgrade_tool.tgz
 UPGRADE_TOOL_S3 = $(call pbr_s3_url,$(UPGRADE_TOOL_PREFIX),$(UPGRADE_TOOL_VERSION),$(UPGRADE_TOOL_ASSET))


### PR DESCRIPTION
Bringing in the following changes: https://github.com/swift-nav/piksi_upgrade_tool/compare/v2.2.4...v2.2.6