### PR TITLE
Add file check for skylark and ntrip enable filepaths [ESD-1135]

### DIFF
--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -21,6 +21,10 @@ ping_log_file=/var/log/ping.log
 
 skylark_enabled()
 {
+  if ! [[ -f $skylark_enabled_file ]]; then
+    return 0
+  fi
+
   if [ x`cat $skylark_enabled_file` != "x0" ]; then
     return 0
   else
@@ -30,6 +34,10 @@ skylark_enabled()
 
 ntrip_enabled()
 {
+  if ! [[ -f $ntrip_enabled_file ]]; then
+    return 0
+  fi
+
   if [ x`cat $ntrip_enabled_file` != "x0" ]; then
     return 0
   else


### PR DESCRIPTION
Since `skylark` client has been removed, reports of `WARNING No route to Internet` have popped up. Makes sense since the file doesn't exist anymore.