### PR TITLE
Fix data drops that occurred under heavy load [ESD-1203]

### DIFF
--- a/board/piksiv3/rootfs-overlay/etc/init.d/S83endpoint_adapter_rpmsg_piksi100
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S83endpoint_adapter_rpmsg_piksi100
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-name="endpoint_adapter_rpmsg_piksi100"
-cmd="endpoint_adapter --name rpmsg_piksi100 --file /dev/rpmsg_piksi100 -p 'ipc:///var/run/sockets/firmware.sub' -s 'ipc:///var/run/sockets/firmware.pub'"
-dir="/"
-user="ad_r100"
-priority="-18"
+export name="endpoint_adapter_rpmsg_piksi100"
+
+export cmd="endpoint_adapter\
+ --name rpmsg_piksi100\
+ --framer-in sbp\
+ --file /dev/rpmsg_piksi100\
+ -p 'ipc:///var/run/sockets/firmware.sub'\
+ -s 'ipc:///var/run/sockets/firmware.pub'"
+
+export dir="/"
+export user="ad_r100"
+export priority="-18"
 
 setup_permissions()
 {

--- a/board/piksiv3/rootfs-overlay/etc/init.d/S83endpoint_adapter_rpmsg_piksi101
+++ b/board/piksiv3/rootfs-overlay/etc/init.d/S83endpoint_adapter_rpmsg_piksi101
@@ -1,10 +1,16 @@
 #!/bin/sh
 
-name="endpoint_adapter_rpmsg_piksi101"
-cmd="endpoint_adapter --name rpmsg_piksi101 --file /dev/rpmsg_piksi101 -p 'ipc:///var/run/sockets/nmea_firmware.sub' -s 'ipc:///var/run/sockets/nmea_firmware.pub'"
-dir="/"
-user="ad_r101"
-priority="-18"
+export name="endpoint_adapter_rpmsg_piksi101"
+
+export cmd="endpoint_adapter\
+ --name rpmsg_piksi101\
+ --file /dev/rpmsg_piksi101\
+ -p 'ipc:///var/run/sockets/nmea_firmware.sub'\
+ -s 'ipc:///var/run/sockets/nmea_firmware.pub'"
+
+export dir="/"
+export user="ad_r101"
+export priority="-18"
 
 setup_permissions()
 {
@@ -13,4 +19,3 @@ setup_permissions()
 }
 
 source /etc/init.d/template_runsv.inc.sh
-

--- a/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
+++ b/package/common_init/overlay/etc/init.d/S80endpoint_router_sbp
@@ -24,6 +24,6 @@ else
   router_config="/etc/endpoint_router/sbp_router.yml"
 fi
 
-export cmd="endpoint_router --sbp --name sbp -f $router_config"
+export cmd="endpoint_router --name sbp -f $router_config"
 
 source /etc/init.d/template_runsv.inc.sh

--- a/package/endpoint_adapter/src/endpoint_adapter.c
+++ b/package/endpoint_adapter/src/endpoint_adapter.c
@@ -45,8 +45,8 @@
 #define FILTER_NONE_NAME "none"
 #define METRIC_NAME_LEN 128
 
-/* Sleep for a maximum 10ms while waiting for a send to complete */
-#define MAX_SEND_SLEEP_MS (10)
+/* Sleep for a maximum 1s while waiting for a send to complete */
+#define MAX_SEND_SLEEP_MS (1000)
 #define SEND_SLEEP_NS (100)
 
 #define PROGRAM_NAME "endpoint_adapter"
@@ -612,14 +612,16 @@ static ssize_t fd_write_with_timeout(int handle,
       if (!eagain_warned) {
         PK_LOG_ANNO(LOG_WARNING,
                     "call to write() to send data returned EAGAIN for more than %d ms, "
-                    "dropping %u queued bytes (endpoint ident: %s)",
+                    "%u queued bytes are pending (endpoint ident: %s), max_send_sleep_count: %zu",
                     max_send_sleep_ms,
                     count,
-                    port_name);
+                    port_name,
+                    max_send_sleep_count);
         eagain_warned = true;
       }
       PK_METRICS_UPDATE(MR, MI.bytes_dropped, PK_METRICS_VALUE((u32)count));
-      return count;
+      sleep_count = 0;
+      continue;
     } else {
       return ret;
     }

