### PR TITLE
Disable orion daemon start-up script [ESD-968]

### DIFF
--- a/package/orion_daemon/overlay/etc/init.d/S82orion_daemon
+++ b/package/orion_daemon/overlay/etc/init.d/S82orion_daemon
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+exit 0
+
 name="orion_daemon"
 cmd="orion_daemon"
 dir="/"


### PR DESCRIPTION
Avoid more errors on start-up by not attempting to start a service that doesn't exist.  This commit WILL NOT be merged to master.