### PR TITLE
Allow piksi_buildroot to pull custom pfwp versions [ESD-1096]

### DIFF
--- a/fetch_firmware.sh
+++ b/fetch_firmware.sh
@@ -27,12 +27,14 @@ if [[ $(uname -a) == *NixOS* ]]; then
   export LD_LIBRARY_PATH=/lib:/usr/lib
 fi
 
+FW_BUCKET=swiftnav-artifacts
+
 BR_VERSION=$(git describe --abbrev=0 --tags)
 FW_VERSION=${1:-v2.1.0-develop-2019020822}
 NAP_VERSION=${2:-v2.1.0-develop-2019020822}
 
 CCACHE_S3_PATH=s3://swiftnav-artifacts/piksi_buildroot/$BR_VERSION
-FW_S3_PATH=s3://swiftnav-artifacts/piksi_firmware_private/$FW_VERSION/v3
+FW_S3_PATH=s3://$FW_BUCKET/piksi_firmware_private/$FW_VERSION/v3
 NAP_S3_PATH=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION
 NAP_S3_PATH_PROD=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION
 
@@ -70,7 +72,7 @@ if [[ -n "$GENERATE_REQUIREMENTS" ]]; then
   REQUIREMENTS_M4="$D/requirements.yaml.m4"
   REQUIREMENTS_OUT="${REQUIREMENTS_M4%.m4}"
   [[ -f "$REQUIREMENTS_M4" ]] || error "could not find $REQUIREMENTS_M4"
-  m4 -DFW_VERSION=$FW_VERSION -DNAP_VERSION=$NAP_VERSION $REQUIREMENTS_M4 >$REQUIREMENTS_OUT
+  m4 -DFW_BUCKET=$FW_BUCKET -DFW_VERSION=$FW_VERSION -DNAP_VERSION=$NAP_VERSION $REQUIREMENTS_M4 >$REQUIREMENTS_OUT
 elif [[ -n "$DOWNLOAD_PBR_CCACHE" ]]; then
   fetch $CCACHE_S3_PATH/piksi_br_${PBR_TARGET}_ccache.tgz .
 else

--- a/fetch_firmware.sh.m4
+++ b/fetch_firmware.sh.m4
@@ -27,12 +27,14 @@ if [[ $(uname -a) == *NixOS* ]]; then
   export LD_LIBRARY_PATH=/lib:/usr/lib
 fi
 
+FW_BUCKET=M4_BUCKET
+
 BR_VERSION=$(git describe --abbrev=0 --tags)
 FW_VERSION=${1:-M4_FW_VERSION}
 NAP_VERSION=${2:-M4_NAP_VERSION}
 
 CCACHE_S3_PATH=s3://swiftnav-artifacts/piksi_buildroot/$BR_VERSION
-FW_S3_PATH=s3://M4_BUCKET/piksi_firmware_private/$FW_VERSION/v3
+FW_S3_PATH=s3://$FW_BUCKET/piksi_firmware_private/$FW_VERSION/v3
 NAP_S3_PATH=s3://M4_BUCKET/piksi_fpga/$NAP_VERSION
 NAP_S3_PATH_PROD=s3://swiftnav-artifacts/piksi_fpga/$NAP_VERSION
 
@@ -73,7 +75,7 @@ if [[ -n "$GENERATE_REQUIREMENTS" ]]; then
   REQUIREMENTS_M4="$D/requirements.yaml.m4"
   REQUIREMENTS_OUT="${REQUIREMENTS_M4%.m4}"
   [[ -f "$REQUIREMENTS_M4" ]] || error "could not find $REQUIREMENTS_M4"
-  m4 -DFW_VERSION=$FW_VERSION -DNAP_VERSION=$NAP_VERSION $REQUIREMENTS_M4 >$REQUIREMENTS_OUT
+  m4 -DFW_BUCKET=$FW_BUCKET -DFW_VERSION=$FW_VERSION -DNAP_VERSION=$NAP_VERSION $REQUIREMENTS_M4 >$REQUIREMENTS_OUT
 elif [[ -n "$DOWNLOAD_PBR_CCACHE" ]]; then
   fetch $CCACHE_S3_PATH/piksi_br_${PBR_TARGET}_ccache.tgz .
 else

--- a/requirements.yaml.m4
+++ b/requirements.yaml.m4
@@ -8,7 +8,7 @@
         - uImage.piksiv3_prod
   artifacts:
     -
-      bucket: swiftnav-artifacts
+      bucket: FW_BUCKET
       prefix: piksi_firmware_private/FW_VERSION/v3
       files:
         - piksi_firmware_v3_prod.stripped.elf


### PR DESCRIPTION
Allow the bucket that we fetch the firmware from to be manually overridden in the `fetch_firmware.sh` script so that requirement.yaml that gets generated can have a different bucket.  This PR tests these changes: https://github.com/swift-nav/piksi_buildroot/pull/1153.