--- a/package/endpoint_router/endpoint_router.mk
+++ b/package/endpoint_router/endpoint_router.mk
@@ -24,7 +24,7 @@ endef
 
 ifeq    ($(BR2_RUN_TESTS),y) ####
 define ENDPOINT_ROUTER_INSTALL_TARGET_CMDS_TESTS_RUN
-	{ TEST_DATA_DIR=$(ENDPOINT_ROUTER_SITE)/test \
+	{ TEST_DATA_DIR=$(ENDPOINT_ROUTER_SITE)/test TARGET_DIR=$(TARGET_DIR) \
     LD_LIBRARY_PATH=$(TARGET_DIR)/usr/lib \
 			valgrind --track-origins=yes --leak-check=full --error-exitcode=1 \
 				$(TARGET_DIR)/usr/bin/test_endpoint_router; }

--- a/package/endpoint_router/endpoint_router/src/endpoint_router.c
+++ b/package/endpoint_router/endpoint_router/src/endpoint_router.c
@@ -94,7 +94,6 @@ static void usage(char *command)
 
   puts("-f, --file <config.yml>");
   puts("--name <name>");
-  puts("--sbp");
   puts("--print");
   puts("--debug");
 }
@@ -238,33 +237,31 @@ static void cache_match_process(const forwarding_rule_t *forwarding_rule,
 
   assert(length >= rule_cache->rule_prefixes->prefix_len);
 
+  if (rule_cache->hash == NULL) {
+    /* Port only has one accept rule, no need for a hash, incoming packets should
+     *   get picked up by the rule_cache_t->accept_ports list
+     */
+    return;
+  }
+
+  uint32_t key =
+    cmph_search(rule_cache->hash, (const char *)data, rule_cache->rule_prefixes->prefix_len);
+
   switch (filter->action) {
   case FILTER_ACTION_ACCEPT: {
-
-    if (rule_cache->hash != NULL) {
-
-      uint32_t key =
-        cmph_search(rule_cache->hash, (const char *)data, rule_cache->rule_prefixes->prefix_len);
-      rule_cache->cached_ports[key].endpoints[rule_cache->cached_ports[key].count++] =
-        forwarding_rule->dst_port->pub_ept;
-      memcpy(rule_cache->cached_ports[key].prefix, data, rule_cache->rule_prefixes->prefix_len);
-
-    } else {
-      /* Port only has one accept rule, no need for a hash, incoming packets should
-       *   get picked up by the rule_cache_t->accept_ports list
-       */
-    }
-
+    rule_cache->cached_ports[key].endpoints[rule_cache->cached_ports[key].count++] =
+      forwarding_rule->dst_port->pub_ept;
   } break;
-
   case FILTER_ACTION_REJECT: {
-    /* NOOP */
+    rule_cache->cached_ports[key].endpoints[rule_cache->cached_ports[key].count++] =
+      NULL;
   } break;
-
   default: {
     piksi_log(LOG_ERR, "invalid filter action\n");
   } break;
   }
+
+  memcpy(rule_cache->cached_ports[key].prefix, data, rule_cache->rule_prefixes->prefix_len);
 }
 
 static void process_forwarding_rule(const forwarding_rule_t *forwarding_rule,
@@ -359,7 +356,9 @@ static void process_buffer(rule_cache_t *rule_cache, const u8 *data, const size_
   if (memcmp(rule_cache->cached_ports[key].prefix, data, prefix_len) == 0) {
     /* Match, forward to list of rules */
     for (size_t idx = 0; idx < rule_cache->cached_ports[key].count; idx++) {
-      endpoint_send_fn(rule_cache->cached_ports[key].endpoints[idx], data, length);
+      if (rule_cache->cached_ports[key].endpoints[idx] != NULL) {
+        endpoint_send_fn(rule_cache->cached_ports[key].endpoints[idx], data, length);
+      }
     }
   } else {
     /* No match, forward to everything that's default accept */
@@ -857,8 +856,8 @@ int main(int argc, char *argv[])
     exit(cleanup(EXIT_FAILURE, &loop, &router, &router_metrics));
   }
 
-  PK_METRICS_UPDATE(MR, MI.skip_framer, PK_METRICS_VALUE(router->skip_framer_count));
-  PK_METRICS_UPDATE(MR, MI.accept_last, PK_METRICS_VALUE(router->accept_last_count));
+  PK_METRICS_UPDATE(MR, MI.skip_framer, PK_METRICS_VALUE((u32)router->skip_framer_count));
+  PK_METRICS_UPDATE(MR, MI.accept_last, PK_METRICS_VALUE((u32)router->accept_last_count));
 
   /* Print router config and exit if requested */
   if (options.print) {

--- a/package/endpoint_router/endpoint_router/src/endpoint_router.h
+++ b/package/endpoint_router/endpoint_router/src/endpoint_router.h
@@ -24,8 +24,6 @@
 extern "C" {
 #endif
 
-typedef struct framer_s framer_t;
-
 typedef enum {
   FILTER_ACTION_ACCEPT, /** A prefix which if matched, will cause data to be forwarded. */
   FILTER_ACTION_REJECT, /** A prefix which if matched, will cause data to be ignored. */
@@ -39,10 +37,9 @@ typedef struct filter_s {
 } filter_t;
 
 typedef struct forwarding_rule_s {
-  const char *dst_port_name; /** The name of the destination port */
-  struct port_s *dst_port;   /** The port that data will be forwarded to */
-  filter_t *filters_list;    /** The list of filters that will trigger forwarding rule */
-  bool skip_framer;
+  const char *dst_port_name;      /** The name of the destination port */
+  struct port_s *dst_port;        /** The port that data will be forwarded to */
+  filter_t *filters_list;         /** The list of filters that will trigger forwarding rule */
   struct forwarding_rule_s *next; /** The next fowarding fule */
 } forwarding_rule_t;
 
@@ -88,21 +85,17 @@ typedef struct {
   cached_port_t *cached_ports;        /** An array of prefixes with an array of associated ports */
   size_t accept_ports_count;          /** A count of ports that are "accept everything" ports */
   pk_endpoint_t **accept_ports;       /** The actual ports that default to accepting everything  */
-  size_t no_framer_ports_count;       /** Count of the list of ports that skip the framer */
-  pk_endpoint_t **no_framer_ports;    /** List of ports that skip the framer */
   rule_prefixes_t *rule_prefixes;     /** A list of all rule prefixes */
   size_t rule_count;                  /** A count of all rules */
   pk_endpoint_t *sub_ept;             /** The SUB enpoint that feeds this rule cache */
-  framer_t *framer;                   /** The framer associated with this endpoint */
 } rule_cache_t;
 
 typedef struct {
   router_cfg_t *router_cfg;      /** Router config structure */
   rule_cache_t *port_rule_cache; /** A cache structure for each 'SUB' socket in the router config */
   size_t port_count;             /** A count of all SUB ports */
-  size_t skip_framer_count; /** How many rule destination ports within the config skip framing */
-  size_t accept_last_count; /** How many rule destination ports within the config default to an
-                                "accept everything" filter as the last filter. */
+  size_t accept_last_count;      /** How many rule destination ports within the config default to an
+                                     "accept everything" filter as the last filter. */
 } router_t;
 
 void debug_printf(const char *msg, ...);

--- a/package/endpoint_router/endpoint_router/src/endpoint_router_load.c
+++ b/package/endpoint_router/endpoint_router/src/endpoint_router_load.c
@@ -45,7 +45,6 @@ static PROCESS_FN(sub_addr);
 static PROCESS_FN(forwarding_rules_);
 static PROCESS_FN(forwarding_rule_);
 static PROCESS_FN(dst_port);
-static PROCESS_FN(skip_framer);
 static PROCESS_FN(filters);
 static PROCESS_FN(filter);
 static PROCESS_FN(action);
@@ -91,7 +90,6 @@ static expected_event_t forwarding_rules_events[] = {
 static expected_event_t forwarding_rule_events[] = {
   {YAML_SCALAR_EVENT, "dst_port", process_dst_port, true},
   {YAML_SCALAR_EVENT, "filters", process_filters, true},
-  {YAML_SCALAR_EVENT, "skip_framer", process_skip_framer, true},
   {YAML_MAPPING_END_EVENT, NULL, NULL, false},
   {YAML_NO_EVENT, NULL, NULL, false},
 };
@@ -441,7 +439,6 @@ static PROCESS_FN(forwarding_rule_)
     .dst_port_name = "",
     .dst_port = NULL,
     .filters_list = NULL,
-    .skip_framer = false,
     .next = NULL,
   };
 
@@ -476,31 +473,6 @@ static PROCESS_FN(filters)
 
   debug_printf("%s\n", __FUNCTION__);
   return handle_expected_events(parser, filters_events, context);
-}
-
-static PROCESS_FN(skip_framer)
-{
-  (void)event;
-
-  debug_printf("%s\n", __FUNCTION__);
-  router_cfg_t *router = (router_cfg_t *)context;
-
-  forwarding_rule_t *forwarding_rule = current_forwarding_rule_get(router);
-  if (forwarding_rule == NULL) {
-    return -1;
-  }
-
-  char *str;
-  if (event_scalar_value_get(parser, &str) != 0) {
-    return -1;
-  }
-
-  forwarding_rule->skip_framer = str != NULL && strcasecmp(str, "true") == 0;
-  if (str != NULL) free(str);
-
-  debug_printf("value: %s\n", forwarding_rule->skip_framer ? "true" : "false");
-
-  return 0;
 }
 
 static PROCESS_FN(filter)

--- a/package/endpoint_router/endpoint_router/test/endpoint_router_test.cc
+++ b/package/endpoint_router/endpoint_router/test/endpoint_router_test.cc
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <libpiksi/logging.h>
+#include <libpiksi/util.h>
 
 #include "endpoint_router.h"
 #include "endpoint_router_load.h"
@@ -23,6 +24,7 @@
 #define PROGRAM_NAME "router"
 
 static char *test_data_dir;
+static char *target_dir;
 
 class EndpointRouterTests : public ::testing::Test {
 };
@@ -271,6 +273,21 @@ TEST_F(EndpointRouterTests, DedupeRulePrefixes)
   free(rule_cache.accept_ports);
 }
 
+TEST_F(EndpointRouterTests, RunRouter)
+{
+  char command[1024];
+  snprintf_assert(command,
+                  sizeof(command),
+                  "TARGET_DIR=%s TEST_DATA_DIR=%s %s/test_router.bash",
+                  target_dir,
+                  test_data_dir,
+                  test_data_dir);
+
+  int rc = system(command);
+
+  EXPECT_EQ(rc, 0);
+}
+
 int main(int argc, char **argv)
 {
   endpoint_destroy_fn = dummy_pk_endpoint_destroy;
@@ -283,6 +300,9 @@ int main(int argc, char **argv)
 
   test_data_dir = getenv("TEST_DATA_DIR");
   assert(test_data_dir != NULL);
+
+  target_dir = getenv("TARGET_DIR");
+  assert(target_dir != NULL);
 
   int rc = RUN_ALL_TESTS();
 

--- a/package/endpoint_router/endpoint_router/test/run_test.yml
+++ b/package/endpoint_router/endpoint_router/test/run_test.yml
@@ -1,0 +1,109 @@
+name: SBP_ROUTER
+ports:
+
+  - name: SBP_PORT_FIRMWARE
+    metric: "sbp/firmware"
+    pub_addr: "ipc:///tmp/sbp_port_firmware.pub"
+    sub_addr: "ipc:///tmp/sbp_port_firmware.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x61, 0x62, 0x7a] } # Settings register (abz)
+          - { action: REJECT, prefix: [0x61, 0x63, 0x7a] } # File read         (acz)
+          - { action: REJECT, prefix: [0x61, 0x64, 0x7a] } # File read dir     (adz)
+          - { action: REJECT, prefix: [0x61, 0x65, 0x7a] } # File remove       (aez)
+          - { action: REJECT, prefix: [0x61, 0x66, 0x7a] } # File write        (afz)
+          - { action: ACCEPT }
+      - dst_port: SBP_PORT_FILEIO_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x61, 0x63, 0x7a] } # File read         (acz)
+          - { action: ACCEPT, prefix: [0x61, 0x64, 0x7a] } # File read dir     (adz)
+          - { action: ACCEPT, prefix: [0x61, 0x65, 0x7a] } # File remove       (aez)
+          - { action: ACCEPT, prefix: [0x61, 0x66, 0x7a] } # File write        (afz)
+          - { action: REJECT }
+      - dst_port: SBP_PORT_INTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x61, 0x63, 0x7a] } # File read         (acz)
+          - { action: ACCEPT, prefix: [0x61, 0x64, 0x7a] } # File read dir     (adz)
+          - { action: ACCEPT, prefix: [0x61, 0x65, 0x7a] } # File remove       (aez)
+          - { action: ACCEPT, prefix: [0x61, 0x66, 0x7a] } # File write        (afz)
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_EXTERNAL
+    metric: "sbp/external"
+    pub_addr: "ipc:///tmp/sbp_port_external.pub"
+    sub_addr: "ipc:///tmp/sbp_port_external.sub"
+    forwarding_rules:
+
+      - dst_port: SBP_PORT_FILEIO_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x61, 0x63, 0x7a] } # File read               (acz)
+          - { action: ACCEPT, prefix: [0x61, 0x64, 0x7a] } # File read dir           (adz)
+          - { action: ACCEPT, prefix: [0x61, 0x65, 0x7a] } # File remove             (aez)
+          - { action: ACCEPT, prefix: [0x61, 0x66, 0x7a] } # File write              (afz)
+          - { action: ACCEPT }
+
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: REJECT, prefix: [0x61, 0x63, 0x7a] } # File read               (acz)
+          - { action: REJECT, prefix: [0x61, 0x64, 0x7a] } # File read dir           (adz)
+          - { action: REJECT, prefix: [0x61, 0x65, 0x7a] } # File remove             (aez)
+          - { action: REJECT, prefix: [0x61, 0x66, 0x7a] } # File write              (afz)
+          - { action: REJECT, prefix: [0x61, 0x67, 0x7a] } # Settings register       (agz)
+          - { action: REJECT, prefix: [0x61, 0x68, 0x7a] } # Settings read response  (ahz)
+          - { action: ACCEPT }
+
+      - dst_port: SBP_PORT_INTERNAL
+        filters:
+          - { action: REJECT, prefix: [0x61, 0x63, 0x7a] } # File read               (acz)
+          - { action: REJECT, prefix: [0x61, 0x64, 0x7a] } # File read dir           (adz)
+          - { action: REJECT, prefix: [0x61, 0x65, 0x7a] } # File remove             (aez)
+          - { action: REJECT, prefix: [0x61, 0x66, 0x7a] } # File write              (afz)
+          - { action: ACCEPT }
+
+      - dst_port: SBP_PORT_SETTINGS_CLIENT
+        filters:
+          - { action: ACCEPT, prefix: [0x61, 0x69, 0x7a] } # Settings write
+          - { action: REJECT }
+
+  - name: SBP_PORT_FILEIO_FIRMWARE
+    metric: "sbp/fileio_fw"
+    pub_addr: "ipc:///tmp/sbp_port_fileio_firmware.pub"
+    sub_addr: "ipc:///tmp/sbp_port_fileio_firmware.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_FILEIO_EXTERNAL
+    metric: "sbp/fileio_ex"
+    pub_addr: "ipc:///tmp/sbp_port_fileio_external.pub"
+    sub_addr: "ipc:///tmp/sbp_port_fileio_external.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT }
+
+
+  - name: SBP_PORT_INTERNAL
+    metric: "sbp/internal"
+    pub_addr: "ipc:///tmp/sbp_port_internal.pub"
+    sub_addr: "ipc:///tmp/sbp_port_internal.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT }
+
+  - name: SBP_PORT_SETTINGS_CLIENT
+    metric: "sbp/settings_client"
+    pub_addr: "ipc:///tmp/sbp_port_settings_client.pub"
+    sub_addr: "ipc:///tmp/sbp_port_settings_client.sub"
+    forwarding_rules:
+      - dst_port: SBP_PORT_EXTERNAL
+        filters:
+          - { action: ACCEPT, prefix: [0x61, 0x70, 0x7a] } # Settings write response
+          - { action: REJECT }
+      - dst_port: SBP_PORT_FIRMWARE
+        filters:
+          - { action: ACCEPT, prefix: [0x61, 0x70, 0x7a] } # Settings write response
+          - { action: REJECT }

