### PR TITLE
Clarify unknown setting read warning [ESD-908]

### DIFF
--- a/package/libsettings/libsettings.mk
+++ b/package/libsettings/libsettings.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSETTINGS_VERSION = v0.1
+LIBSETTINGS_VERSION = v0.1.1
 LIBSETTINGS_SITE = https://github.com/swift-nav/libsettings
 LIBSETTINGS_SITE_METHOD = git
 LIBSETTINGS_INSTALL_STAGING = YES

--- a/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
+++ b/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
@@ -257,7 +257,7 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void *contex
   s = settings_lookup(section, setting);
   if (s == NULL) {
     piksi_log(LOG_WARNING,
-              "Error in settings read message: setting not found (%s.%s)",
+              "Bad settings read request: setting not found (%s.%s)",
               section,
               setting);
     return;


### PR DESCRIPTION
To avoid further focus on issues indicated by the case that a setting is requested when it does not exist or has not been registered yet.