### PR TITLE
piksi_ins startup: avoid reset in sdk & some configs

### DIFF
--- a/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
+++ b/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
@@ -16,7 +16,7 @@ setup_permissions()
 
 starling_daemon_enabled=$(query_config --section experimental_flags --key starling_on_linux)
 
-if detect_piksi_ins; then
+if detect_piksi_ins_router && detect_piksi_ins; then
   router_config="/etc/endpoint_router/sbp_router_smoothpose.yml"
 elif [[ "$starling_daemon_enabled" == "True" ]]; then
   router_config="/etc/endpoint_router/sbp_router_starling.yml"

--- a/package/common_init/overlay/etc/init.d/common.sh
+++ b/package/common_init/overlay/etc/init.d/common.sh
@@ -171,8 +171,21 @@ lockdown()
   [[ -f "$_release_lockdown" ]]
 }
 
-detect_piksi_ins()
+detect_piksi_ins_router()
 {
   ins_output_mode=$(query_config --section ins --key output_mode)
   [[ "$ins_output_mode" == "Loosely Coupled" ]]
+}
+
+# in order to be a real piksi_ins, you need all of the following:
+#  - output mode configured to either "Debug" or "Loosely Coupled"
+#  - the license file must exist
+#  - the PoseDaemon executable must exist
+
+detect_piksi_ins()
+{
+  ins_output_mode=$(query_config --section ins --key output_mode)
+  { detect_piksi_ins_router || [[ "$ins_output_mode" == "Debug" ]]; } \
+    && [[ -f /usr/bin/PoseDaemon ]] \
+    && [[ -f /persistent/licenses/smoothpose_license.json ]]
 }


### PR DESCRIPTION
We don't want to reset the device when smoothpose isn't running if
  * the config won't allow smoothpose to run
  * or the binary is missing completely.
#1101 for master