### PR TITLE
Output framers, per socket framer for router  [ESD-1139]

### DIFF
--- a/package/common_init/overlay/usr/bin/dump-metrics
+++ b/package/common_init/overlay/usr/bin/dump-metrics
@@ -5,4 +5,4 @@ cd "/var/log/metrics/$1" || exit 1
 find . \
   -type f \
   -not -name '.*' \
-  -exec sh -c 'f=$1; printf "$f: "; cat $f' _ {} \;
+  -exec sh -c 'f=$1; printf "$f: "; flock $f cat $f' _ {} \;

--- a/package/common_init/overlay/usr/bin/watch-metrics
+++ b/package/common_init/overlay/usr/bin/watch-metrics
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-watch -n1 "dump-metrics $1"
+interval=0.5
+watch -n$interval "dump-metrics $1"

--- a/package/endpoint_router/endpoint_router/src/endpoint_router.h
+++ b/package/endpoint_router/endpoint_router/src/endpoint_router.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+typedef struct framer_s framer_t;
+
 typedef enum {
   FILTER_ACTION_ACCEPT, /** A prefix which if matched, will cause data to be forwarded. */
   FILTER_ACTION_REJECT, /** A prefix which if matched, will cause data to be ignored. */
@@ -91,6 +93,7 @@ typedef struct {
   rule_prefixes_t *rule_prefixes;     /** A list of all rule prefixes */
   size_t rule_count;                  /** A count of all rules */
   pk_endpoint_t *sub_ept;             /** The SUB enpoint that feeds this rule cache */
+  framer_t *framer;                   /** The framer associated with this endpoint */
 } rule_cache_t;
 
 typedef struct {

--- a/package/ntrip_daemon/src/ntrip_settings.c
+++ b/package/ntrip_daemon/src/ntrip_settings.c
@@ -98,7 +98,7 @@ static int ntrip_adapter_execfn(void)
   char *argv[] = {
     "endpoint_adapter",
     "--name", "ntrip_daemon",
-    "-f", "rtcm3",
+    "--framer-in", "rtcm3",
     "--file", FIFO_FILE_PATH,
     "-p", "ipc:///var/run/sockets/rtcm3_external.sub",
     NULL,

--- a/package/rtcm3_in_protocol/src/info_rtcm3_in.c
+++ b/package/rtcm3_in_protocol/src/info_rtcm3_in.c
@@ -23,7 +23,7 @@ int port_adapter_opts_get(char *buf, size_t buf_size, const char *port_name)
 {
   return snprintf(buf,
                   buf_size,
-                  "-f rtcm3 "
+                  "--framer-in rtcm3 --framer-out none "
                   "-p 'ipc:///var/run/sockets/rtcm3_external.sub'",
                   port_name);
 }

--- a/package/sbp_protocol/src/framer_sbp.c
+++ b/package/sbp_protocol/src/framer_sbp.c
@@ -64,7 +64,8 @@ static s32 sbp_write(u8 *buff, u32 n, void *context)
 
 void *framer_create(void)
 {
-  framer_sbp_state_t *s = (framer_sbp_state_t *)malloc(sizeof(*s));
+  framer_sbp_state_t *s = calloc(1, sizeof(*s));
+
   if (s == NULL) {
     return NULL;
   }
@@ -109,7 +110,8 @@ uint32_t framer_process(void *state,
                            s->sbp_state.msg_buff,
                            sbp_write)
           == SBP_OK) {
-        *frame = s->send_buffer, *frame_length = c.write_offset;
+        *frame = s->send_buffer;
+        *frame_length = c.write_offset;
         return c.read_offset;
       } else {
         syslog(LOG_ERR, "SBP send error");

--- a/package/sbp_protocol/src/info_sbp.c
+++ b/package/sbp_protocol/src/info_sbp.c
@@ -23,7 +23,7 @@ int port_adapter_opts_get(char *buf, size_t buf_size, const char *port_name)
 {
   return snprintf(buf,
                   buf_size,
-                  "-f sbp "
+                  "--framer-in none --framer-out sbp "
                   "--filter-out sbp "
                   "--filter-out-config /etc/filter_out_config/%s "
                   "-p 'ipc:///var/run/sockets/external.sub' "

--- a/package/skylark_daemon/src/skylark_settings.c
+++ b/package/skylark_daemon/src/skylark_settings.c
@@ -99,7 +99,7 @@ static int skylark_download_adapter_execfn(void)
     "endpoint_adapter",
     "--name",
     "skylark_download",
-    "-f",
+    "--framer-in",
     "sbp",
     "--file",
     DOWNLOAD_FIFO_FILE_PATH,


### PR DESCRIPTION
## Design Notes

+ Allow an output framer to be specified for the `endpoint_adapter` so that the output filter can process individual SBP messages if they arrive "bunched" in a read from the `endpoint_router` (or whatever the adapter is receiving data from).

+ Fix the `handle_write_*_via_framer*` function so that it can process the whole buffer, even if some of the packets are rejected by the filter.  Previously these functions would bail on an entire read buffer if one frame was rejected.

+ Change `endpoint_router` such that there is one framer per "sub" stream in the router-- this means that any data that arrives on a sub stream will have it's own state for framing so partially written data won't conflict with data from another stream.

## Testing

+ Spot checked via bench testing and HITL runs

+ Tested `fileio.py` from `piksi_tools` and the previous (fast) upload speed was restored.