### PR TITLE
EX-516: Update gnss-convertors, librtcm, libswiftnav to latest tagged branches

### DIFF
--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.37
+LIBRTCM_VERSION = v0.2.38
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/libswiftnav/libswiftnav.mk
+++ b/package/libswiftnav/libswiftnav.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSWIFTNAV_VERSION = v0.1.4
+LIBSWIFTNAV_VERSION = v0.1.5
 LIBSWIFTNAV_SITE = https://github.com/swift-nav/libswiftnav
 LIBSWIFTNAV_SITE_METHOD = git
 LIBSWIFTNAV_INSTALL_STAGING = YES


### PR DESCRIPTION
Update the `librtcm` and `libswiftnav` packages to their latest tagged versions.