### PR TITLE
EX-445: Send receiver&antenna descriptors via RTCM out

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.70
+GNSS_CONVERTORS_VERSION = v0.3.71
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.34
+LIBRTCM_VERSION = v0.2.35
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -234,6 +234,13 @@ static int notify_ant_height_changed(void *context)
   return SBP_SETTINGS_WRITE_STATUS_OK;
 }
 
+static int notify_rcv_ant_descriptor_changed(void *context)
+{
+  (void)context;
+  sbp2rtcm_set_rcv_ant_descriptors(ant_descriptor, rcv_descriptor, &sbp_to_rtcm3_state);
+  return SBP_SETTINGS_WRITE_STATUS_OK;
+}
+
 static int cleanup(pk_endpoint_t **rtcm_ept_loc, int status);
 
 int main(int argc, char *argv[])
@@ -356,6 +363,24 @@ int main(int argc, char *argv[])
                     sizeof(ant_height),
                     SETTINGS_TYPE_FLOAT,
                     notify_ant_height_changed,
+                    NULL);
+
+  settings_register(settings_ctx,
+                    "rtcm_out",
+                    "ant_descriptor",
+                    &ant_descriptor,
+                    sizeof(ant_descriptor),
+                    SETTINGS_TYPE_STRING,
+                    notify_rcv_ant_descriptor_changed,
+                    NULL);
+
+  settings_register(settings_ctx,
+                    "rtcm_out",
+                    "rcv_descriptor",
+                    &rcv_descriptor,
+                    sizeof(rcv_descriptor),
+                    SETTINGS_TYPE_STRING,
+                    notify_rcv_ant_descriptor_changed,
                     NULL);
 
   sbp_run();

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -262,9 +262,6 @@ int main(int argc, char *argv[])
   rtcm2sbp_init(&rtcm3_to_sbp_state, sbp_message_send, sbp_base_obs_invalid, NULL);
   sbp2rtcm_init(&sbp_to_rtcm3_state, rtcm3_out_callback, NULL);
 
