### PR TITLE
Fix standalone logging crash [ESD-981]

### DIFF
--- a/package/standalone_file_logger/standalone_file_logger/src/Makefile
+++ b/package/standalone_file_logger/standalone_file_logger/src/Makefile
@@ -3,8 +3,8 @@ SOURCES= \
 	rotating_logger.cc \
 	standalone_file_logger.cc
 
-LIBS=-luv -lsbp -lpiksi
-CFLAGS=-std=gnu++11
+LIBS=-luv -lsbp -lpiksi -lpthread
+CFLAGS=-std=gnu++11 -g
 ARFLAGS=rcs $(LTO_PLUGIN)
 
 CROSS=

--- a/package/standalone_file_logger/standalone_file_logger/src/Makefile
+++ b/package/standalone_file_logger/standalone_file_logger/src/Makefile
@@ -4,7 +4,7 @@ SOURCES= \
 	standalone_file_logger.cc
 
 LIBS=-luv -lsbp -lpiksi -lpthread
-CFLAGS=-std=gnu++11 -g
+CFLAGS=-std=gnu++11
 ARFLAGS=rcs $(LTO_PLUGIN)
 
 CROSS=

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -221,11 +221,13 @@ void RotatingLogger::process_frame()
     piksi_log(LOG_INFO, "process_frame not closed, acquiring lock");
     mlock.lock();
     piksi_log(LOG_INFO, "process_frame lock acquired");
-    while (_queue.empty()) {
+    if (_queue.empty()) {
       piksi_log(LOG_INFO, "process_frame queue empty, waiting");
       _cond.wait(mlock);
+      mlock.unlock();
+      piksi_log(LOG_INFO, "process_frame woken up");
+      continue;
     }
-    piksi_log(LOG_INFO, "process_frame woken up");
 
     if (!_dest_available) {
       // check imediately on startup for path availability. Subsequently, check
@@ -273,6 +275,7 @@ void RotatingLogger::process_frame()
     _bytes_written += size;
   }
   piksi_log(LOG_INFO, "process_frame closed");
+  // TODO: flush queue
 }
 
 void RotatingLogger::update_dir(const std::string &out_dir)

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -187,6 +187,7 @@ double RotatingLogger::get_time_passed()
 
 void RotatingLogger::frame_handler(const uint8_t *data, size_t size)
 {
+  // TODO: keep track of total data bytes: enforce a limit/warning in .h
   std::vector<uint8_t> *frame = new std::vector<uint8_t> (data, data + size);
 
   std::unique_lock<std::mutex> mlock(_mutex);
@@ -244,7 +245,7 @@ void RotatingLogger::process_frame()
     }
     _bytes_written += size;
   }
-  // TODO: flush queue
+  // TODO: flush queue - the queue may still have data in it
 }
 
 void RotatingLogger::update_dir(const std::string &out_dir)

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -190,7 +190,8 @@ void RotatingLogger::frame_handler(const uint8_t *data, size_t size)
 {
   // TODO: keep track of total data bytes: enforce a limit/warning in .h
   std::unique_lock<std::mutex> mlock(_mutex);
-  _queue.push_back( std::unique_ptr< std::vector<uint8_t> > (new std::vector<uint8_t> (data, data + size)) );
+  _queue.push_back(
+    std::unique_ptr<std::vector<uint8_t>>(new std::vector<uint8_t>(data, data + size)));
   _cond.notify_one();
 }
 
@@ -223,7 +224,7 @@ std::unique_ptr<std::vector<uint8_t>> RotatingLogger::get_frame()
     }
     _cond.wait(mlock);
   }
-   auto frame = std::move(_queue.front());
+  auto frame = std::move(_queue.front());
   _queue.pop_front();
   return frame;
 }
@@ -244,7 +245,8 @@ void RotatingLogger::process_frame()
     auto frame = frame_ptr.get();
     size_t size = sizeof(std::vector<uint8_t>::value_type) * frame->size();
     if (_cur_file != nullptr) {
-      num_written = fwrite(&frame[0], sizeof(std::vector<uint8_t>::value_type), frame->size(), _cur_file);
+      num_written =
+        fwrite(&frame[0], sizeof(std::vector<uint8_t>::value_type), frame->size(), _cur_file);
     }
 
     if (num_written != size) {

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -203,15 +203,15 @@ void RotatingLogger::process_frame()
       // check imediately on startup for path availability. Subsequently, check
       // periodically
       if (_session_start_time.time_since_epoch().count() != 0 && get_time_passed() < _poll_period) {
-        return;
+        continue;
       }
       _session_start_time = std::chrono::steady_clock::now();
       if (!start_new_session()) {
-        return;
+        continue;
       }
     }
     if (!check_slice_time()) {
-      return;
+      continue;
     }
 
     mlock.lock();

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -202,7 +202,7 @@ void RotatingLogger::frame_handler(const uint8_t *data, size_t size)
   _cond.notify_one();
 }
 
