### PR TITLE
Clarify unknown setting read warning [ESD-908]

### DIFF
--- a/package/libpiksi/libpiksi/src/settings.c
+++ b/package/libpiksi/libpiksi/src/settings.c
@@ -688,7 +688,7 @@ static int setting_perform_request_reply_from(settings_ctx_t *ctx,
   compare_deinit(ctx);
 
   if (!success) {
-    piksi_log(LOG_ERR, "setting req/reply failed");
+    piksi_log(LOG_WARNING, "settings request timed out without reply");
     return -1;
   }
 
@@ -1329,7 +1329,7 @@ static int settings_add_setting(settings_ctx_t *ctx,
       piksi_log(LOG_ERR, "error registering settings write resp callback");
     }
     if (setting_read_watched_value(ctx, setting_data) != 0) {
-      piksi_log(LOG_ERR, "error reading watched setting to initial value");
+      piksi_log(LOG_WARNING, "Unable to read watched setting to initial value");
     }
   } else {
     if (settings_register_write_callback(ctx) != 0) {

--- a/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
+++ b/package/sbp_settings_daemon/sbp_settings_daemon/src/settings.c
@@ -251,7 +251,7 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void *contex
   s = settings_lookup(section, setting);
   if (s == NULL) {
     piksi_log(LOG_WARNING,
-              "Error in settings read message: setting not found (%s.%s)",
+              "Bad settings read request: setting not found (%s.%s)",
               section,
               setting);
     return;


### PR DESCRIPTION
To avoid HITL indicating errors when these behaviors occur, update actual failure mode and downgrade to warning as needed/appropriate.