### PR TITLE
Don't broadcast base bias messages [ESD-1013]

### DIFF
--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -194,7 +194,10 @@ static void ephemeris_glo_callback(u16 sender_id, u8 len, u8 msg[], void *contex
 static void base_pos_ecef_callback(u16 sender_id, u8 len, u8 msg[], void *context)
 {
   (void)context;
-  sbp2rtcm_base_pos_ecef_cb(sender_id, len, msg, &sbp_to_rtcm3_state);
+  /* do not relay base pos messages (sender_id 0) */
+  if (sender_id > 0) {
+    sbp2rtcm_base_pos_ecef_cb(sender_id, len, msg, &sbp_to_rtcm3_state);
+  }
 }
 
 static void glo_bias_callback(u16 sender_id, u8 len, u8 msg[], void *context)

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -200,7 +200,10 @@ static void base_pos_ecef_callback(u16 sender_id, u8 len, u8 msg[], void *contex
 static void glo_bias_callback(u16 sender_id, u8 len, u8 msg[], void *context)
 {
   (void)context;
-  sbp2rtcm_glo_biases_cb(sender_id, len, msg, &sbp_to_rtcm3_state);
+  /* do not relay base biases (sender_id 0) */
+  if (sender_id > 0) {
+    sbp2rtcm_glo_biases_cb(sender_id, len, msg, &sbp_to_rtcm3_state);
+  }
 }
 
 static void obs_callback(u16 sender_id, u8 len, u8 msg[], void *context)


### PR DESCRIPTION

I think if we ever setup a piksi as a base, but still in RTK mode receiving a correction stream from another receiver, the current setup would output both the piksi, and the received correction bias in RTCM out. This is not wanted, we should only output the piksi bias message

@nsirola - does this make sense to you?