### PR TITLE
fix metrics mismatch issue as described in [ESD-899]

### DIFF
--- a/package/metrics_daemon/metrics_daemon/src/metrics_daemon.c
+++ b/package/metrics_daemon/metrics_daemon/src/metrics_daemon.c
@@ -116,8 +116,9 @@ struct json_object *loop_through_folder_name(const char *process_path,
                                    key,
                                    val) // for each subfolder, search the name as key in json tree
         {
-          if (strncmp((start_ptr), key, substr_len) == 0) // if find the folder name, continue on
-                                                          // the loop with the new current node
+          if (strncmp((start_ptr), key, substr_len) == 0
+              && strlen(key) == substr_len) // if find the folder name, continue on
+                                            // the loop with the new current node
           {
             json_current = val;
             found_target = true;


### PR DESCRIPTION
Added a check on string length when searching the json tree to prevent using wrong nodes which start with the same sub-string as parent when looping through the folders. 