### PR TITLE
EX-472: Reject invalid RTCM antenna height setting values

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.71
+GNSS_CONVERTORS_VERSION = v0.3.72
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.35
+LIBRTCM_VERSION = v0.2.37
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -236,11 +236,10 @@ static int notify_rtcm_out_output_mode_changed(void *context)
 static int notify_ant_height_changed(void *context)
 {
   (void)context;
-  if (ant_height < 0.0) {
-    return SETTINGS_WR_VALUE_REJECTED;
+  if (sbp2rtcm_set_ant_height(ant_height, &sbp_to_rtcm3_state)) {
+    return SETTINGS_WR_OK;
   }
-  sbp2rtcm_set_ant_height(ant_height, &sbp_to_rtcm3_state);
-  return SETTINGS_WR_OK;
+  return SETTINGS_WR_VALUE_REJECTED;
 }
 
 static int notify_rcv_ant_descriptor_changed(void *context)


### PR DESCRIPTION
Check `rtcm_out.antenna_height` setting for both minimum and maximum value. 
Pulls in https://github.com/swift-nav/librtcm/pull/70 and https://github.com/swift-nav/gnss-converters/pull/161 which implement the check.

![image](https://user-images.githubusercontent.com/18000866/49508272-f4bcf680-f88a-11e8-948b-b3fe972fa7b3.png)
