### PR TITLE
Close TCP server socket in spawned child processes [ESD-1118]

### DIFF
--- a/package/endpoint_adapter/src/endpoint_adapter.c
+++ b/package/endpoint_adapter/src/endpoint_adapter.c
@@ -845,15 +845,8 @@ static void read_fd_cb(pk_loop_t *loop, void *handle, int status, void *context)
   io_loop_pubsub(loop, &loop_ctx.read_handle, &loop_ctx.pub_handle);
 }
 
-int io_loop_run(int read_fd, int write_fd, bool fork_needed)
+int io_loop_run(int read_fd, int write_fd)
 {
-  if (fork_needed) {
-    pid_t pid = fork();
-    if (pid != 0) {
-      return 0;
-    }
-  }
-
   loop_ctx.loop = pk_loop_create();
   setup_metrics();
 
@@ -943,10 +936,9 @@ int io_loop_run(int read_fd, int write_fd, bool fork_needed)
   pk_loop_destroy(&loop_ctx.loop);
   pk_metrics_destroy(&MR);
 
-  debug_printf("Exiting from pubsub (fork: %s)\n", fork_needed ? "y" : "n");
+  debug_printf("Exiting from io_loop_run ()\n");
 
   if (rc != 0) return IO_LOOP_ERROR;
-  if (fork_needed) return IO_LOOP_STOP;
 
   return IO_LOOP_SUCCESS;
 }

--- a/package/endpoint_adapter/src/endpoint_adapter.h
+++ b/package/endpoint_adapter/src/endpoint_adapter.h
@@ -36,7 +36,7 @@ enum {
   IO_LOOP_SUCCESS = 0,
 };
 
-int io_loop_run(int read_fd, int write_fd, bool fork_needed);
+int io_loop_run(int read_fd, int write_fd);
 
 extern bool debug;
 

--- a/package/endpoint_adapter/src/endpoint_adapter_can.c
+++ b/package/endpoint_adapter/src/endpoint_adapter_can.c
@@ -278,7 +278,7 @@ int can_loop(const char *can_name, u32 can_filter_in)
     pthread_t write_thread;
     pthread_create(&write_thread, NULL, can_write_thread_handler, &write_thread_ctx);
 
-    io_loop_run(pipe_from_can[READ], pipe_to_can[WRITE], /* fork_needed = */ false);
+    io_loop_run(pipe_from_can[READ], pipe_to_can[WRITE]);
 
     close(socket_can);
 

--- a/package/endpoint_adapter/src/endpoint_adapter_file.c
+++ b/package/endpoint_adapter/src/endpoint_adapter_file.c
@@ -68,7 +68,7 @@ int file_loop(const char *file_path, int need_read, int need_write)
     debug_printf("Open %s for write, fd=%d\n", file_path, fd_write);
   }
 
-  io_loop_run(fd_read, fd_write, false);
+  io_loop_run(fd_read, fd_write);
 
   if (need_read) {
     close(fd_read);

--- a/package/endpoint_adapter/src/endpoint_adapter_stdio.c
+++ b/package/endpoint_adapter/src/endpoint_adapter_stdio.c
@@ -14,5 +14,5 @@
 
 int stdio_loop(void)
 {
-  return io_loop_run(STDIN_FILENO, STDOUT_FILENO, false);
+  return io_loop_run(STDIN_FILENO, STDOUT_FILENO);
 }

--- a/package/endpoint_adapter/src/endpoint_adapter_tcp_connect.c
+++ b/package/endpoint_adapter/src/endpoint_adapter_tcp_connect.c
@@ -148,7 +148,7 @@ int tcp_connect_loop(const char *addr)
       return 1;
     }
     int wfd = dup(fd);
-    io_loop_run(fd, wfd, false);
+    io_loop_run(fd, wfd);
     close(fd);
     close(wfd);
   }

--- a/package/endpoint_adapter/src/endpoint_adapter_udp_connect.c
+++ b/package/endpoint_adapter/src/endpoint_adapter_udp_connect.c
@@ -79,7 +79,7 @@ int udp_connect_loop(const char *addr)
       continue;
     }
 
-    io_loop_run(-1, fd, false);
+    io_loop_run(-1, fd);
     close(fd);
   }
 }

--- a/package/endpoint_adapter/src/endpoint_adapter_udp_listen.c
+++ b/package/endpoint_adapter/src/endpoint_adapter_udp_listen.c
@@ -55,7 +55,7 @@ int udp_listen_loop(int port)
     return 1;
   }
 
-  io_loop_run(fd, -1, false);
+  io_loop_run(fd, -1);
   close(fd);
 
   return 0;


### PR DESCRIPTION
endpoint_adaptor uses a common POSIX service pattern of calling fork() to spawn a child process when it receives an incoming connection. The call to fork duplicates all open file descriptors, in this case including the socket the server is listening on for new incoming connections. The new child process should immediately close this duplicated socket, but it doesn't. This means the child process can hold the listening socket open for as long as it exists even though it doesn't use it.

If configuration is changed such that the TCP server moves to a different port and then back to the original while the child process is still holding open the origin socket, the server will be unable to restart.


Solution is to simply close the listening socket in newly spawned child processes.