-  /* Init the default values for receiver and antenna descriptors */
-  sbp2rtcm_set_rcv_ant_descriptors(ant_descriptor, rcv_descriptor, &sbp_to_rtcm3_state);
-
   if (sbp_init() != 0) {
     piksi_log(LOG_ERR, "error initializing SBP");
     exit(cleanup(&rtcm3_sub, EXIT_FAILURE));

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -49,7 +49,7 @@ static u8 rtcm_out_mode = (u8)RTCM_OUT_MODE_MSM5;
 static float ant_height = 0.0;
 
 /* Antenna descriptor */
-static char ant_descriptor[RTCM_MAX_STRING_LEN] = "HXCGPS500       DOME";
+static char ant_descriptor[RTCM_MAX_STRING_LEN] = "HXCGPS500       NONE";
 
 /* TODO: fill in the actual IGS code when assigned */
 static char rcv_descriptor[RTCM_MAX_STRING_LEN] = "PIKSI";


### PR DESCRIPTION
Issue https://swift-nav.atlassian.net/browse/EX-445

Pull in https://github.com/swift-nav/gnss-converters/pull/159 that implements sending of 1006, 1008, and 1033.

Add settings `rtcm_out.antenna_height`, `rtcm_out.ant_descriptor` and `rtcm_out.rcv_descriptor`, and fill the descriptors with default values.

## Testing

### RTCM output on bench
- antenna height is output in 1006 and respond to changing the value from console
- antenna type is output as `HXCGPS500       NONE` in 1008 & 1033 and responds to changes
- receiver type output as `PIKSI` in 1033 and responds to changes
- station_id is the same in all messages

```
$ nc 192.168.1.13 55556 | gpsdecode | grep "type\":1006"
{"class":"RTCM3","device":"stdin","type":1006,"length":21,"station_id":669,"system":["GPS","GLONASS","GALILEO"],"refstation":false,"sro":true,"x":2795371.3120,"y":1236315.2730,"z":557948.7 010,"h":1.5000}

$ nc 192.168.1.13 55556 | gpsdecode | grep "type\":1008"
{"class":"RTCM3","device":"stdin","type":1008,"length":26,"station_id":669,"desc":"HXCGPS500       DOME","setup-id":0,"serial":""}

$ nc 192.168.1.13 55556 | gpsdecode | grep "type\":1033"
{"class":"RTCM3","device":"stdin","type":1033,"length":34,"station_id":669,"desc":"HXCGPS500       DOME","setup-id":0,"serial":"","receiver":PIKSI,"firmware":""}                             

$ nc 192.168.1.13 55556 | gpsdecode | grep "station_id"
{"class":"RTCM3","device":"stdin","type":1004,"length":149,"station_id":669,"tow":219460000,"sync":"true","smoothing":"false","interval":"0","satellites":[{"ident":2,"L1":{"ind":0,"prange": 158394.54,"delta":-0.7090,"lockt":234,"amb":76,"CNR":44.25}"L2":{"ind":0,"prange":  163.84,"delta":-262.1440,"lockt":0,"CNR":0.00}},{"ident":3,"L1":{"ind":0,"prange":22660.94,"delta":-0.841 5,"lockt":234,"amb":79,"CNR":45.00}"L2":{"ind":0,"prange":    4.90,"delta":-0.4080,"lockt":234,"CNR":41.00}},{"ident":6,"L1":{"ind":0,"prange":160910.78,"delta":-0.7495,"lockt":234,"amb":73 ,"CNR":47.00}"L2":{"ind":0,"prange":    5.10,"delta":2.0600,"lockt":234,"CNR":43.75}},{"ident":7,"L1":{"ind":0,"prange":297048.26,"delta":0.5615,"lockt":234,"amb":77,"CNR":49.25}"L2":{"ind" :0,"prange":    1.64,"delta":2.1525,"lockt":234,"CNR":40.50}},{"ident":9,"L1":{"ind":0,"prange":46516.20,"delta":0.5875,"lockt":234,"amb":67,"CNR":54.25}"L2":{"ind":0,"prange":    2.90,"del ta":0.6275,"lockt":234,"CNR":47.50}},{"ident":16,"L1":{"ind":0,"prange":264714.24,"delta":4.1475,"lockt":234,"amb":76,"CNR":43.50}"L2":{"ind":0,"prange":  163.84,"delta":-262.1440,"lockt":0 ,"CNR":0.00}},{"ident":23,"L1":{"ind":0,"prange":208765.46,"delta":-0.5550,"lockt":234,"amb":69,"CNR":49.75}"L2":{"ind":0,"prange":  163.84,"delta":-262.1440,"lockt":0,"CNR":0.00}},{"ident" :26,"L1":{"ind":0,"prange":254831.20,"delta":-1.2230,"lockt":234,"amb":76,"CNR":43.50}"L2":{"ind":0,"prange":    1.66,"delta":0.0210,"lockt":234,"CNR":38.25}},{"ident":29,"L1":{"ind":0,"pra nge":226917.00,"delta":-1.5515,"lockt":234,"amb":80,"CNR":41.50}"L2":{"ind":0,"prange":    0.24,"delta":-6.3375,"lockt":16,"CNR":32.50}}]}                                                    {"class":"RTCM3","device":"stdin","type":1012,"length":122,"station_id":669,"tow":57442000,"sync":"false","smoothing":"false","interval":"0","satellites":[{"ident":10,"channel":-7,"L1":{"in d":0,"prange":171257.00,"delta":11.1935,"lockt":83,"amb":39,"CNR":44.25},"L2":{"ind":0,"prange":    8.06,"delta":12.6075,"lockt":211,"CNR":37.00},},{"ident":9,"channel":-2,"L1":{"ind":0,"pr ange":108737.44,"delta":9.8945,"lockt":106,"amb":34,"CNR":50.00},"L2":{"ind":0,"prange":    0.96,"delta":8.7200,"lockt":234,"CNR":45.25},},{"ident":16,"channel":-1,"L1":{"ind":0,"prange":53 1732.44,"delta":11.1810,"lockt":106,"amb":34,"CNR":41.50},"L2":{"ind":0,"prange":    3.52,"delta":6.5715,"lockt":234,"CNR":37.50},},{"ident":24,"channel":2,"L1":{"ind":0,"prange":47697.58," delta":9.6540,"lockt":106,"amb":36,"CNR":42.00},"L2":{"ind":0,"prange":    0.00,"delta":-262.1440,"lockt":0,"CNR":0.00},},{"ident":23,"channel":3,"L1":{"ind":0,"prange":312393.14,"delta":11 .8195,"lockt":106,"amb":36,"CNR":46.00},"L2":{"ind":0,"prange":    5.04,"delta":10.8630,"lockt":234,"CNR":35.75},},{"ident":7,"channel":5,"L1":{"ind":0,"prange":279047.60,"delta":11.0460,"l ockt":106,"amb":32,"CNR":50.00},"L2":{"ind":0,"prange":    2.66,"delta":7.0785,"lockt":234,"CNR":43.25},},{"ident":8,"channel":6,"L1":{"ind":0,"prange":354630.90,"delta":13.1925,"lockt":106 ,"amb":33,"CNR":46.50},"L2":{"ind":0,"prange":    2.26,"delta":7.3430,"lockt":234,"CNR":44.75},}]}                                                                                            {"class":"RTCM3","device":"stdin","type":1006,"length":21,"station_id":669,"system":["GPS","GLONASS","GALILEO"],"refstation":false,"sro":true,"x":2795371.3120,"y":1236315.2730,"z":5579480.7 010,"h":1.5000}                                                                                                                                                                               {"class":"RTCM3","device":"stdin","type":1008,"length":26,"station_id":669,"desc":"HXCGPS500       DOME","setup-id":0,"serial":""}                                                            {"class":"RTCM3","device":"stdin","type":1033,"length":40,"station_id":669,"desc":"HXCGPS500       DOME","setup-id":0,"serial":"","receiver":PIKSI MULTI,"firmware":""}
```
### Console settings
Changing the settings changes the RTCM output on the fly.

Console v2.2.1 validates the lengths of string inputs so that 31 characters is ok and passed (note that IGS actually uses only 10 characters for receiver descriptor and 20 for the antenna), but trying to input 32 characters gives "Could not parse value"



