### PR TITLE
Allow standalone logging to create files in  F2FS mode [ESD-1005]

### DIFF
--- a/package/common_init/overlay/etc/init.d/common.sh
+++ b/package/common_init/overlay/etc/init.d/common.sh
@@ -168,7 +168,7 @@ _release_lockdown=/etc/release_lockdown
 
 lockdown()
 {
-    [[ -f "$_release_lockdown" ]]
+  [[ -f "$_release_lockdown" ]]
 }
 
 detect_piksi_ins()

--- a/package/common_init/overlay/etc/init.d/copy_sys_logs.sh
+++ b/package/common_init/overlay/etc/init.d/copy_sys_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 
 log_tag=copy_sys_logs
 
@@ -52,7 +52,7 @@ cleanup_rsync()
   [[ -z "$rsync_pid" ]] || kill "$rsync_pid"
 }
 
-trap 'cleanup_loggers; cleanup_rsync; exit 0' EXIT TERM STOP HUP INT
+trap 'cleanup_loggers; cleanup_rsync; exit 0' EXIT TERM HUP INT
 
 mkdir "$log_dir_n"
 

--- a/package/common_init/overlay/etc/init.d/migrate_sdcard.sh
+++ b/package/common_init/overlay/etc/init.d/migrate_sdcard.sh
@@ -1,7 +1,7 @@
 #!/bin/ash
 
-name="migrate_sdcard"
-log_tag=$name
+export name="migrate_sdcard"
+export log_tag=$name
 
 source /etc/init.d/sdcard.sh
 source /etc/init.d/logging.sh
@@ -52,7 +52,7 @@ wait_for_sdcard_mount
 
 for dev in $(list_partitions); do
   devname=${dev:2}
-  if needs_migration $devname; then
+  if needs_migration "$devname"; then
 
     # Stop services that use the sdcard
     /etc/init.d/S83standalone_file_logger stop
@@ -65,7 +65,7 @@ for dev in $(list_partitions); do
     [[ -z "$mountpoint" ]] || umount $mountpoint
 
     logw "Migrating '${devname}' to F2FS..."
-    format_with_f2fs $devname
+    format_with_f2fs "$devname"
 
     reboot -f
   fi

--- a/package/common_init/overlay/etc/init.d/sdcard.sh
+++ b/package/common_init/overlay/etc/init.d/sdcard.sh
@@ -2,6 +2,9 @@ MOUNT_BASE="/media"
 MOUNTNAME="mmcblk0p1"
 MOUNTPOINT="$MOUNT_BASE/$MOUNTNAME"
 
+# Wait 30 seconds for the sdcard to be mounted
+wait_sdcard_limit=30
+
 is_mounted()
 {
   grep -q $MOUNTPOINT /proc/mounts
@@ -12,33 +15,63 @@ inotify_wait_mountpoint()
   [[ -e "$MOUNTPOINT" ]] || inotifywait -e create "$MOUNT_BASE" -q -t 1 | grep -q "CREATE $MOUNTNAME"
 }
 
+seconds_since_start() {
+  local the_time=$(cut -f1 -d' ' </proc/uptime)
+  echo ${the_time/.*}
+}
+
 wait_for_sdcard_mount()
 {
+  local start_time=$(seconds_since_start)
+  local current_time=
+
   while ! inotify_wait_mountpoint; do
+
+    current_time=$(seconds_since_start)
+    if [[ $(( current_time - start_time )) -gt $wait_sdcard_limit ]]; then
+      logi "Ending wait for sdcard mount..."
+      exit 0
+    fi
+
     continue;
   done
+
   while ! is_mounted; do
-    sleep 0.5; continue;
+
+    current_time=$(seconds_since_start)
+    if [[ $(( current_time - start_time )) -gt $wait_sdcard_limit ]]; then
+      logi "Ending wait for sdcard mount..."
+      exit 0
+    fi
+
+    sleep 0.5;
+    continue;
   done
+
   if ! [[ -d "$MOUNTPOINT" ]]; then
     logw "Mountpoint exists, but is not a directory"
   fi
+}
+
+is_f2fs_enabled()
+{
+  [[ "$(query_config --section standalone_logging --key logging_file_system)" == "F2FS" ]]
 }
 
 needs_migration()
 {
   local devname=$1; shift
 
-  if ! grep -q "logging_file_system=F2FS" /persistent/config.ini; then
+  if ! is_f2fs_enabled; then
     logd "Did not detect F2FS in config"
-    return 1
+    return 1 # no
   fi
 
   if detect_f2fs $devname; then
-    return 1
+    return 1 # no
   fi
 
-  return 0
+  return 0 # yes
 }
 
 detect_f2fs()

--- a/package/common_init/overlay/lib/mdev/automount.sh
+++ b/package/common_init/overlay/lib/mdev/automount.sh
@@ -5,6 +5,7 @@ log_tag=automount
 
 source /etc/init.d/sdcard.sh
 source /etc/init.d/logging.sh
+
 setup_loggers
 
 do_umount()
@@ -43,6 +44,10 @@ do_mount()
     loge "Mount failed, cleaning up mount point..."
     rmdir $mountpoint
     exit 1
+  fi
+
+  if detect_f2fs $devname; then
+    chmod 1777 "$mountpoint/."
   fi
 }
 

--- a/package/common_init/overlay/usr/bin/service_stopped
+++ b/package/common_init/overlay/usr/bin/service_stopped
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 # shellcheck disable=SC1091,SC2169
 
 set -e

--- a/package/common_init/overlay/usr/bin/start_service
+++ b/package/common_init/overlay/usr/bin/start_service
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 # shellcheck disable=SC1091,SC2169
 
 set -e

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/syslog.h>
+#include <sys/stat.h>
 
 /*
  * Name format: xxxx-yyyyy.sbp
@@ -116,7 +117,11 @@ bool RotatingLogger::open_new_file()
   }
   sprintf(log_name_buf, "%04lu-%05lu%s", _session_count, _minute_count, LOG_SUFFIX.c_str());
 
-  _cur_file = fopen((_out_dir + "/" + log_name_buf).c_str(), "wb");
+  mode_t mode = umask(0111);
+  int fd = open((_out_dir + "/" + log_name_buf).c_str(), O_CREAT|O_WRONLY, 0666);
+
+  _cur_file = fdopen(fd, "w");
+  umask(mode);
 
   if (_cur_file != nullptr && ferror(_cur_file) != 0) {
     fclose(_cur_file);

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -118,7 +118,7 @@ bool RotatingLogger::open_new_file()
   sprintf(log_name_buf, "%04lu-%05lu%s", _session_count, _minute_count, LOG_SUFFIX.c_str());
 
   mode_t mode = umask(0111);
-  int fd = open((_out_dir + "/" + log_name_buf).c_str(), O_CREAT|O_WRONLY, 0666);
+  int fd = open((_out_dir + "/" + log_name_buf).c_str(), O_CREAT | O_WRONLY, 0666);
 
   _cur_file = fdopen(fd, "w");
   umask(mode);


### PR DESCRIPTION
F2FS support combined with the IP security work created a bug where standalone logging could not create files if an sdcard was formatted with F2FS.  Fix this by changing the permissions of the top-level directory of the mount point to be like a temporary directory.

Also includes the following fix-ups:
+ Don't allow the `migrate_sdcard` service to run indefinitely if the board doesn't have an sdcard attached
+ Create .sbp files such that the FileIO daemon will be able to read/delete them

https://swift-nav.atlassian.net/browse/ESD-1005