### PR TITLE
remove WRITE_RESP message from udp/tcp_client [ESD-922]

### DIFF
--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -336,7 +336,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UDP_CLIENT0] = {
     .name = "udp_client0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -358,7 +358,8 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        MsgSettingsWriteResp         175
+        //TODO: Disabled - bandaid fix for ESD-922
+        //MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187
@@ -385,7 +386,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UDP_CLIENT1] = {
     .name = "udp_client1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -407,7 +408,8 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        MsgSettingsWriteResp         175
+        //TODO: Disabled - bandaid fix for ESD-922
+        //MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187

--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -228,7 +228,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_CLIENT0] = {
     .name = "tcp_client0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -250,7 +250,8 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        MsgSettingsWriteResp         175
+        //TODO: Disabled - bandaid fix for ESD-922
+        //MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187
@@ -277,7 +278,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_CLIENT1] = {
     .name = "tcp_client1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -299,7 +300,8 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        MsgSettingsWriteResp         175
+        //TODO: Disabled - bandaid fix for ESD-922
+        //MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187


### PR DESCRIPTION
A temporary solution to ESD-922. Changing a setting on one piksi would
also send a WRITE_RESP to a second piksi, also causing an unintentional
setting change there.

Backport of (#1029)