### PR TITLE
Fix creation of service dir links [ESD-968]

### DIFF
--- a/package/common_init/overlay/etc/init.d/S79runsvdir
+++ b/package/common_init/overlay/etc/init.d/S79runsvdir
@@ -17,6 +17,12 @@ do_start()
 {
   mkdir -p $run_dir
 
+  # By runit convention, we link each service definition from
+  #   `/etc/sv` to `/var/service` to enable (and launch) the service,
+  #   at runtime a service can be disabled by removing it from
+  #   `/var/service`.  Services are typically enabled in this fashion
+  #   to allow a complete service definition (which is specified by
+  #   several files in the service directory) to appear atomically.
   find $svc_dir -type d -mindepth 1 -maxdepth 1 -exec basename {} \; | \
   while read -r svc; do
      ln -sf "$svc_dir/$svc" "$run_dir/$svc"

--- a/package/common_init/overlay/etc/init.d/S79runsvdir
+++ b/package/common_init/overlay/etc/init.d/S79runsvdir
@@ -17,7 +17,7 @@ do_start()
 {
   mkdir -p $run_dir
 
-  find $svc_dir -type d -maxdepth 1 -exec basename {} \; | \
+  find $svc_dir -type d -mindepth 1 -maxdepth 1 -exec basename {} \; | \
   while read -r svc; do
      ln -sf "$svc_dir/$svc" "$run_dir/$svc"
   done


### PR DESCRIPTION
This prevents us from creating an "sv" link which points to nothing
and causes runsvdir to issue warnings about it.