### PR TITLE
Avoid crash by switching back to a regular pass by value [ESD-981]

### DIFF
--- a/package/standalone_file_logger/standalone_file_logger/src/Makefile
+++ b/package/standalone_file_logger/standalone_file_logger/src/Makefile
@@ -4,7 +4,7 @@ SOURCES= \
 	standalone_file_logger.cc
 
 LIBS=-luv -lsbp -lpiksi -lpthread
-CFLAGS=-std=gnu++11
+CFLAGS=-std=gnu++11 -ggdb3
 ARFLAGS=rcs $(LTO_PLUGIN)
 
 CROSS=

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.cc
@@ -291,7 +291,7 @@ RotatingLogger::RotatingLogger(const std::string &out_dir,
                                size_t slice_duration,
                                size_t poll_period,
                                size_t disk_full_threshold,
-                               const LogCall &logging_callback)
+                               LogCall logging_callback)
   : _dest_available(false), _session_count(0), _minute_count(0), _out_dir(out_dir),
     _slice_duration(slice_duration), _poll_period(poll_period),
     _disk_full_threshold(disk_full_threshold), _logging_callback(logging_callback),

--- a/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
+++ b/package/standalone_file_logger/standalone_file_logger/src/rotating_logger.h
@@ -40,7 +40,7 @@ class RotatingLogger {
                  size_t slice_duration,
                  size_t poll_period,
                  size_t disk_full_threshold,
-                 const LogCall &logging_callback = LogCall());
+                 LogCall logging_callback = LogCall());
 
   ~RotatingLogger();
   /*
@@ -127,7 +127,7 @@ class RotatingLogger {
   size_t _slice_duration;
   size_t _poll_period;
   size_t _disk_full_threshold;
-  const LogCall &_logging_callback;
+  LogCall _logging_callback;
   std::string _out_dir;
   std::chrono::time_point<std::chrono::steady_clock> _session_start_time;
 


### PR DESCRIPTION
Clang-tidy complained about this being copied but only used once, our "fix" was to change this to a pass by reference, but this causes a crash, probably because we're asking for the address of a temporary `std::function` object?