### PR TITLE
Decimate raw IMU / mag msgs by 50 to improve Swift Console [ESD-1014]

### DIFF
--- a/package/ports_daemon/ports_daemon/src/whitelists.c
+++ b/package/ports_daemon/ports_daemon/src/whitelists.c
@@ -77,7 +77,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UART1] = {
     .name = "uart1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -116,9 +116,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -130,7 +130,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_SERVER0] = {
     .name = "tcp_server0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -169,9 +169,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -179,7 +179,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_SERVER1] = {
     .name = "tcp_server1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,175,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -218,9 +218,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -228,7 +228,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_CLIENT0] = {
     .name = "tcp_client0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -268,9 +268,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -278,7 +278,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_TCP_CLIENT1] = {
     .name = "tcp_client1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -318,9 +318,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -336,7 +336,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UDP_CLIENT0] = {
     .name = "udp_client0",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -376,9 +376,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282
@@ -386,7 +386,7 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
   },
   [PORT_UDP_CLIENT1] = {
     .name = "udp_client1",
-    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304,2305,2306,30583,65280,65282,65535"
+    .wl = "23,65,72,74,81,97,117,134,136,137,138,139,144,149,163,165,166,167,171,181,185,187,188,189,190,257,258,259,520,522,524,526,527,528,1025,2304/50,2305,2306/50,30583,65280,65282,65535"
     /*  This filter represents the messages in use by the console.
         It removes all ECEF nav messages as well as parts of nav msg.
         MsgThreadState                23
@@ -426,9 +426,9 @@ static port_whitelist_config_t port_whitelist_config[PORT_MAX] = {
         MsgBaselineHeading           527
         MsgAgeCorrections            528
         MsgLog                      1025
-        MsgImuRaw                   2304
+        MsgImuRaw                   2304/50 (messages decimated by factor of 50)
         MsgImuAux                   2305
-        MsgMagRaw                   2306
+        MsgMagRaw                   2306/50 (messages decimated by factor of 50)
         MsgSbasRaw                 30583
         MsgStartup                 65280
         MsgDgnssStatus             65282


### PR DESCRIPTION
To improve Swift Console responsiveness, and add raw IMU msg back to UART1 to work out of the box with IMU tab in the Swift Console to reduce customer confusion.

@silverjam @denniszollo @nicolekelley 