### PR TITLE
EX-518: fix GLO L2 indicator decoding

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.74
+GNSS_CONVERTORS_VERSION = bda0e1bf826b11b94bb70bb6706bac48b49b35e8
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = bda0e1bf826b11b94bb70bb6706bac48b49b35e8
+GNSS_CONVERTORS_VERSION = v0.3.75
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES


### PR DESCRIPTION
Pull in https://github.com/swift-nav/gnss-converters/pull/171

Works on bench: decodes GLO L2 observations from the problematic base and produces RTK Fix.