-bool RotatingLogger::current_session_valid()
+bool RotatingLogger::ensure_session_valid()
 {
   if (!_dest_available) {
     // check imediately on startup for path availability. Subsequently, check
@@ -241,7 +241,7 @@ void RotatingLogger::process_frame()
 {
   std::unique_lock<std::mutex> mlock(_mutex, std::defer_lock);
   while (!_finished.load()) {
-    if (!current_session_valid()) {
+    if (!ensure_session_valid()) {
       continue;
     }
 

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -223,9 +223,7 @@ bool RotatingLogger::ensure_session_valid()
 std::unique_ptr<std::vector<uint8_t>> RotatingLogger::get_frame()
 {
   std::unique_lock<std::mutex> mlock(_mutex);
-  if (_queue.empty()) {
-    _cond.wait(mlock);
-  }
+  _cond.wait(mlock, [this] { return !_queue.empty(); });
   auto frame = std::move(_queue.front());
   _queue.pop_front();
   if (frame != nullptr) {

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -22,7 +22,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/syslog.h>
-#include <memory>
 
 /*
  * Name format: xxxx-yyyyy.sbp
@@ -188,7 +187,6 @@ double RotatingLogger::get_time_passed()
 
 void RotatingLogger::frame_handler(const uint8_t *data, size_t size)
 {
-  // TODO: keep track of total data bytes: enforce a limit/warning in .h
   if (_queue_bytes + size > MAX_QUEUE_SIZE) {
     log_msg(LOG_WARNING,
             std::string("Internal queue full, dropping bytes: ") + std::to_string(size));

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <memory>
+#include <atomic>
 
 class RotatingLogger {
 
@@ -127,7 +128,7 @@ class RotatingLogger {
   size_t _bytes_written;
 
 
-  bool _finished = false;
+  std::atomic_bool _finished;
   std::thread _thread;
   std::mutex _mutex;
   std::condition_variable _cond;

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -17,9 +17,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <chrono>
+#include <deque>
 #include <string>
 #include <functional>
+#include <thread>
+#include <vector>
+#include <mutex>
+#include <condition_variable>
 
+#include <libpiksi/common.h>
 
 class RotatingLogger {
 
@@ -36,7 +42,7 @@ class RotatingLogger {
 
   ~RotatingLogger();
   /*
-   * try to log a data frame
+   * read a frame from the endpoint
    */
   void frame_handler(const uint8_t *data, size_t size);
 
@@ -105,6 +111,21 @@ class RotatingLogger {
 
   FILE *_cur_file;
   size_t _bytes_written;
+
+  /*
+   * try to log a data frame
+   */
+  void process_frame();
+
+  void test();
+  std::thread _thread;
+
+  std::mutex _mutex;
+  std::condition_variable _cond;
+
+  std::deque< std::vector<uint8_t>* > _queue;
+
+  bool _closed = false;
 };
 
 #endif // SWIFTNAV_ROTATING_LOGGER_H

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -32,7 +32,7 @@ class RotatingLogger {
   /* Pad new files out to minimize filesystem updates */
   static const size_t NEW_FILE_PAD_SIZE = 15 * 1024 * 1024;
   /* Maximum size of internal queue */
-  static const size_t MAX_QUEUE_SIZE = 1;
+  static const size_t MAX_QUEUE_SIZE = 1 * 1024 * 1024;
 
  public:
   typedef std::function<void(int, const char *)> LogCall;
@@ -112,7 +112,7 @@ class RotatingLogger {
   /*
    * Validate current logging session
    */
-  bool current_session_valid();
+  bool ensure_session_valid();
 
   void log_errno_warning(const char *msg);
 

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -31,6 +31,8 @@ class RotatingLogger {
 
   /* Pad new files out to minimize filesystem updates */
   static const size_t NEW_FILE_PAD_SIZE = 15 * 1024 * 1024;
+  /* Maximum size of internal queue */
+  static const size_t MAX_QUEUE_SIZE = 1;
 
  public:
   typedef std::function<void(int, const char *)> LogCall;
@@ -134,6 +136,7 @@ class RotatingLogger {
   std::condition_variable _cond;
 
   std::deque<std::unique_ptr<std::vector<uint8_t>>> _queue;
+  size_t _queue_bytes;
 };
 
 #endif // SWIFTNAV_ROTATING_LOGGER_H

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -102,6 +102,11 @@ class RotatingLogger {
   void process_frame();
 
   /*
+   * Blocking get next data frame from internal queue
+   */
+  std::unique_ptr<std::vector<uint8_t>> get_frame();
+
+  /*
    * Validate current logging session
    */
   bool current_session_valid();

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -25,8 +25,6 @@
 #include <mutex>
 #include <condition_variable>
 
-#include <libpiksi/common.h>
-
 class RotatingLogger {
 
   /* Pad new files out to minimize filesystem updates */

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -95,6 +95,11 @@ class RotatingLogger {
    */
   void pad_new_file();
 
+  /*
+   * try to log a data frame
+   */
+  void process_frame();
+
   void log_errno_warning(const char *msg);
 
   bool _dest_available;
@@ -110,20 +115,14 @@ class RotatingLogger {
   FILE *_cur_file;
   size_t _bytes_written;
 
-  /*
-   * try to log a data frame
-   */
-  void process_frame();
 
-  void test();
+  bool _finished = false;
   std::thread _thread;
-
   std::mutex _mutex;
   std::condition_variable _cond;
 
   std::deque< std::vector<uint8_t>* > _queue;
 
-  bool _closed = false;
 };
 
 #endif // SWIFTNAV_ROTATING_LOGGER_H

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <mutex>
 #include <condition_variable>
+#include <memory>
 
 class RotatingLogger {
 
@@ -121,7 +122,7 @@ class RotatingLogger {
   std::mutex _mutex;
   std::condition_variable _cond;
 
-  std::deque< std::vector<uint8_t>* > _queue;
+  std::deque<std::unique_ptr<std::vector<uint8_t>>> _queue;
 
 };
 

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -97,9 +97,14 @@ class RotatingLogger {
   void pad_new_file();
 
   /*
-   * try to log a data frame
+   * Try to log a data frame
    */
   void process_frame();
+
+  /*
+   * Validate current logging session
+   */
+  bool current_session_valid();
 
   void log_errno_warning(const char *msg);
 

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -129,7 +129,6 @@ class RotatingLogger {
   FILE *_cur_file;
   size_t _bytes_written;
 
-
   std::atomic_bool _finished;
   std::thread _thread;
   std::mutex _mutex;

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -133,7 +133,6 @@ class RotatingLogger {
   std::condition_variable _cond;
 
   std::deque<std::unique_ptr<std::vector<uint8_t>>> _queue;
-
 };
 
 #endif // SWIFTNAV_ROTATING_LOGGER_H

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -114,6 +114,11 @@ class RotatingLogger {
    */
   bool ensure_session_valid();
 
+  /*
+   * Stop the process_frame thread
+   */
+  void stop_thread();
+
   void log_errno_warning(const char *msg);
 
   bool _dest_available;

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -40,7 +40,7 @@ class RotatingLogger {
                  size_t slice_duration,
                  size_t poll_period,
                  size_t disk_full_threshold,
-                 LogCall logging_callback = LogCall());
+                 const LogCall &logging_callback = LogCall());
 
   ~RotatingLogger();
   /*
@@ -127,14 +127,13 @@ class RotatingLogger {
   size_t _slice_duration;
   size_t _poll_period;
   size_t _disk_full_threshold;
-  LogCall _logging_callback;
+  const LogCall &_logging_callback;
   std::string _out_dir;
   std::chrono::time_point<std::chrono::steady_clock> _session_start_time;
 
   FILE *_cur_file;
   size_t _bytes_written;
 
-  std::atomic_bool _finished;
   std::thread _thread;
   std::mutex _mutex;
   std::condition_variable _cond;

--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -147,10 +147,13 @@ static void process_log_callback(int priority, const char *msg_text)
 
 static void stop_logging()
 {
+  piksi_log(LOG_INFO, "stop_logging");
   if (logger != nullptr) {
     process_log_callback(LOG_INFO, "Logging stopped");
     delete logger;
     logger = nullptr;
+  } else {
+    piksi_log(LOG_INFO, "nothing to stop");
   }
 }
 
@@ -219,6 +222,7 @@ static int setting_usb_logging_notify(void *context)
   (void *)context;
 
   if (setting_usb_logging_enable) {
+    piksi_log(LOG_INFO, "setting_usb_logging_enable");
     if (logger == nullptr) {
       process_log_callback(LOG_INFO, "Logging started");
       logger = new RotatingLogger(setting_usb_logging_dir,
@@ -227,12 +231,17 @@ static int setting_usb_logging_notify(void *context)
                                   setting_usb_logging_max_fill,
                                   &process_log_callback);
     } else {
+      piksi_log(LOG_INFO | LOG_SBP, "logger != null, updating");
       logger->update_dir(setting_usb_logging_dir);
       logger->update_fill_threshold(setting_usb_logging_max_fill);
       logger->update_slice_duration(setting_usb_logging_slice_duration);
     }
   } else {
+    piksi_log(LOG_INFO | LOG_SBP, "setting_usb_logging_disable");
     stop_logging();
+    if (logger != nullptr) {
+      piksi_log(LOG_INFO, "stopped logging, but logger not null");
+    }
   }
 
   return SBP_SETTINGS_WRITE_STATUS_OK;
@@ -241,7 +250,10 @@ static int setting_usb_logging_notify(void *context)
 static int log_frame_callback(const u8 *data, const size_t length, void *context)
 {
   if (logger != nullptr) {
+    piksi_log(LOG_INFO, "frame_callback: logger is not null");
     logger->frame_handler(data, length);
+  } else {
+    piksi_log(LOG_INFO, "frame_callback: logger is null");
   }
   return 0;
 }
@@ -267,6 +279,7 @@ static void sub_poll_handler(pk_loop_t *loop, void *handle, int status, void *co
 static void sigchld_handler(int signum)
 {
   (void)signum;
+  piksi_log(LOG_INFO, "sigchild handler");
   int saved_errno = errno;
   while (waitpid(-1, nullptr, WNOHANG) > 0) {
     ;

--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -264,16 +264,6 @@ static void sub_poll_handler(pk_loop_t *loop, void *handle, int status, void *co
   return;
 }
 
-static void sigchld_handler(int signum)
-{
-  (void)signum;
-  int saved_errno = errno;
-  while (waitpid(-1, nullptr, WNOHANG) > 0) {
-    ;
-  }
-  errno = saved_errno;
-}
-
 static void terminate_handler(pk_loop_t *loop, void *handle, int status, void *context)
 {
   (void)context;
@@ -323,18 +313,6 @@ int main(int argc, char *argv[])
   }
 
   signal(SIGPIPE, SIG_IGN); /* Allow write to return an error */
-
-  /* Set up SIGCHLD handler */
-  /*
-  struct sigaction sigchld_sa;
-  sigchld_sa.sa_handler = sigchld_handler;
-  sigemptyset(&sigchld_sa.sa_mask);
-  sigchld_sa.sa_flags = SA_NOCLDSTOP;
-  if (sigaction(SIGCHLD, &sigchld_sa, nullptr) != 0) {
-    piksi_log(LOG_ERR, "error setting up sigchld handler");
-    exit(EXIT_FAILURE);
-  }
-  */
 
   if (setup_terminate_handler(loop) != 0) {
     piksi_log(LOG_ERR, "error setting up terminate handler");

--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -147,17 +147,11 @@ static void process_log_callback(int priority, const char *msg_text)
 
 static void stop_logging()
 {
-  piksi_log(LOG_INFO, "stop_logging");
   if (logger != nullptr) {
     process_log_callback(LOG_INFO, "Logging stopped");
     delete logger;
-    process_log_callback(LOG_INFO, "logger deleted");
     logger = nullptr;
-    process_log_callback(LOG_INFO, "logger set to null");
-  } else {
-    piksi_log(LOG_INFO, "nothing to stop");
   }
-  process_log_callback(LOG_INFO, "leaving stop_logging");
 }
 
 static void save_prev_logging_fs_type_value()
@@ -225,7 +219,6 @@ static int setting_usb_logging_notify(void *context)
   (void *)context;
 
   if (setting_usb_logging_enable) {
-    piksi_log(LOG_INFO, "setting_usb_logging_enable");
     if (logger == nullptr) {
       process_log_callback(LOG_INFO, "Logging started");
       logger = new RotatingLogger(setting_usb_logging_dir,
@@ -233,19 +226,13 @@ static int setting_usb_logging_notify(void *context)
                                   poll_period_s,
                                   setting_usb_logging_max_fill,
                                   &process_log_callback);
-      process_log_callback(LOG_INFO, "Logging started fin");
     } else {
-      piksi_log(LOG_INFO | LOG_SBP, "logger != null, updating");
       logger->update_dir(setting_usb_logging_dir);
       logger->update_fill_threshold(setting_usb_logging_max_fill);
       logger->update_slice_duration(setting_usb_logging_slice_duration);
     }
   } else {
-    piksi_log(LOG_INFO | LOG_SBP, "setting_usb_logging_disable");
     stop_logging();
-    if (logger != nullptr) {
-      piksi_log(LOG_INFO, "stopped logging, but logger not null");
-    }
   }
 
   return SBP_SETTINGS_WRITE_STATUS_OK;
@@ -254,10 +241,7 @@ static int setting_usb_logging_notify(void *context)
 static int log_frame_callback(const u8 *data, const size_t length, void *context)
 {
   if (logger != nullptr) {
-    piksi_log(LOG_INFO, "frame_callback: logger is not null");
     logger->frame_handler(data, length);
-  } else {
-    piksi_log(LOG_INFO, "frame_callback: logger is null");
   }
   return 0;
 }
@@ -283,7 +267,6 @@ static void sub_poll_handler(pk_loop_t *loop, void *handle, int status, void *co
 static void sigchld_handler(int signum)
 {
   (void)signum;
-  piksi_log(LOG_INFO, "sigchild handler");
   int saved_errno = errno;
   while (waitpid(-1, nullptr, WNOHANG) > 0) {
     ;

--- a/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/standalone_file_logger.cc
@@ -151,10 +151,13 @@ static void stop_logging()
   if (logger != nullptr) {
     process_log_callback(LOG_INFO, "Logging stopped");
     delete logger;
+    process_log_callback(LOG_INFO, "logger deleted");
     logger = nullptr;
+    process_log_callback(LOG_INFO, "logger set to null");
   } else {
     piksi_log(LOG_INFO, "nothing to stop");
   }
+  process_log_callback(LOG_INFO, "leaving stop_logging");
 }
 
 static void save_prev_logging_fs_type_value()
@@ -230,6 +233,7 @@ static int setting_usb_logging_notify(void *context)
                                   poll_period_s,
                                   setting_usb_logging_max_fill,
                                   &process_log_callback);
+      process_log_callback(LOG_INFO, "Logging started fin");
     } else {
       piksi_log(LOG_INFO | LOG_SBP, "logger != null, updating");
       logger->update_dir(setting_usb_logging_dir);
@@ -338,6 +342,7 @@ int main(int argc, char *argv[])
   signal(SIGPIPE, SIG_IGN); /* Allow write to return an error */
 
   /* Set up SIGCHLD handler */
+  /*
   struct sigaction sigchld_sa;
   sigchld_sa.sa_handler = sigchld_handler;
   sigemptyset(&sigchld_sa.sa_mask);
@@ -346,6 +351,7 @@ int main(int argc, char *argv[])
     piksi_log(LOG_ERR, "error setting up sigchld handler");
     exit(EXIT_FAILURE);
   }
+  */
 
   if (setup_terminate_handler(loop) != 0) {
     piksi_log(LOG_ERR, "error setting up terminate handler");

--- a/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
+++ b/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
@@ -62,7 +62,9 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
   // invalidate current file pointer
   void SetNullFilePointer()
   {
-    while (!_queue.empty()) {std::this_thread::sleep_for(std::chrono::milliseconds(50));}
+    while (!_queue.empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
     close_current_file();
   }
 
@@ -73,14 +75,18 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
 
   void SetOutputPath(const std::string &path)
   {
-    while (!_queue.empty()) {std::this_thread::sleep_for(std::chrono::milliseconds(50));}
+    while (!_queue.empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
     update_dir(path);
   }
 
   // make logger think time progressed
   void MoveStartTimeBack(size_t minutes_back)
   {
-    while (!_queue.empty()) {std::this_thread::sleep_for(std::chrono::milliseconds(50));}
+    while (!_queue.empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
     _session_start_time -= std::chrono::minutes(minutes_back);
   }
 };

--- a/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
+++ b/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
@@ -38,12 +38,12 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
 
   RotatingLoggerTest() : RotatingLogger("", 0, 0, 100, &RotatingLoggerTest::log_call)
   {
-    rm_wrapper("*.sbp");
+    //rm_wrapper("*.sbp");
   }
 
   ~RotatingLoggerTest() override
   {
-    rm_wrapper("*.sbp");
+    //rm_wrapper("*.sbp");
   }
 
   void rm_wrapper(const char *arg)
@@ -78,6 +78,7 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
   // make logger think time progressed
   void MoveStartTimeBack(size_t minutes_back)
   {
+    while (!_queue.empty()) {std::this_thread::sleep_for(std::chrono::milliseconds(50));}
     _session_start_time -= std::chrono::minutes(minutes_back);
   }
 };
@@ -103,6 +104,7 @@ TEST_F(RotatingLoggerTest, NormalOperation)
     expected_file_content[i / 5][i % 5] = i;
   }
 
+  stop_thread();
   close_current_file();
 
   // Check that log roll overs occured and each has correct data

--- a/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
+++ b/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
@@ -38,12 +38,12 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
 
   RotatingLoggerTest() : RotatingLogger("", 0, 0, 100, &RotatingLoggerTest::log_call)
   {
-    //rm_wrapper("*.sbp");
+    rm_wrapper("*.sbp");
   }
 
   ~RotatingLoggerTest() override
   {
-    //rm_wrapper("*.sbp");
+    rm_wrapper("*.sbp");
   }
 
   void rm_wrapper(const char *arg)

--- a/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
+++ b/package/standalone_file_logger/standalone_file_logger/test/run_rotating_logger_test.cc
@@ -62,6 +62,7 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
   // invalidate current file pointer
   void SetNullFilePointer()
   {
+    while (!_queue.empty()) {std::this_thread::sleep_for(std::chrono::milliseconds(50));}
     close_current_file();
   }
 
@@ -72,7 +73,8 @@ class RotatingLoggerTest : public ::testing::Test, public RotatingLogger {
 
   void SetOutputPath(const std::string &path)
   {
-    _out_dir = path;
+    while (!_queue.empty()) {std::this_thread::sleep_for(std::chrono::milliseconds(50));}
+    update_dir(path);
   }
 
   // make logger think time progressed
@@ -183,6 +185,7 @@ TEST_F(RotatingLoggerTest, StartDisconnected)
   SetOutputPath(out_dir);
   frame_handler(reinterpret_cast<uint8_t *>(&i), sizeof(int));
 
+  stop_thread();
   close_current_file();
 
   char file_name_buf[1024];
@@ -231,6 +234,7 @@ TEST_F(RotatingLoggerTest, DisconnectReconnect)
   // 0003-00000.sbp <- 5
   frame_handler(reinterpret_cast<uint8_t *>(&i), sizeof(int));
 
+  stop_thread();
   close_current_file();
 
   for (i = 0; i < 3; i++) {


### PR DESCRIPTION
When the endpoint router's internal buffer fills up, the connection is silently dropped. This causes both loss of data, and breaks the standalone_logger since it doesn't currently attempt to reconnect. standalone_logger occasionally needs to perform blocking I/O. During these operations, the endpoint router is not being serviced, which ends up overflowing the buffer.

This PR attempts to alleviate the situation by splitting the I/O intensive operations into it's own thread. The endpoint receiver callback will read incoming data into an internal `std::deque< vector<uint8t> * >'. While this will not guarantee that the endpoint router never overflows, it should make it much less likely to occur.

`RotatingLogger::frame_handler` callback has been changed to only copy data from the endpoint router into an internal queue.
`RotatingLoggger:process_frame` does the heavy lifting the callback was previously responsible for in it's own thread. Sections where data is read are protected by a mutex; I/O intensive sections are not locked, allowing `frame_handler` to continue draining the queue.

Upon tear-down, a sentinel nullptr is placed onto the internal queue. `process_frame` will continue reading forever until it encounters this value.
This implementation should be thread-safe in the single producer, single consumer case. 

The tests have been changed slightly to include a sleep on certain operations. This allows `process_frame` and `frame_handler` to synchronize their operations, since the tests depend on a deterministic ordering. 

See also: https://github.com/swift-nav/piksi_buildroot/pull/1097