### PR TITLE
hide can settings if can_ports flag not enabled [ESD-883]

### DIFF
--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -521,7 +521,7 @@ static int mode_lookup(const char *mode_name, u8 *mode)
   return -1;
 }
 
-int ports_init(pk_settings_ctx_t *settings_ctx)
+int ports_init(pk_settings_ctx_t *settings_ctx, bool can_enabled)
 {
   size_t i;
 
@@ -573,6 +573,11 @@ int ports_init(pk_settings_ctx_t *settings_ctx)
 
     if (port_config->type == PORT_TYPE_UDP_CLIENT) {
       setting_udp_client_address_register(settings_ctx, port_config);
+    }
+
+    if ((port_config->type == PORT_TYPE_CAN) && !can_enabled) {
+      // Do not register CAN ports if feature not enabled
+      continue;
     }
 
     setting_mode_register(settings_ctx, settings_type_mode, port_config);

--- a/package/ports_daemon/ports_daemon/src/ports.h
+++ b/package/ports_daemon/ports_daemon/src/ports.h
@@ -19,7 +19,7 @@
 #include <sys/wait.h>
 #include <libpiksi/settings_client.h>
 
-int ports_init(pk_settings_ctx_t *settings_ctx);
+int ports_init(pk_settings_ctx_t *settings_ctx, bool can_enabled);
 bool port_is_enabled(const char *name);
 
 #endif /* SWIFTNAV_PORTS_H */

--- a/package/ports_daemon/ports_daemon/src/ports_daemon.c
+++ b/package/ports_daemon/ports_daemon/src/ports_daemon.c
@@ -78,9 +78,9 @@ static int parse_options(int argc, char *argv[])
 
 static void settings_init(pk_settings_ctx_t *s)
 {
-  if (whitelists_init(s) != 0) exit(EXIT_FAILURE);
+  if (whitelists_init(s, can_enabled) != 0) exit(EXIT_FAILURE);
 
-  if (ports_init(s) != 0) exit(EXIT_FAILURE);
+  if (ports_init(s, can_enabled) != 0) exit(EXIT_FAILURE);
 
   if (serial_init(s) != 0) exit(EXIT_FAILURE);
 

--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -531,9 +531,14 @@ int whitelist_notify(void *context)
   return SETTINGS_WR_OK;
 }
 
-int whitelists_init(pk_settings_ctx_t *settings_ctx)
+int whitelists_init(pk_settings_ctx_t *settings_ctx, bool can_enabled)
 {
   for (int i = 0; i < PORT_MAX; i++) {
+    if ((strncmp(port_whitelist_config[i].name, "can", 3) == 0) &&
+         !can_enabled) {
+      continue;
+    }
+
     int rc = pk_settings_register(settings_ctx,
                                   port_whitelist_config[i].name,
                                   "enabled_sbp_messages",

--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -534,8 +534,7 @@ int whitelist_notify(void *context)
 int whitelists_init(pk_settings_ctx_t *settings_ctx, bool can_enabled)
 {
   for (int i = 0; i < PORT_MAX; i++) {
-    if ((strncmp(port_whitelist_config[i].name, "can", 3) == 0) &&
-         !can_enabled) {
+    if ((strncmp(port_whitelist_config[i].name, "can", 3) == 0) && !can_enabled) {
       continue;
     }
 

--- a/package/ports_daemon/ports_daemon/src/whitelists.h
+++ b/package/ports_daemon/ports_daemon/src/whitelists.h
@@ -15,6 +15,6 @@
 
 #include <libpiksi/settings_client.h>
 
-int whitelists_init(pk_settings_ctx_t *settings_ctx);
+int whitelists_init(pk_settings_ctx_t *settings_ctx, bool can_enabled);
 
 #endif


### PR DESCRIPTION
The CAN port settings should be visible if and only if the can_ports flag is on. That flag is set if 
```
[experimental_flags]
can_ports = True
```
Is in `config.ini`