### PR TITLE
Reconnect in sbp_rx if we get disconnected [ESD-968]

### DIFF
--- a/package/libpiksi/libpiksi/src/endpoint.c
+++ b/package/libpiksi/libpiksi/src/endpoint.c
@@ -615,24 +615,22 @@ static int send_impl(client_context_t *ctx, const u8 *data, const size_t length)
 
     if (error == EAGAIN || error == EWOULDBLOCK) {
 
-      int queued_input = -1;
+      int queued_input = 0;
       int error = ioctl(ctx->handle, SIOCINQ, &queued_input);
 
       if (error < 0) PK_LOG_ANNO(LOG_WARNING, "unable to read SIOCINQ: %s", strerror(errno));
 
-      int queued_output = -1;
+      int queued_output = 0;
       error = ioctl(ctx->handle, SIOCOUTQ, &queued_output);
 
       if (error < 0) PK_LOG_ANNO(LOG_WARNING, "unable to read SIOCOUTQ: %s", strerror(errno));
 
       PK_LOG_ANNO(LOG_WARNING,
-                  "sendmsg returned EAGAIN, dropping %d bytes "
-                  "(path: %s, node: %p, queued input: %d, queued output: %d)",
-                  length,
+                  "sendmsg returned EAGAIN, disconnecting and dropping %d queued bytes "
+                  "(path: %s, node: %p)",
+                  length + queued_input + queued_output,
                   ctx->ept->path,
-                  ctx->node,
-                  queued_input,
-                  queued_output);
+                  ctx->node);
 
       send_close_socket_helper(ctx);
 

--- a/package/libpiksi/libpiksi/src/sbp_rx.c
+++ b/package/libpiksi/libpiksi/src/sbp_rx.c
@@ -111,13 +111,13 @@ static void rx_ctx_reader_loop_callback(pk_loop_t *pk_loop, void *handle, int st
       goto fail;
     }
 
-    /* Workaround for issue in libuv which causes a crash if the same IO handle (file descriptor number)
-     *   gets created for something that was just closed...
+    /* Workaround for issue in libuv which causes a crash if the same IO handle (file descriptor
+     * number) gets created for something that was just closed...
      *
      * Wisps of hints on how to fix this extracted from the following bug reports:
      *   - https://github.com/libuv/libuv/issues/1495
      *   - https://github.com/nodejs/node-v0.x-archive/issues/4558
-     */ 
+     */
     force_new_fd = open("/dev/null", O_RDWR);
 
     /* Socket was disconnected, reconnect */

--- a/package/resource_monitor/resource_monitor/src/sbp.c
+++ b/package/resource_monitor/resource_monitor/src/sbp.c
@@ -18,8 +18,8 @@
 
 #include "sbp.h"
 
-#define SBP_SUB_ENDPOINT "ipc:///var/run/sockets/internal.pub"
-#define SBP_PUB_ENDPOINT "ipc:///var/run/sockets/internal.sub"
+#define SBP_SUB_ENDPOINT "ipc:///var/run/sockets/resource_monitor.pub"
+#define SBP_PUB_ENDPOINT "ipc:///var/run/sockets/resource_monitor.sub"
 
 static uv_timer_t *uv_timer = NULL;
 

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -213,3 +213,16 @@ ports:
   - name: SBP_PORT_RESOURCE_MONITOR
     pub_addr: "ipc:///var/run/sockets/resource_monitor.pub"
     sub_addr: "ipc:///var/run/sockets/resource_monitor.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          # All resource monitor messages.
