### PR TITLE
EX-524: send NMEA GSA also in Time Matched mode

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.75
+GNSS_CONVERTORS_VERSION = 0f5214390574da0181124298252a004298263518
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = 0f5214390574da0181124298252a004298263518
+GNSS_CONVERTORS_VERSION = 17f6cf95848a7b10c431b3dc10d4746cfab2a7bc
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES


### PR DESCRIPTION
Pulls in https://github.com/swift-nav/gnss-converters/pull/153

Verified on bench in both Low Latency (1Hz and 5Hz) and Time Matched (1Hz) that all NMEA messages get sent at the requested rates.