### PR TITLE
Golang 1.9 decided that <host>:<port> isn't a URL anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ docker-sync-setup:
 	@./scripts/check-docker-sync
 	@./scripts/gen-docker-sync $(DOCKER_BUILD_VOLUME) $(UID) $(DOCKER_HOST)
 	@docker volume create --name=$(DOCKER_BUILD_VOLUME)-sync
-	@echo "Done, run: make docker-start-sync"
+	@echo "Done, run: make docker-sync-start"
 
 docker-sync-start:
 	@docker-sync start -c .docker-sync.yml

--- a/scripts/gen-docker-sync
+++ b/scripts/gen-docker-sync
@@ -9,7 +9,7 @@ die_usage() {
   exit 1
 }
 
-[[ -n "$docker_host" ]] || { echo $'ERROR: no <DOCKER_HOST> specifid\n' >&2; die_usage; }
+[[ -n "$docker_host" ]] || { echo $'ERROR: no <DOCKER_HOST> specified\n' >&2; die_usage; }
 
 cat >.docker-sync.yml <<EOF
 version: "2"
@@ -20,7 +20,7 @@ syncs:
   ${docker_build_volume}-sync:
     notify_terminal: true
     src: '.'
-    sync_host_ip: '$(echo "${docker_host}" | cut -d: -f1)'
+    sync_host_ip: '$(echo "${docker_host}" | sed s@tcp://@@ | cut -d: -f1)'
     sync_strategy: 'unison'
     sync_userid: '${docker_sync_uid}'
     sync_args:


### PR DESCRIPTION
This affects DOCKER_HOST var for docker, using <host-ip>:<port> as a
value in the DOCKER_HOST variable used to work, but no longer in the
latest version of Docker for Mac.

See https://github.com/golang/go/issues/19297