--- a/package/endpoint_router/endpoint_router/test/sbp_router_full.yml
+++ b/package/endpoint_router/endpoint_router/test/sbp_router_full.yml
@@ -82,7 +82,6 @@ ports:
           - { action: REJECT, prefix: [0x55, 0xA5, 0x00] } # Settings read response
           - { action: ACCEPT }
       - dst_port: SBP_PORT_FILEIO_EXTERNAL
-        skip_framer: true # Whole "blobs" are copied to the port before being deframed
         filters:
           - { action: ACCEPT }
       - dst_port: SBP_PORT_INTERNAL

--- a/package/endpoint_router/endpoint_router/test/test_router.bash
+++ b/package/endpoint_router/endpoint_router/test/test_router.bash
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+#set -x
+
+set -euo pipefail
+IFS=$'\n\t'
+
+[[ -n "${TEST_DATA_DIR:-}" ]] || { echo "ERROR: TEST_DATA_DIR must not be empty" >&2; exit 1; }
+[[ -n "${TARGET_DIR:-}" ]] || { echo "ERROR: TARGET_DIR must not be empty" >&2; exit 1; }
+
+echo '<<<< ' Starting scripted test ...
+
+red=$(echo -ne "\e[91m")
+grn=$(echo -ne "\e[36m")
+rst=$(echo -ne "\e[0m")
+
+pass_color() {
+  echo "${grn}$*${rst}"
+}
+
+fail_color() {
+  echo "${red}$*${rst}"
+}
+
+export PK_METRICS_PATH=/tmp/endpoint_router.metrics
+
+rm -rf $PK_METRICS_PATH
+mkdir $PK_METRICS_PATH
+
+export PK_METRICS_PATH=$PK_METRICS_PATH
+
+"$TARGET_DIR"/usr/bin/endpoint_router -f "$TEST_DATA_DIR"/run_test.yml --name test_router &
+router_pid=$!
+
+declare -a socat_list
+declare -A socat_map
+
+next_fifo_fd=9
+
+setup_socat()
+{
+  local n=$1
+
+  socat_list+=("$n")
+
+  socat_map[inp_$n]=/tmp/sbp_port_$n.inp
+  socat_map[out_$n]=/tmp/sbp_port_$n.out
+  socat_map[pub_$n]=/tmp/sbp_port_$n.pub
+  socat_map[sub_$n]=/tmp/sbp_port_$n.sub
+  socat_map[fd_$n]=$next_fifo_fd
+
+  next_fifo_fd=$(( next_fifo_fd + 1 ))
+
+  local inp="${socat_map[inp_$n]}"
+  local out="${socat_map[out_$n]}"
+  local fd="${socat_map[fd_$n]}"
+  local pub="${socat_map[pub_$n]}"
+  local sub="${socat_map[sub_$n]}"
+  
+  rm -f "$inp" "$out"
+
+  # Bind FD to the fifo so it'll stay open as we write messages
+  mkfifo "$inp"
+  eval "exec $fd<>$inp"
+
+  socat -u FILE:/dev/stdin UNIX-CONNECT:"$sub",type=5 <"$inp" &
+  socat_map[inp_pid_$n]=$!
+
+  socat -u unix-connect:"$pub",type=5 file:/dev/stdout >"$out" &
+  socat_map[out_pid_$n]=$!
+}
+
+send_message()
+{
+  local n=$1; shift
+  local msg=$1; shift
+
+  local inp="${socat_map[inp_$n]}"
+
+  echo "$msg" >"$inp"
+}
+
+output_file()
+{
+  local n=$1
+  echo "${socat_map[out_$n]}"
+}
+
+cleanup_one()
+{
+  local n=$1
+
+  local inp="${socat_map[inp_$n]}"
+  local out="${socat_map[out_$n]}"
+  local fd="${socat_map[fd_$n]}"
+  local pub="${socat_map[pub_$n]}"
+  local sub="${socat_map[sub_$n]}"
+  local inp_pid="${socat_map[inp_pid_$n]}"
+  local out_pid="${socat_map[out_pid_$n]}"
+
+  eval "exec $fd<&-"
+
+  rm $inp $out $pub $sub
+
+  kill $inp_pid $out_pid
+  wait $inp_pid $out_pid
+}
+
+cleanup_all()
+{
+  set +e && echo -n '>>>> ' Cleaning up ...
+
+  for n in ${socat_list[*]}; do
+    cleanup_one "$n"
+  done
+
+  kill $router_pid
+  wait $router_pid &>/dev/null
+
+  echo " DONE"
+}
+
+trap 'cleanup_all' EXIT
+
+run_test()
+{
+  local test_func=$1; shift
+  local succ_msg=$1; shift
+  local fail_msg=$1; shift
+
+  if "$test_func"; then
+    echo "$(pass_color PASS): ${succ_msg}"
+  else
+    echo "$(fail_color FAIL): ${fail_msg}"
+    exit 1
+  fi
+}
+
+main()
+{
+  ### Firmware socket ###
+  setup_socat "firmware"
+
+  ### Firmware FileIO socket ###
+  setup_socat "fileio_firmware"
+
+  ### External socket ###
+  setup_socat "external"
+
+  ### External socket ###
+  setup_socat "fileio_external"
+
+  local file_read=acz
+  local file_read_dir=adz
+  local other=qqq
+  local pad=xxxxxyyyy
+
+  ## Allow things time to setup...
+  sleep 0.2
+
+  ### TEST: if firmware sends a FileIO req it should show up on fw_fileio pub socket ###
+  test_1() {
+    local fw_fileio_msg=${file_read}${pad}001
+    send_message "firmware" "$fw_fileio_msg"
+    grep -q "$fw_fileio_msg" "$(output_file "fileio_firmware")"
+  }
+
+  run_test test_1 \
+    "firmware fileio message DID go to fileio daemon" \
+    "firmware fileio message DID NOT go to fileio daemon"
+
+  ### TEST: if fileio gets sent to external, it should not show up on the fileio socket ###
+  test_2() {
+    local ext_fileio_msg=${file_read_dir}${pad}002
+    send_message "external" "$ext_fileio_msg"
+    grep -q "$ext_fileio_msg" "$(output_file "firmware")" && return 1
+    grep -q "$ext_fileio_msg" "$(output_file "fileio_external")" && return 0
+  }
+
+  run_test test_2 \
+    "external fileio message DID NOT go to firmware" \
+    "external fileio message DID go to firmware"
+
+
+  ### TEST: Other messages should show up as input to the firmware port ###
+
+  test_3() {
+    local other_msg=${other}${pad}003
+    send_message "external" ${other_msg}
+    grep -q "$other_msg" "$(output_file "firmware")"
+  }
+
+  run_test test_3 \
+    "external 'other' message DID go to firmware port" \
+    "external 'other' message DID NOT go to firmware port"
+
+  test_4() {
+    local fw_fileio_msg=${file_read_dir}${pad}004
+    send_message "firmware" ${fw_fileio_msg}
+    grep -q "$fw_fileio_msg" "$(output_file "fileio_firmware")"
+  }
+
+  run_test test_4 \
+    "firmware fileio message DID go to firmware fileio port" \
+    "firmware fileio message DID NOT go to firmware fileio port"
+}
+
+main

