### PR TITLE
Default init script logging to kernel for increased reboots info collection [ESD-951]

### DIFF
--- a/package/common_init/overlay/etc/init.d/S09sysctl
+++ b/package/common_init/overlay/etc/init.d/S09sysctl
@@ -7,4 +7,5 @@ mkdir -p /var/run/sockets
 chmod 1777 /var/run/sockets
 mkdir -p /var/log/metrics
 chmod 1777 /var/log/metrics
+chmod 666 /dev/kmsg
 echo "denyinterfaces eth0" >> /etc/dhcpcd.conf

--- a/package/common_init/overlay/etc/init.d/S09sysctl
+++ b/package/common_init/overlay/etc/init.d/S09sysctl
@@ -7,5 +7,4 @@ mkdir -p /var/run/sockets
 chmod 1777 /var/run/sockets
 mkdir -p /var/log/metrics
 chmod 1777 /var/log/metrics
-chmod 666 /dev/kmsg
 echo "denyinterfaces eth0" >> /etc/dhcpcd.conf

--- a/package/common_init/overlay/etc/init.d/S18cfg
+++ b/package/common_init/overlay/etc/init.d/S18cfg
@@ -10,6 +10,11 @@ source /etc/init.d/logging.sh
 
 setup_loggers
 
+chmod_kmsg()
+{
+  chmod 666 /dev/kmsg
+}
+
 init_cfg_folder()
 {
   mkdir -p /cfg
@@ -37,6 +42,7 @@ case "$1" in
   init_cfg_folder
   init_sender_id_file
   init_uuid_file
+  chmod_kmsg
   /etc/init.d/copy_duro_eeprom.sh &
   ;;
   stop)

--- a/package/common_init/overlay/etc/init.d/logging.sh
+++ b/package/common_init/overlay/etc/init.d/logging.sh
@@ -15,6 +15,7 @@ log_base()
     esac
   done
   [[ -z "$send_sbp" ]] || { echo $* | sbp_log --"${_log_level}"; }
+  echo "$log_tag [${log_fac}.${_log_level}]: $*" | tee /dev/kmsg;
   logger -t $log_tag -p ${log_fac}.${_log_level} $*;
 }
 

--- a/package/libpiksi/libpiksi/include/libpiksi/logging.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/logging.h
@@ -155,6 +155,14 @@ void sbp_log(int priority, const char *msg_text, ...);
  */
 void sbp_vlog(int priority, const char *msg_text, va_list ap);
 
+/**
+ * @brief   Send a log message directly to the kernel log
+ *
+ * @param[in] priority      Priority level as defined in <syslog.h>.
+ * @param[in] msg_text      The log message text to send.
+ */
+void piksi_klog(int priority, const char *msg_text, ...);
+
 #define log_assert(TheExpr)                         \
   ({                                                \
     bool result = false;                            \

--- a/package/libpiksi/libpiksi/include/libpiksi/logging.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/logging.h
@@ -81,6 +81,14 @@
  */
 #define LOG_SBP LOG_LOCAL1
 
+/**
+ * Add to piksi_log to send the log message to kernel log as well as
+ *   the system log (syslog).
+ *
+ *  E.g. `piksi_log(LOG_KMSG|LOG_ERR, "Some message");`
+ */
+#define LOG_KMSG LOG_LOCAL3
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/package/libpiksi/libpiksi/src/logging.c
+++ b/package/libpiksi/libpiksi/src/logging.c
@@ -95,8 +95,8 @@ static void piksi_vklog(int priority, const char *format, va_list ap)
   const char *priority_string = get_priority_string(priority);
   char *with_preamble = (char *)alloca(strlen(identity) + 9 /* space + bracket + 'daemon.' */
                                        + strlen(priority_string) + 3 /* bracket, colon, space */
-                                       + strlen(format) + 1 /* terminator */);
-  sprintf(with_preamble, "%s [daemon.%s]: %s", identity, priority_string, format);
+                                       + strlen(format) + 2 /* return + terminator */);
+  sprintf(with_preamble, "%s [daemon.%s]: %s\n", identity, priority_string, format);
 
   int count = vsnprintf(msg, sizeof(msg), with_preamble, ap);
   if ((size_t)count >= sizeof(msg)) {

--- a/package/libpiksi/libpiksi/src/logging.c
+++ b/package/libpiksi/libpiksi/src/logging.c
@@ -144,7 +144,7 @@ void piksi_log(int priority, const char *format, ...)
 {
   va_list ap;
   va_start(ap, format);
-  piksi_vlog(priority|LOG_KMSG, format, ap);
+  piksi_vlog(priority | LOG_KMSG, format, ap);
   va_end(ap);
 }
 


### PR DESCRIPTION
Investigating reboots seen in HITL

Phase 1:
 - Add logging to `kmsg` (kernel log) which is output via UART1 in dev boot, which is used by HITL, in order to see more information between reboots

Phase 2:
 - (TBD) Add kernel logging to `piksi_log` as well