### PR TITLE
Remove raw IMU messages from whitelist

### DIFF
--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -48,8 +48,6 @@ enum port {
   PORT_UDP_SERVER1,
   PORT_UDP_CLIENT0,
   PORT_UDP_CLIENT1,
-  PORT_CAN0,
-  PORT_CAN1,
   PORT_MAX
 };
 
@@ -58,7 +56,6 @@ typedef struct {
   char wl[256];
 } port_whitelist_config_t;
 
-// clang-format off
 static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   [PORT_UART0] = {
     .name = "uart0",
@@ -77,7 +74,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UART1] = {
     .name = "uart1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -116,9 +113,6 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -130,7 +124,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_SERVER0] = {
     .name = "tcp_server0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -169,9 +163,6 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -179,7 +170,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_SERVER1] = {
     .name = "tcp_server1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -218,9 +209,6 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -228,7 +216,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_CLIENT0] = {
     .name = "tcp_client0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -250,8 +238,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        //TODO: Disabled - bandaid fix for ESD-922
-        //MsgSettingsWriteResp         175
+        MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187
@@ -268,9 +255,6 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -278,7 +262,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_CLIENT1] = {
     .name = "tcp_client1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -300,8 +284,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        //TODO: Disabled - bandaid fix for ESD-922
-        //MsgSettingsWriteResp         175
+        MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187
@@ -318,9 +301,6 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -336,7 +316,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UDP_CLIENT0] = {
     .name = "udp_client0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -358,8 +338,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        //TODO: Disabled - bandaid fix for ESD-922
-        //MsgSettingsWriteResp         175
+        MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187
@@ -376,9 +355,6 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -386,7 +362,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UDP_CLIENT1] = {
     .name = "udp_client1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -408,8 +384,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgSettingsReadByIndexDone   166
         MsgSettingsReadByIndexResp   167
         MsgFileioWriteResp           171
-        //TODO: Disabled - bandaid fix for ESD-922
-        //MsgSettingsWriteResp         175
+        MsgSettingsWriteResp         175
         MsgDeviceMonitor             181
         MsgCommandResp               185
         MsgNetworkStateResp          187
@@ -426,32 +401,21 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
-        MsgImuAux                   2305
-        MsgMagRaw                   2306
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
         MsgHeartbeat               65535 */
-  },
-  [PORT_CAN0] = {
-    .name = "can0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
-  },
-  [PORT_CAN1] = {
-    .name = "can1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
-  },
+  }
 };
-// clang-format on
 
 int whitelist_notify(void *context)
 {
-  port_whitelist_config_t *port_whitelist_config_ = (port_whitelist_config_t *)context;
+  port_whitelist_config_t *port_whitelist_config_ =
+      (port_whitelist_config_t *)context;
 
   char *c = port_whitelist_config_->wl;
   unsigned tmp;
-  enum { PARSE_ID, PARSE_AFTER_ID, PARSE_DIV, PARSE_AFTER_DIV } state = PARSE_ID;
+  enum {PARSE_ID, PARSE_AFTER_ID, PARSE_DIV, PARSE_AFTER_DIV} state = PARSE_ID;
   struct {
     unsigned id;
     unsigned div;
@@ -473,11 +437,12 @@ int whitelist_notify(void *context)
         break;
       case PARSE_DIV:
         state = PARSE_AFTER_DIV;
-        whitelist[entries - 1].div = tmp;
+        whitelist[entries-1].div = tmp;
         break;
       case PARSE_AFTER_DIV:
       case PARSE_AFTER_ID:
-      default: return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
+      default:
+        return -1;
       }
       break;
 
@@ -487,7 +452,7 @@ int whitelist_notify(void *context)
         state = PARSE_DIV;
         c++;
       } else {
-        return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
+        return -1;
       }
       break;
 
@@ -497,21 +462,18 @@ int whitelist_notify(void *context)
         state = PARSE_ID;
         c++;
       } else {
-        return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
+        return -1;
       }
       break;
 
     /* Ignore whitespace */
-    case ' ':
-    case '\t':
-    case '\n':
-    case '\r':
-    case '\v':
+    case ' ': case '\t': case '\n': case '\r': case '\v':
       c++;
       break;
 
     /* Invalid token, parse error */
-    default: return SBP_SETTINGS_WRITE_STATUS_PARSE_FAILED;
+    default:
+      return -1;
     }
   }
 
@@ -521,30 +483,22 @@ int whitelist_notify(void *context)
   FILE *cfg = fopen(fn, "w");
   if (cfg == NULL) {
     piksi_log(LOG_ERR, "Error opening file: %s (error: %s)", fn, strerror(errno));
-    return SBP_SETTINGS_WRITE_STATUS_SERVICE_FAILED;
+    return -1;
   }
   for (int i = 0; i < entries; i++) {
     fprintf(cfg, "%x %x\n", whitelist[i].id, whitelist[i].div);
   }
   fclose(cfg);
 
-  return SBP_SETTINGS_WRITE_STATUS_OK;
+  return 0;
 }
 
-int whitelists_init(settings_ctx_t *settings_ctx, bool can_enabled)
+int whitelists_init(settings_ctx_t *settings_ctx)
 {
   for (int i = 0; i < PORT_MAX; i++) {
-    if ((strncmp(port_whitelist_config[i].name, "can", 3) == 0) && !can_enabled) {
-      continue;
-    }
-    int rc = settings_register(settings_ctx,
-                               port_whitelist_config[i].name,
-                               "enabled_sbp_messages",
-                               port_whitelist_config[i].wl,
-                               sizeof(port_whitelist_config[i].wl),
-                               SETTINGS_TYPE_STRING,
-                               whitelist_notify,
-                               &port_whitelist_config[i]);
+    int rc = settings_register(settings_ctx, port_whitelist_config[i].name, "enabled_sbp_messages",
+                               port_whitelist_config[i].wl, sizeof(port_whitelist_config[i].wl),
+                               SETTINGS_TYPE_STRING, whitelist_notify, &port_whitelist_config[i]);
     if (rc != 0) {
       return rc;
     }


### PR DESCRIPTION
These are causing the tracking and solution plots in the console to choke. I'll open a piksi_tools PR that updates the console documentation to tell people that they need to add these messages to the whitelist to use the IMU tab.