### PR TITLE
Jenkins build pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "buildroot"]
 	path = buildroot
-	url = git://git.buildroot.net/buildroot
+	url = https://github.com/buildroot/buildroot.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // Use 'ci-jenkins@somebranch' to pull shared lib from a different branch than the default.
 // Default is configured in Jenkins and should be from "stable" tag.
 // TODO: Remove the branch name here once lib support is merged and tagged
-@Library("ci-jenkins@master") import com.swiftnav.ci.*
+@Library("ci-jenkins@klaus/post-build") import com.swiftnav.ci.*
 
 String dockerFile = "scripts/Dockerfile.jenkins"
 String dockerMountArgs = "-v /mnt/efs/refrepo:/mnt/efs/refrepo -v /mnt/efs/buildroot:/mnt/efs/buildroot"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -294,7 +294,10 @@ pipeline {
         always {
             // Common post-run function from ci-jenkins shared libs.
             // Used to e.g. notify slack.
-            commonPostPipeline()
+            script {
+                context.slackNotify()
+                context.postCommon()
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // Use 'ci-jenkins@somebranch' to pull shared lib from a different branch than the default.
 // Default is configured in Jenkins and should be from "stable" tag.
 // TODO: Remove the branch name here once lib support is merged and tagged
-@Library("ci-jenkins@klaus/pbr-support") import com.swiftnav.ci.*
+@Library("ci-jenkins@master") import com.swiftnav.ci.*
 
 String dockerFile = "scripts/Dockerfile.jenkins"
 String dockerMountArgs = "-v /mnt/efs/refrepo:/mnt/efs/refrepo -v /mnt/efs/buildroot:/mnt/efs/buildroot"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,418 @@
+#!groovy
+
+// Use 'ci-jenkins@somebranch' to pull shared lib from a different branch than the default.
+// Default is configured in Jenkins and should be from "stable" tag.
+// TODO: Remove the branch name here once lib support is merged and tagged
+@Library("ci-jenkins@klaus/pbr-support") import com.swiftnav.ci.*
+
+String dockerFile = "scripts/Dockerfile.jenkins"
+String dockerMountArgs = "-v /mnt/efs/refrepo:/mnt/efs/refrepo -v /mnt/efs/buildroot:/mnt/efs/buildroot"
+
+String dockerSecArgs = "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+def context = new Context(context: this)
+def builder = context.getBuilder()
+
+pipeline {
+    // Override agent in each stage to make sure we don't share containers among stages.
+    agent any
+    options {
+        // Make sure job aborts eventually if hanging.
+        timeout(time: 8, unit: 'HOURS')
+        timestamps()
+        // Keep builds for 7 days.
+        buildDiscarder(logRotator(daysToKeepStr: '7'))
+    }
+
+    parameters {
+        string(name: "REF", defaultValue: "master", description: "git ref for piksi_buildroot repo")
+        choice(name: "LOG_LEVEL", choices: ['INFO', 'DEBUG', 'WARNING', 'ERROR'])
+        booleanParam(name: "UPLOAD_TO_S3", defaultValue: true, description: "Enable if artifacts should be uploaded to S3")
+    }
+
+    environment {
+        PIKSI_NON_INTERACTIVE_BUILD="y"
+        // Cache package downloads here
+        BR2_DL_DIR="/mnt/efs/buildroot/downloads"
+        // Needed to add multiple private keys
+        SSH_AUTH_SOCK="/tmp/ssh_auth_sock"
+    }
+
+    stages {
+        stage('Build') {
+            parallel {
+                // This is a stage that can be used to quickly try some changes.
+                // It won't run if STAGE_INCLUDE is empty. To run it, set the STAGE_INCLUDE parameter
+                // to "s3-test".
+                stage('s3-test') {
+                    when {
+                        // Run only when specifically included via the STAGE_INCLUDE parameter.
+                        expression {
+                            context.isStageIncluded(name: 'S3-test', includeOnEmpty: false)
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs
+                        }
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        // create a dummy file that we can save later
+                        sh("date > dummy_file.txt")
+                    }
+                    post {
+                        success {
+                            archivePatterns(
+                                    context: context,
+                                    patterns:
+                                            ['dummy_file.txt'],
+                                    addPath: 'v3/dummy',
+                                    allowEmpty: false)
+                        }
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+
+                stage('Release') {
+                    when {
+                        expression {
+                            context.isStageIncluded(name: 'Release')
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs
+                        }
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        script {
+                            builder.make(target: "firmware")
+                            builder.make(target: "image-release-open")
+                            builder.make(target: "image-release-ins")
+                        }
+                    }
+                    post {
+                        success {
+                            archivePatterns(
+                                context: context,
+                                patterns:
+                                    ['buildroot/output/images/piksiv3_prod/PiksiMulti-v*.bin',
+                                     'buildroot/output/images/piksiv3_prod/PiksiMulti-UNPROTECTED-v*.bin'],
+                                addPath: 'v3/prod',
+                                allowEmpty: true)
+                        }
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+
+                stage('Internal') {
+                    when {
+                        expression {
+                            context.isStageIncluded()
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs
+                        }
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        script {
+                            builder.make(target: "firmware")
+                            builder.make(target: "image")
+                        }
+                    }
+                    post {
+                        success {
+                            archivePatterns(
+                                context: context,
+                                patterns: ['buildroot/output/images/piksiv3_prod/'],
+                                addPath: 'v3/prod',
+                                allowEmpty: true)
+                        }
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+
+                stage('Host') {
+                    when {
+                        expression {
+                            context.isStageIncluded()
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs + " " + dockerSecArgs
+                        }
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        script {
+                            builder.make(target: "host-image")
+                        }
+                    }
+                    post {
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+
+                stage('Nano') {
+                    when {
+                        expression {
+                            context.isStageIncluded()
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs
+                        }
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        script {
+                            builder.make(target: "nano-config")
+                            builder.make(target: "nano-image")
+                        }
+                    }
+                    post {
+                        success {
+                            archivePatterns(
+                                context: context,
+                                patterns: ['buildroot/nano_output/images/sdcard.img'],
+                                addPath: "nano")
+                        }
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+
+                stage('SDK') {
+                    when {
+                        expression {
+                            context.isStageIncluded()
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs
+                        }
+                    }
+                    environment {
+                        BR2_BUILD_SAMPLE_DAEMON = "y"
+                        BR2_BUILD_PIKSI_INS_REF = "y"
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        script {
+                            builder.make(target: "nano-image")
+                        }
+                    }
+                    post {
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+
+                stage('Format Check') {
+                    when {
+                        expression {
+                            context.isStageIncluded()
+                        }
+                    }
+                    agent {
+                        dockerfile {
+                            filename dockerFile
+                            args dockerMountArgs
+                        }
+                    }
+                    steps {
+                        stageStart()
+                        gitPrep()
+                        crlKeyAdd()
+
+                        // Ensure that the docker tag in docker_version_tag is same as in Dockerfile.jenkins
+                        script {
+                            String dockerVersionTag = readFile(file: 'scripts/docker_version_tag').trim()
+                            sh("""grep "FROM .*:${dockerVersionTag}" scripts/Dockerfile.jenkins""")
+                            builder.make(target: "clang-format")
+                            sh('''
+                                | git --no-pager diff --name-only HEAD > /tmp/clang-format-diff
+                                | if [ -s "/tmp/clang-format-diff" ]; then
+                                |     echo "clang-format warning found"
+                                |     git --no-pager diff
+                                |     exit 1
+                                | fi
+                              '''.stripMargin())
+                        }
+                    }
+                    post {
+                        always {
+                            cleanUp()
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            // Common post-run function from ci-jenkins shared libs.
+            // Used to e.g. notify slack.
+            commonPostPipeline()
+        }
+    }
+}
+
+/**
+ * Add the private key for accessing CRL repo.
+ * Consider moving this off to the shared libs.
+ * @return
+ */
+def crlKeyAdd() {
+    withCredentials([string(credentialsId: 'github-crl-ssh-key-string', variable: 'GITHUB_CRL_KEY')]) {
+        sh("""/bin/bash -e
+            set +x
+            echo "${GITHUB_CRL_KEY}" > /tmp/github-crl-ssh-key
+            set -x
+            ssh-agent -a \${SSH_AUTH_SOCK}
+            chmod 0600 /tmp/github-crl-ssh-key
+            ssh-add /tmp/github-crl-ssh-key
+            ssh-add /home/jenkins/.ssh/id_rsa
+            ssh-add -l
+           """)
+    }
+}
+
+/**
+ * Archive the specified files both to jenkins and to S3.
+ * Consider moving this off to the shared libs.
+ * @param args
+ *   args.patterns: List of file patterns
+ * @return
+ */
+def archivePatterns(Map args) {
+    archiveArtifacts(artifacts: args.patterns.join(','))
+
+    if (shouldUploadToS3(args)) {
+        args.patterns.each() {
+            uploadArtifactsToS3(args + [includePattern: it])
+        }
+    }
+}
+
+/**
+ * Upload to S3 if the UPLOAD_TO_S3 parameter is enabled;
+ * this may be extended with more criteria later.
+ * @return
+ */
+boolean shouldUploadToS3(Map args=[:]) {
+    if (env.UPLOAD_TO_S3 && env.UPLOAD_TO_S3 == "true") {
+        return true
+    } else {
+        return false
+    }
+}
+
+/**
+ * Upload artifacts to S3. Determin ethe bucket and path bvased on whether this
+ * is a PR, a branch, or a tag push.
+ * @param args
+ *   args.context
+ *   args.path
+ *   args.bucket
+ *   args.addPath
+ * @return
+ */
+def uploadArtifactsToS3(Map args) {
+    // Initially, use a bucket separate from travis so we can run both in parallel without conflict.
+    String bucket
+    String path
+    if (args.context.isPrPush()) {
+        bucket = "swiftnav-artifacts-pull-requests-jenkins"
+        path = "piksi_buildroot/" + args.context.gitDescribe() + "/"
+    } else {
+        if (args.context.isBranchPush(branches: ['master', '*-release'])) {
+            bucket = "swiftnav-artifacts-jenkins"
+            path = "piksi_buildroot/" + args.context.gitDescribe() + "/"
+        } else {
+            // TODO: Handle the tag pushes
+            bucket = "swiftnav-artifacts-jenkins"
+            path = "piksi_buildroot_notype/" + args.context.gitDescribe() + "/"
+        }
+    }
+
+    // You can override the bucket/path via arg
+    if (args.bucket) {
+        bucket = args.bucket
+    }
+    if (args.path) {
+        path = args.path
+    }
+
+    // Append to the path if specified
+    if (args.addPath) {
+        path += args.addPath + "/"
+    }
+
+    String pattern = args.includePattern ?: "**"
+
+    // s3Upload is provided by the Jenkins S3 plugin
+    s3Upload(
+        includePathPattern: pattern,
+        bucket: bucket,
+        path: path,
+        acl: 'BucketOwnerFullControl')
+}
+
+/**
+ * Clean up some file generated with wrong permissions during the build.
+ * This is needed so that a workspace clean is able to remove all files.
+ * @return
+ */
+def cleanUp() {
+    // The persistent files get created with root permissions during the build, so
+    // the regular 'workspace wipe' is not able to delete them.
+    // Remove them explicitly at the end of a build stage.
+    cleanWs(
+        externalDelete: 'sudo rm -rf %s',
+        notFailBuild: true,
+        patterns: [[pattern: 'buildroot/host_output/target/fake_persist', type: 'INCLUDE'],
+                   [pattern: 'buildroot/host_output/target/persistent', type: 'INCLUDE'],
+        ])
+}

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,9 @@ docker-cp:
 	docker cp $(DOCKER_TAG)-copy:$(SRC) $(DST) || :
 	docker stop $(DOCKER_TAG)-copy
 
+docker-jenkins:
+	docker-compose --file scripts/docker-compose.yml --project-directory ${PWD} run pbr
+
 help:
 	@[[ -x $(shell which less) ]] && \
 		less $(CURDIR)/scripts/make_help.txt || \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+
+services:
+  pbr:
+    build:
+      dockerfile: scripts/Dockerfile.jenkins
+      context: .
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp=unconfined
+    volumes:
+      - ${PWD}:/mnt/workspace:delegated
+      - ${HOME}/.ssh/id_rsa:/home/jenkins/.ssh/id_rsa
+      - ${HOME}/.ccache:/home/jenkins/.ccache:delegated
+      - ${HOME}/.aws:/home/jenkins/.aws

--- a/package/sbp_fileio_daemon/sbp_fileio_daemon.mk
+++ b/package/sbp_fileio_daemon/sbp_fileio_daemon.mk
@@ -43,6 +43,7 @@ define SBP_FILEIO_DAEMON_INSTALL_TARGET_CMDS_TESTS
 	$(INSTALL) -D -m 0755 $(@D)/test/run_sbp_fileio_daemon_tests $(TARGET_DIR)/usr/bin
 	sudo mkdir -p $(TARGET_DIR)/fake_data
 	sudo mkdir -p $(TARGET_DIR)/fake_persist/blah
+	sudo chmod -R 0777 $(TARGET_DIR)/fake_data $(TARGET_DIR)/fake_persist
 	sudo chroot $(TARGET_DIR) run_sbp_fileio_daemon_tests
 endef
 endif

--- a/scripts/Dockerfile.jenkins
+++ b/scripts/Dockerfile.jenkins
@@ -1,0 +1,26 @@
+# Jenkins's docker plugin has problems when using a variable in the 'FROM' string,
+# so we'll have to hard code it here. Make sure to also update docker_version_tag when updating
+# the tag here.
+
+FROM swiftnav/buildroot-base:2018.10.26
+
+# Add a "jenkins" user with sudo capabilities
+RUN useradd -u 1001 -ms /bin/bash -G sudo jenkins
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Use newer ccache to fix issue with parallel cleanup
+RUN cd /tmp && \
+    wget https://www.samba.org/ftp/ccache/ccache-3.4.2.tar.gz && \
+    tar fxvz ccache-3.4.2.tar.gz && \
+    cd ccache-3.4.2 && \
+    ./configure && \
+    make install
+#ENV PATH=/usr/lib/ccache:${PATH}
+
+# Enable 'jenkins' user to clone from github
+USER jenkins
+SHELL ["/bin/bash", "-c"]
+RUN mkdir -p $HOME/.ssh && chmod go-rwx $HOME/.ssh
+RUN ssh-keyscan github.com >> $HOME/.ssh/known_hosts
+
+WORKDIR /mnt/workspace

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -12,5 +12,3 @@ services:
     volumes:
       - ${PWD}:/mnt/workspace:delegated
       - ${HOME}/.ssh/id_rsa:/home/jenkins/.ssh/id_rsa
-      - ${HOME}/.ccache:/home/jenkins/.ccache:delegated
-      - ${HOME}/.aws:/home/jenkins/.aws

--- a/scripts/env-setup.mk
+++ b/scripts/env-setup.mk
@@ -1,6 +1,9 @@
 # File: env-setup.mk
 
-CCACHE_DIR := $(CURDIR)/buildroot/output/ccache
+# Allow override of ccache dir from env var
+ifeq ($(CCACHE_DIR),)
+CCACHE_DIR := $(CURDIR)/.buildroot-ccache
+endif
 
 ifneq ($(CCACHE_READONLY),)
 CCACHE_RO_VAR := CCACHE_READONLY=$(CCACHE_READONLY)

--- a/scripts/env-setup.mk
+++ b/scripts/env-setup.mk
@@ -2,7 +2,7 @@
 
 # Allow override of ccache dir from env var
 ifeq ($(CCACHE_DIR),)
-CCACHE_DIR := $(CURDIR)/.buildroot-ccache
+CCACHE_DIR := $(CURDIR)/buildroot/output/ccache
 endif
 
 ifneq ($(CCACHE_READONLY),)


### PR DESCRIPTION
This runs a build pipeline for piksi_buildroot.
Limitations:
- Only runs on PRs and branch pushes (not for tags)
- Pushes artifacts to a separate S3 bucket as not to conflict with the Travis-run builds
- No notifications sent (other than posting status to the PRs as can be seen in this PR)
- Doesn't use any kind of persistent ccache yet

The limitations will be addressed in a separate PR - but this one should allow us to evaluate if it works ok in parallel to travis builds.