### PR TITLE
piksi_ins startup: update startup scripts to avoid resets in some con…

### DIFF
--- a/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
+++ b/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
@@ -16,7 +16,7 @@ setup_permissions()
 
 starling_daemon_enabled=$(query_config --section experimental_flags --key starling_on_linux)
 
-if detect_piksi_ins; then
+if detect_piksi_ins_router && detect_piksi_ins; then
   router_config="/etc/endpoint_router/sbp_router_smoothpose.yml"
 elif [[ "$starling_daemon_enabled" == "True" ]]; then
   router_config="/etc/endpoint_router/sbp_router_starling.yml"

--- a/package/common_init/overlay/etc/init.d/common.sh
+++ b/package/common_init/overlay/etc/init.d/common.sh
@@ -171,8 +171,19 @@ lockdown()
     [[ -f "$_release_lockdown" ]]
 }
 
-detect_piksi_ins()
+detect_piksi_ins_router()
 {
   ins_output_mode=$(query_config --section ins --key output_mode)
   [[ "$ins_output_mode" == "Loosely Coupled" ]]
+}
+
+# in order to be a real piksi_ins, you need all of the following:
+#  - output mode configured to either "Debug" or "Loosely Coupled"
+#  - the license file must exist
+#  - the PoseDaemon executable must exist
+
+detect_piksi_ins()
+{
+  ins_output_mode=$(query_config --section ins --key output_mode)
+  { detect_piksi_ins_router || [[ "$ins_output_mode" == "Debug" ]];} && [[ -f /usr/bin/PoseDaemon ]] && [[ -f /persistent/licenses/smoothpose_license.json ]]
 }

--- a/package/common_init/overlay/etc/init.d/common.sh
+++ b/package/common_init/overlay/etc/init.d/common.sh
@@ -185,5 +185,7 @@ detect_piksi_ins_router()
 detect_piksi_ins()
 {
   ins_output_mode=$(query_config --section ins --key output_mode)
-  { detect_piksi_ins_router || [[ "$ins_output_mode" == "Debug" ]];} && [[ -f /usr/bin/PoseDaemon ]] && [[ -f /persistent/licenses/smoothpose_license.json ]]
+  { detect_piksi_ins_router || [[ "$ins_output_mode" == "Debug" ]]; } \
+    && [[ -f /usr/bin/PoseDaemon ]] \
+    && [[ -f /persistent/licenses/smoothpose_license.json ]]
 }


### PR DESCRIPTION
This PR is to address two things

1. If someone or a Swifter manages to build an SDK version of piksi_buildroot and then flashes that to a Duro_Inertial, the device will end up in a restart loop that may even prevent them from doing anything
2. Sometimes Swifters ended up with the Smoothpose router config even though their device didn't have a license file or their build was missing the PoseDaemon.

I think I address either case with the changes.  I want to put it into v2.2.0 release and master with hopes that v2.2.0 will have SDK support that is reasonable.

TODO: test travis build thoroughly for all combinations of license and setting.