--- a/package/libpiksi/libpiksi/src/metrics.c
+++ b/package/libpiksi/libpiksi/src/metrics.c
@@ -37,6 +37,8 @@
 
 #define NEW_DIR_MODE (0777)
 
+static const char *default_metrics_path = METRICS_PATH;
+
 typedef struct {
   pk_metrics_type_t type;
   pk_metrics_updater_fn_t update_fn;
@@ -183,8 +185,12 @@ ssize_t pk_metrics_add(pk_metrics_t *metrics,
 
   metrics_descriptor_t *desc = &metrics->descriptors[metrics->count];
 
+  const char *env_metrics_path = getenv("PK_METRICS_PATH");
+  const char *metrics_base_path =
+    env_metrics_path != NULL ? env_metrics_path : default_metrics_path;
+
   char metric_dir_path[PATH_MAX];
-  int res = snprintf(metric_dir_path, sizeof(metric_dir_path), "%s/%s", METRICS_PATH, path);
+  int res = snprintf(metric_dir_path, sizeof(metric_dir_path), "%s/%s", metrics_base_path, path);
 
   if (res < 0) {
     PK_LOG_ANNO(LOG_ERR, "metrics add failed: %s", strerror(errno));

--- a/package/rpmsg_piksi/src/rpmsg_piksi.c
+++ b/package/rpmsg_piksi/src/rpmsg_piksi.c
@@ -286,6 +286,10 @@ static void ept_rpmsg_cb(struct rpmsg_channel *rpdev, void *data, int len, void 
   len_in = kfifo_in(&ept_params->rx_fifo, data, (unsigned int)len);
   if (len_in != len) {
     /* There was no space for incoming data */
+    dev_err(ept_params->device,
+            "rx data truncated, incoming count = %d, copied count = %d\n",
+            len,
+            len_in);
     return;
   }
 

--- a/package/sbp_protocol/src/info_sbp.c
+++ b/package/sbp_protocol/src/info_sbp.c
@@ -23,7 +23,7 @@ int port_adapter_opts_get(char *buf, size_t buf_size, const char *port_name)
 {
   return snprintf(buf,
                   buf_size,
-                  "--framer-in none --framer-out sbp "
+                  "--framer-in sbp --framer-out sbp "
                   "--filter-out sbp "
                   "--filter-out-config /etc/filter_out_config/%s "
                   "-p 'ipc:///var/run/sockets/external.sub' "

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -91,10 +91,9 @@ ports:
     pub_addr: "ipc:///var/run/sockets/external.pub"
     sub_addr: "ipc:///var/run/sockets/external.sub"
     forwarding_rules:
-
       - dst_port: SBP_PORT_FILEIO_EXTERNAL
-        skip_framer: true
-
+        filters:
+          - { action: ACCEPT }
       - dst_port: SBP_PORT_FIRMWARE
         filters:
           - { action: REJECT, prefix: [0x55, 0xA8, 0x00] } # File read
@@ -144,7 +143,8 @@ ports:
     sub_addr: "ipc:///var/run/sockets/fileio_external.sub"
     forwarding_rules:
       - dst_port: SBP_PORT_EXTERNAL
-        skip_framer: true
+        filters:
+          - { action: ACCEPT }
 
   - name: SBP_PORT_INTERNAL
     metric: "sbp/internal"


### PR DESCRIPTION
## Design Notes

Addresses a number of messaging issues that can occur under heavy load, primarily we're removing framing support from `endpoint_router` and moving it back into `endpoint_adapter`.  An output framer was also added to the endpoint that receives data from rpmsg, there's a remote possibility that data from the RTOS would be truncated in a particular read if we're under (very) heavy load.

## Testing

Bench testing and HITL smoke tests.  Testing scenario as follows: (1) start a file upload while Piksi is receiving corrections from a NTRIP service (2) observe that occasionally the console would report packets dropped because one of a sequence of remote obs would be missing.

Apart from the console, remote Piksi obs can be sampled using the following script:
```sh
socat tcp:$THE_PIKSI:55555 - | sbp2json  | jq -r --unbuffered -c 'select(.msg_type==74 and .sender==0) | .header.n_obs'|python3 -u n_obs.py
```

The `n_ops.py` script would break apart the `sequence` field to get the `N/M` form of the obs message:
```py
import sys
for line in sys.stdin:
    line = line.strip()
    X = int(line)
    index = X & ((1 << 4) - 1)
    total = int(X) >> 4
    print((line, index, total,))
```

Then a `validate_obs.py` script was used to make sure no obs messages were missing:
```py
import sys
def _process_obs(obs):
    last_count = None
    for idx, (_, the_ob, _) in enumerate(obs):
        if (last_count is not None
                and the_ob != 0 and (last_count + 1) != the_ob):
            print(idx)
        last_count = the_ob
_process_obs(eval(X) for X in iter(sys.stdin))
```

## To-do
- [x] Add unit test for endpoint_router reject rules
- [x] Fix unit tests for drop of "skip_framer" field