### PR TITLE
reduce baseline alert to once every 10 seconds [v2.2]

### DIFF
--- a/package/health_daemon/src/baseline_monitor.c
+++ b/package/health_daemon/src/baseline_monitor.c
@@ -32,8 +32,8 @@
 #define FIXED_POSITION 4
 #define POSITION_MODE_MASK 0x07 /* Bits 0-2 */
 
-#define BASELINE_THRESHOLD_M (80000.0f)   /* m */
-#define BASELINE_ALERT_RATE_LIMIT (1000u) /* ms */
+#define BASELINE_THRESHOLD_M (80000.0f)    /* m */
+#define BASELINE_ALERT_RATE_LIMIT (10000u) /* ms */
 
 #define MM_TO_M_FLOAT(val_in_mm) ((float)(val_in_mm) / 1000.0f)
 static health_monitor_t *baseline_monitor;


### PR DESCRIPTION
(v2.2 version of #1019)

* reduce baseline alert to once every 10 seconds

* clang format