### PR TITLE
Create a flag that represents INS configuration being active [ESD-1065]

### DIFF
--- a/package/common_init/overlay/etc/init.d/S20flags
+++ b/package/common_init/overlay/etc/init.d/S20flags
@@ -19,3 +19,10 @@ elif [[ "$can_ports_enabled" == "False" ]]; then
   echo "0" > /etc/flags/can_ports
 fi
 
+# used by PFWP to determine IMU default
+if detect_piksi_ins; then
+  echo "1" > /etc/flags/ins_active
+else
+  echo "0" > /etc/flags/ins_active
+fi
+

--- a/package/common_init/overlay/etc/init.d/S20flags
+++ b/package/common_init/overlay/etc/init.d/S20flags
@@ -3,6 +3,8 @@
 # initialize flags
 #
 
+source /etc/init.d/common.sh
+
 starling_daemon_enabled=$(query_config --section experimental_flags --key starling_on_linux)
 
 if [[ "$starling_daemon_enabled" == "True" ]]; then


### PR DESCRIPTION
To support https://github.com/swift-nav/piksi_firmware_private/pull/2754

Design:
Use existing `detect_piksi_ins` to create a flag (`/etc/flags/ins_active`) using `S20flags` that allow PFWP to mutate its default IMU output behavior. This should not interfere with any `config.ini` defaults set since the default mutation with happen before registration of the setting. Requires that the flag is created before PFWP starts up which is currently satisfied by the init order.