### PR TITLE
Add an "is duro" flag [ESD-35] [ESD-215]

### DIFF
--- a/package/common_init/overlay/etc/init.d/copy_duro_eeprom.sh
+++ b/package/common_init/overlay/etc/init.d/copy_duro_eeprom.sh
@@ -4,6 +4,7 @@ DURO_EEPROM_PATH="/sys/devices/soc0/amba/e0005000.i2c/i2c-1/1-0050/eeprom"
 DURO_EEPROM_TMP_PATH="/cfg/duro_eeprom.tmp"
 DURO_EEPROM_CFG_PATH="/cfg/duro_eeprom"
 EEPROM_RETRY_DELAY=0.15 # seconds
+DEVICE_DURO_ID_STRING="DUROV"
 
 log_tag=copy_duro_eeprom
 
@@ -46,8 +47,7 @@ copy_duro_eeprom()
   # Downstream systems can either read EEPROM contents or check is_duro flag.
   # pfwp uses is_duro flag as an IPC method to enable can termination setting
 
-  grep -iq duro $DURO_EEPROM_CFG_PATH
-  if [ $? -eq 0 ]; then
+  if grep -q "^${DEVICE_DURO_ID_STRING}" $DURO_EEPROM_CFG_PATH; then
     echo "1" > /etc/flags/is_duro
   else
     echo "0" > /etc/flags/is_duro

--- a/package/common_init/overlay/etc/init.d/copy_duro_eeprom.sh
+++ b/package/common_init/overlay/etc/init.d/copy_duro_eeprom.sh
@@ -41,6 +41,17 @@ copy_duro_eeprom()
   chmod 0644 "$DURO_EEPROM_TMP_PATH"
   logi "Moving $DURO_EEPROM_TMP_PATH to $DURO_EEPROM_CFG_PATH."
   mv $DURO_EEPROM_TMP_PATH $DURO_EEPROM_CFG_PATH
+
+  # Parse eeprom and set is_duro flag if string "duro" appears in eeprom.
+  # Downstream systems can either read EEPROM contents or check is_duro flag.
+  # pfwp uses is_duro flag as an IPC method to enable can termination setting
+
+  grep -iq duro $DURO_EEPROM_CFG_PATH
+  if [ $? -eq 0 ]; then
+    echo "1" > /etc/flags/is_duro
+  else
+    echo "0" > /etc/flags/is_duro
+  fi
 }
 
 copy_duro_eeprom

--- a/package/libpiksi/libpiksi/src/util.c
+++ b/package/libpiksi/libpiksi/src/util.c
@@ -216,7 +216,7 @@ int device_uuid_get(char *str, size_t str_size)
 
 bool device_is_duro(void)
 {
-  char is_duro_flag = '0'; 
+  char is_duro_flag = '0';
   /* Existence of DEVICE_DURO_FLAG_PATH indicates EEPROM
    * has been read or has timed out */
   for (int i = 0; i < DEVICE_DURO_EEPROM_RETRY_TIMES; i++) {

--- a/package/libpiksi/libpiksi/src/util.c
+++ b/package/libpiksi/libpiksi/src/util.c
@@ -41,9 +41,7 @@
 #define DEVICE_HARDWARE_VERSION_FILE_PATH "/factory/hardware_version"
 #define DEVICE_HARDWARE_VERSION_MAX_LENGTH (64u)
 
-#define DEVICE_DURO_EEPROM_PATH "/cfg/duro_eeprom"
-#define DEVICE_DURO_MAX_CONTENTS_SIZE (128u)
-#define DEVICE_DURO_ID_STRING "DUROV0"
+#define DEVICE_DURO_FLAG_PATH "/etc/flags/is_duro"
 #define POSEDAEMON_FILE_PATH "/usr/bin/PoseDaemon.enc"
 #define SMOOTHPOSE_LICENSE_FILE_PATH "/persistent/licenses/smoothpose_license.json"
 #define DEVICE_DURO_EEPROM_RETRY_INTERVAL_MS 250
@@ -218,21 +216,21 @@ int device_uuid_get(char *str, size_t str_size)
 
 bool device_is_duro(void)
 {
-  char duro_eeprom_sig[DEVICE_DURO_MAX_CONTENTS_SIZE];
-  /* DEVICE_DURO_EEPROM_PATH will be created by S18 whether
-   * there is EEPROM or not */
+  char is_duro_flag = '0'; 
+  /* Existence of DEVICE_DURO_FLAG_PATH indicates EEPROM
+   * has been read or has timed out */
   for (int i = 0; i < DEVICE_DURO_EEPROM_RETRY_TIMES; i++) {
-    if (access(DEVICE_DURO_EEPROM_PATH, F_OK) == 0) {
+    if (access(DEVICE_DURO_FLAG_PATH, F_OK) == 0) {
       break;
     }
     usleep(DEVICE_DURO_EEPROM_RETRY_INTERVAL_MS * 1000);
   }
-  if (file_read_string(DEVICE_DURO_EEPROM_PATH, duro_eeprom_sig, sizeof(duro_eeprom_sig)) != 0) {
+  if (file_read_string(DEVICE_DURO_FLAG_PATH, &is_duro_flag, sizeof(is_duro_flag)) != 0) {
     piksi_log(LOG_WARNING, "Failed to read DURO eeprom contents");
     return false;
   }
 
-  return (memcmp(duro_eeprom_sig, DEVICE_DURO_ID_STRING, strlen(DEVICE_DURO_ID_STRING)) == 0);
+  return (is_duro_flag == '1');
 }
 
 static bool device_has_ins(void)


### PR DESCRIPTION
This PR adds a new "is_duro" flag to the new /etc/flags mechanism to communicate Duro status back to the real time firmware in support of can termination.

While at it, I decided to use this same mechanism to determine is Duro in libpiksi.  In this way there is  one-stop shopping and right where EEPROM is copied from filesystem, the string comparison is done.  Rather than look for an exact string, I decided to be forwards compatible to other "duro" values in eeprom which may show up in the future.

The eeprom contents is left in /cfg filesystem as it might prove useful for a new rev of the Piski Multi Hostboard, a customers custom host board, or different DURO SKUs.