+          - { action: ACCEPT, prefix: [0x55, 0x00, 0x7F] } # MSG_LINUX_CPU_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x7F] } # MSG_LINUX_MEM_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x02, 0x7F] } # MSG_LINUX_SYS_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0x7F] } # MSG_LINUX_PROCESS_SOCKET_COUNTS
+          - { action: ACCEPT, prefix: [0x55, 0x04, 0x7F] } # MSG_LINUX_PROCESS_SOCKET_QUEUES
+          - { action: ACCEPT, prefix: [0x55, 0x05, 0x7F] } # MSG_LINUX_SOCKET_USAGE
+          - { action: ACCEPT, prefix: [0x55, 0x06, 0x7F] } # MSG_LINUX_PROCESS_FD_COUNT
+          - { action: ACCEPT, prefix: [0x55, 0x07, 0x7F] } # MSG_LINUX_PROCESS_FD_SUMMARY
+          - { action: REJECT }

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -210,3 +210,6 @@ ports:
     pub_addr: "ipc:///var/run/sockets/nmea_bridge.pub"
     sub_addr: "ipc:///var/run/sockets/nmea_bridge.sub"
 
+  - name: SBP_PORT_RESOURCE_MONITOR
+    pub_addr: "ipc:///var/run/sockets/resource_monitor.pub"
+    sub_addr: "ipc:///var/run/sockets/resource_monitor.sub"

--- a/package/sbp_protocol/src/sbp_router_smoothpose.yml
+++ b/package/sbp_protocol/src/sbp_router_smoothpose.yml
@@ -232,3 +232,16 @@ ports:
   - name: SBP_PORT_RESOURCE_MONITOR
     pub_addr: "ipc:///var/run/sockets/resource_monitor.pub"
     sub_addr: "ipc:///var/run/sockets/resource_monitor.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          # All resource monitor messages.
+          - { action: ACCEPT, prefix: [0x55, 0x00, 0x7F] } # MSG_LINUX_CPU_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x7F] } # MSG_LINUX_MEM_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x02, 0x7F] } # MSG_LINUX_SYS_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0x7F] } # MSG_LINUX_PROCESS_SOCKET_COUNTS
+          - { action: ACCEPT, prefix: [0x55, 0x04, 0x7F] } # MSG_LINUX_PROCESS_SOCKET_QUEUES
+          - { action: ACCEPT, prefix: [0x55, 0x05, 0x7F] } # MSG_LINUX_SOCKET_USAGE
+          - { action: ACCEPT, prefix: [0x55, 0x06, 0x7F] } # MSG_LINUX_PROCESS_FD_COUNT
+          - { action: ACCEPT, prefix: [0x55, 0x07, 0x7F] } # MSG_LINUX_PROCESS_FD_SUMMARY
+          - { action: REJECT }

--- a/package/sbp_protocol/src/sbp_router_smoothpose.yml
+++ b/package/sbp_protocol/src/sbp_router_smoothpose.yml
@@ -228,3 +228,7 @@ ports:
   - name: SBP_PORT_NMEA_BRIDGE
     pub_addr: "ipc:///var/run/sockets/nmea_bridge.pub"
     sub_addr: "ipc:///var/run/sockets/nmea_bridge.sub"
+
+  - name: SBP_PORT_RESOURCE_MONITOR
+    pub_addr: "ipc:///var/run/sockets/resource_monitor.pub"
+    sub_addr: "ipc:///var/run/sockets/resource_monitor.sub"

--- a/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
+++ b/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
@@ -272,3 +272,16 @@ ports:
   - name: SBP_PORT_RESOURCE_MONITOR
     pub_addr: "ipc:///var/run/sockets/resource_monitor.pub"
     sub_addr: "ipc:///var/run/sockets/resource_monitor.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          # All resource monitor messages.
+          - { action: ACCEPT, prefix: [0x55, 0x00, 0x7F] } # MSG_LINUX_CPU_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x01, 0x7F] } # MSG_LINUX_MEM_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x02, 0x7F] } # MSG_LINUX_SYS_STATE
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0x7F] } # MSG_LINUX_PROCESS_SOCKET_COUNTS
+          - { action: ACCEPT, prefix: [0x55, 0x04, 0x7F] } # MSG_LINUX_PROCESS_SOCKET_QUEUES
+          - { action: ACCEPT, prefix: [0x55, 0x05, 0x7F] } # MSG_LINUX_SOCKET_USAGE
+          - { action: ACCEPT, prefix: [0x55, 0x06, 0x7F] } # MSG_LINUX_PROCESS_FD_COUNT
+          - { action: ACCEPT, prefix: [0x55, 0x07, 0x7F] } # MSG_LINUX_PROCESS_FD_SUMMARY
+          - { action: REJECT }

