### PR TITLE
Add `show-startup-order` make target [ESD-968]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,6 @@ docker-aws-google-auth:
 	@./scripts/run-aws-google-auth
 
 show-startup-order:
-	@find . -name 'S*'|grep etc/init.d|sed 's@\(.*\)etc/init.d/\(.*\)@\2 - \1/etc/init.d\2@'|sort
+	@find . -name 'S*'|grep etc/init.d|sed 's@\(.*\)etc/init.d/\(.*\)@\2 - \1etc/init.d/\2@'|sort
 
 .PHONY: help


### PR DESCRIPTION
This command makes it easy to see the whole start-up order of the scripts on the device.  In the future this should probably display start-up order on a per-device variant basis.