--- a/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
+++ b/package/starling_daemon/overlay/etc/endpoint_router/sbp_router_starling.yml
@@ -62,7 +62,15 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x84, 0x00] } # SBP_MSG_EPHEMERIS_SBAS
           - { action: ACCEPT, prefix: [0x55, 0x75, 0x00] } # SBP_MSG_GLO_BIASES
           - { action: REJECT }
-
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: ACCEPT, prefix: [0x55, 0x02, 0x01] } # MSG_GPS_TIME
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0x01] } # MSG_UTC_TIME
+          - { action: ACCEPT, prefix: [0x55, 0x08, 0x02] } # MSG_DOPS
+          - { action: ACCEPT, prefix: [0x55, 0x0F, 0x02] } # MSG_BASELINE_HEADING
+          - { action: ACCEPT, prefix: [0x55, 0x10, 0x02] } # MSG_AGE_CORRECTIONS
+          - { action: REJECT }
 
   - name: SBP_PORT_SETTINGS_DAEMON
     pub_addr: "ipc:///var/run/sockets/settings_daemon.pub"
@@ -135,6 +143,10 @@ ports:
         filters:
           - { action: ACCEPT, prefix: [0x55, 0xA0, 0x00] } # Settings write
           - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: REJECT }
 
   - name: SBP_PORT_FILEIO_FIRMWARE
     pub_addr: "ipc:///var/run/sockets/fileio_firmware.pub"
@@ -192,6 +204,10 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x84, 0x00] } # SBP_MSG_EPHEMERIS_SBAS
           - { action: ACCEPT, prefix: [0x55, 0x75, 0x00] } # SBP_MSG_GLO_BIASES
           - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x4A, 0x00] } # SBP_MSG_OBS
+          - { action: REJECT }
 
   - name: SBP_PORT_NAV_DAEMON  # Entire Section Smoothpose Change**
     pub_addr: "ipc:///var/run/sockets/nav_daemon.pub"
@@ -243,5 +259,16 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: ACCEPT, prefix: [0x55, 0xAF, 0x00] } # Settings write response
           - { action: REJECT }
+      - dst_port: SBP_PORT_NMEA_BRIDGE
+        filters:
+          - { action: ACCEPT, prefix: [0x55, 0x0A, 0x02] } # MSG_POS_LLH
+          - { action: ACCEPT, prefix: [0x55, 0x0E, 0x02] } # MSG_VEL_NED
+          - { action: REJECT }
 
+  - name: SBP_PORT_NMEA_BRIDGE
+    pub_addr: "ipc:///var/run/sockets/nmea_bridge.pub"
+    sub_addr: "ipc:///var/run/sockets/nmea_bridge.sub"
 
+  - name: SBP_PORT_RESOURCE_MONITOR
+    pub_addr: "ipc:///var/run/sockets/resource_monitor.pub"
+    sub_addr: "ipc:///var/run/sockets/resource_monitor.sub"


### PR DESCRIPTION
## Design Notes

In `pk_endpoint_t` we disconnect clients that fall behind and failed to empty their buffers:
  - https://github.com/swift-nav/piksi_buildroot/blob/v2.2.0-release/package/libpiksi/libpiksi/src/endpoint.c#L628

This means that clients that wish to continue receiving data must notice the disconnect and manually reconnect in order to receive data again.  This is presumably something that was handled "under the covers" by nanomsg/zmq.

## Testing

Tested with `PoseDaemon` and confirmed that initially on start-up it gets behind on servicing data causing it's connection to the `endpoint_router` to be dropped.  Once it reconnects and behind processing data will remain "ahead" and no further reconnects are necessary.
