### PR TITLE
FileIO "bypass" support [ESD-1203]

### DIFF
--- a/package/common_init/overlay/etc/init.d/S09sysctl
+++ b/package/common_init/overlay/etc/init.d/S09sysctl
@@ -5,6 +5,8 @@ mkdir -p /var/run/fifos
 chmod 1777 /var/run/fifos
 mkdir -p /var/run/sockets
 chmod 1777 /var/run/sockets
+mkdir -p /var/run/sockets/fileio
+chmod 1777 /var/run/sockets/fileio
 mkdir -p /var/log/metrics
 chmod 1777 /var/log/metrics
 echo "denyinterfaces eth0" >> /etc/dhcpcd.conf

--- a/package/endpoint_adapter/src/endpoint_adapter.c
+++ b/package/endpoint_adapter/src/endpoint_adapter.c
@@ -84,7 +84,17 @@ PK_METRICS_TABLE(MT, MI,
   PK_METRICS_ENTRY("tx/write/count",           "per_second",     M_U32,         M_UPDATE_COUNT,   M_RESET_DEF, tx_write_count),
   PK_METRICS_ENTRY("tx/write/size/per_second", "total",          M_U32,         M_UPDATE_SUM,     M_RESET_DEF, tx_write_size_total),
   PK_METRICS_ENTRY("tx/write/size/per_second", "average",        M_U32,         M_UPDATE_AVERAGE, M_RESET_DEF, tx_write_size_average,
-                   M_AVERAGE_OF(MI,         tx_write_size_total, tx_write_count))
+                   M_AVERAGE_OF(MI,         tx_write_size_total, tx_write_count)),
+
+  PK_METRICS_ENTRY("alt/read/count",           "per_second",     M_U32,         M_UPDATE_COUNT,   M_RESET_DEF, alt_read_count),
+  PK_METRICS_ENTRY("alt/read/size/per_second", "total",          M_U32,         M_UPDATE_SUM,     M_RESET_DEF, alt_read_size_total),
+  PK_METRICS_ENTRY("alt/read/size/per_second", "average",        M_U32,         M_UPDATE_AVERAGE, M_RESET_DEF, alt_read_size_average,
+                   M_AVERAGE_OF(MI,         alt_read_size_total, alt_read_count)),
+
+  PK_METRICS_ENTRY("alt/write/count",          "per_second",     M_U32,         M_UPDATE_COUNT,   M_RESET_DEF, alt_write_count),
+  PK_METRICS_ENTRY("alt/write/size/per_second","total",          M_U32,         M_UPDATE_SUM,     M_RESET_DEF, alt_write_size_total),
+  PK_METRICS_ENTRY("alt/write/size/per_second","average",        M_U32,         M_UPDATE_AVERAGE, M_RESET_DEF, alt_write_size_average,
+                   M_AVERAGE_OF(MI,         alt_write_size_total,alt_write_count))
 )
 /* clang-format on */
 
@@ -128,6 +138,9 @@ static void setup_metrics();
 
 static void die_error(const char *error);
 
+static ssize_t handle_write_all_via_framer(handle_t *handle, const uint8_t *buffer, size_t bufsize);
+static void handle_alt_write(handle_t *handle, const uint8_t *buffer, size_t count);
+
 typedef ssize_t (*read_fn_t)(handle_t *handle, void *buffer, size_t count);
 typedef ssize_t (*write_fn_t)(handle_t *handle, const void *buffer, size_t count);
 
@@ -136,13 +149,17 @@ typedef ssize_t (*read_buf_cb_t)(handle_t *read_handle, handle_t *write_handle, 
 static struct {
   pk_loop_t *loop;
   void *loop_sub_handle;
+  void *loop_alt_sub_handle;
   void *read_fd_handle;
   pk_endpoint_t *pub_ept;
   pk_endpoint_t *sub_ept;
+  pk_endpoint_t *alt_pub_ept;
+  pk_endpoint_t *alt_sub_ept;
   handle_t pub_handle;
   handle_t sub_handle;
   handle_t read_handle;
   handle_t write_handle;
+  handle_t alt_sub_handle;
 } loop_ctx;
 
 typedef struct {
@@ -168,6 +185,8 @@ static bool nonblock = false;
 static int outq;
 static const char *pub_addr = NULL;
 static const char *sub_addr = NULL;
+static const char *alt_pub_addr = NULL;
+static const char *alt_sub_addr = NULL;
 static const char *port_name = NULL;
 static char file_path[PATH_MAX] = "";
 static int tcp_listen_port = -1;
@@ -216,6 +235,10 @@ static void usage(char *command)
   fprintf(stderr, "\t--can <can_id>\n");
   fprintf(stderr, "\t--can-f <can_filter>\n");
 
+  fprintf(stderr, "\nAlternate pub/sub sockets - select one or more\n");
+  fprintf(stderr, "\t--pub2 <ipc_path>\n");
+  fprintf(stderr, "\t--sub2 <ipc_path>\n");
+
   fprintf(stderr, "\nMisc options\n");
   fprintf(stderr, "\t--startup-delay <ms>\n");
   fprintf(stderr, "\t\ttime to delay after opening a socket\n");
@@ -251,6 +274,8 @@ static int parse_options(int argc, char *argv[])
     OPT_ID_RETRY_PUBSUB,
     OPT_ID_FRAMER_IN,
     OPT_ID_FRAMER_OUT,
+    OPT_ID_BYPASS_PUB,
+    OPT_ID_BYPASS_SUB,
   };
 
   /* clang-format off */
@@ -277,6 +302,8 @@ static int parse_options(int argc, char *argv[])
     {"can",               required_argument, 0, OPT_ID_CAN},
     {"can-f",             required_argument, 0, OPT_ID_CAN_FILTER},
     {"retry",             no_argument,       0, OPT_ID_RETRY_PUBSUB},
+    {"pub2",              required_argument, 0, OPT_ID_BYPASS_PUB},
+    {"sub2",              required_argument, 0, OPT_ID_BYPASS_SUB},
     {0, 0, 0, 0},
   };
   /* clang-format on */
@@ -381,6 +408,14 @@ static int parse_options(int argc, char *argv[])
     case 's': {
       endpoint_mode = ENDPOINT_PUBSUB;
       sub_addr = optarg;
+    } break;
+
+    case OPT_ID_BYPASS_PUB: {
+      alt_pub_addr = optarg;
+    } break;
+
+    case OPT_ID_BYPASS_SUB: {
+      alt_sub_addr = optarg;
     } break;
 
     case OPT_ID_FRAMER_IN: {
@@ -505,20 +540,22 @@ static int handle_init(handle_t *handle,
   return 0;
 }
 
-static pk_endpoint_t *pk_endpoint_start(int type)
+static pk_endpoint_t *endpoint_start(pk_endpoint_type type, bool alt)
 {
   char metric_name[METRIC_NAME_LEN] = {0};
+
   const char *addr = NULL;
+  const char *alt_metric = alt ? "/alt" : "";
 
   switch (type) {
   case PK_ENDPOINT_PUB: {
-    addr = pub_addr;
-    snprintf_assert(metric_name, sizeof(metric_name), "adapter/%s/pub", port_name);
+    addr = alt ? alt_pub_addr : pub_addr;
+    snprintf_assert(metric_name, sizeof(metric_name), "adapter/%s%s/pub", port_name, alt_metric);
   } break;
 
   case PK_ENDPOINT_SUB: {
-    addr = sub_addr;
-    snprintf_assert(metric_name, sizeof(metric_name), "adapter/%s/sub", port_name);
+    addr = alt ? alt_sub_addr : sub_addr;
+    snprintf_assert(metric_name, sizeof(metric_name), "adapter/%s%s/sub", port_name, alt_metric);
   } break;
 
   default: {
@@ -640,14 +677,19 @@ static ssize_t fd_write(int handle, const void *buffer, size_t count)
   return fd_write_with_timeout(handle, buffer, count, MAX_SEND_SLEEP_MS, SEND_SLEEP_NS);
 }
 
-static ssize_t handle_write_all_via_framer(handle_t *handle, const uint8_t *buffer, size_t count);
-
 static ssize_t process_read_buffer(handle_t *read_handle,
                                    handle_t *write_handle,
                                    uint8_t *buffer,
                                    size_t length)
 {
-  UPDATE_IO_LOOP_METRIC(read_handle, MI.rx_read_count, MI.tx_read_count);
+  if (read_handle->pk_ept != NULL && read_handle->pk_ept == loop_ctx.alt_sub_ept) {
+    /* Update "alt" read metrics metric update */
+    PK_METRICS_UPDATE(MR, MI.alt_read_count);
+    PK_METRICS_UPDATE(MR, MI.alt_read_size_total, PK_METRICS_VALUE((u32)length));
+  } else {
+    /* Normal metric update */
+    UPDATE_IO_LOOP_METRIC(read_handle, MI.rx_read_count, MI.tx_read_count);
+  }
 
   ssize_t write_count = handle_write_all_via_framer(write_handle, buffer, length);
 
@@ -660,6 +702,8 @@ static ssize_t process_read_buffer(handle_t *read_handle,
     PK_LOG_ANNO(LOG_ERR, "input vs output mismatch: data read (%d) != data written(%d)");
     PK_METRICS_UPDATE(MR, MI.mismatch);
   }
+
+  handle_alt_write(write_handle, buffer, length);
 
   return length;
 }
@@ -676,6 +720,19 @@ static int sub_ept_read(const uint8_t *buff, size_t length, void *context)
   }
 
   return read_ctx->status;
+}
+
+static void handle_alt_write(handle_t *handle, const uint8_t *buffer, size_t count)
+{
+  if (handle->pk_ept != NULL && loop_ctx.alt_pub_ept != NULL) {
+
+    PK_METRICS_UPDATE(MR, MI.alt_write_count);
+    PK_METRICS_UPDATE(MR, MI.alt_write_size_total, PK_METRICS_VALUE((u32)count));
+
+    if (pk_endpoint_send(loop_ctx.alt_pub_ept, buffer, count) != 0) {
+      PK_LOG_ANNO(LOG_WARNING, "alt write failed");
+    }
+  }
 }
 
 static ssize_t handle_write(handle_t *handle, const uint8_t *buffer, size_t count)
@@ -778,7 +835,7 @@ static void io_loop_pubsub(pk_loop_t *loop, handle_t *read_handle, handle_t *wri
       .write_handle = write_handle,
       .read_buf_cb = process_read_buffer,
     };
-    rc = pk_endpoint_receive(loop_ctx.sub_ept, sub_ept_read, &read_ctx);
+    rc = pk_endpoint_receive(read_handle->pk_ept, sub_ept_read, &read_ctx);
     if (rc != 0) {
       PK_LOG_ANNO(LOG_WARNING, "pk_endpoint_receive returned error: %d", rc);
     } else if (read_ctx.status == 0) {
@@ -818,6 +875,9 @@ static void timer_handler(pk_loop_t *loop, void *handle, int status, void *conte
   PK_METRICS_UPDATE(MR, MI.tx_read_size_average);
   PK_METRICS_UPDATE(MR, MI.tx_write_size_average);
 
+  PK_METRICS_UPDATE(MR, MI.alt_read_size_average);
+  PK_METRICS_UPDATE(MR, MI.alt_write_size_average);
+
   pk_metrics_flush(MR);
 
   pk_metrics_reset(MR, MI.bytes_dropped);
@@ -838,6 +898,14 @@ static void timer_handler(pk_loop_t *loop, void *handle, int status, void *conte
   pk_metrics_reset(MR, MI.tx_write_count);
   pk_metrics_reset(MR, MI.tx_write_size_total);
   pk_metrics_reset(MR, MI.tx_write_size_average);
+
+  pk_metrics_reset(MR, MI.alt_read_count);
+  pk_metrics_reset(MR, MI.alt_read_size_total);
+  pk_metrics_reset(MR, MI.alt_read_size_average);
+
+  pk_metrics_reset(MR, MI.alt_write_count);
+  pk_metrics_reset(MR, MI.alt_write_size_total);
+  pk_metrics_reset(MR, MI.alt_write_size_average);
 
   eagain_warned = false;
 }
@@ -894,11 +962,16 @@ static bool handle_loop_status(pk_loop_t *loop, int status)
 static void sub_reader_cb(pk_loop_t *loop, void *handle, int status, void *context)
 {
   (void)handle;
-  (void)context;
+  pk_endpoint_t *sub_ept = context;
 
   if (!handle_loop_status(loop, status)) return;
 
-  io_loop_pubsub(loop_ctx.loop, &loop_ctx.sub_handle, &loop_ctx.write_handle);
+  if (sub_ept == loop_ctx.sub_ept) {
+    io_loop_pubsub(loop_ctx.loop, &loop_ctx.sub_handle, &loop_ctx.write_handle);
+  } else {
+    assert(sub_ept == loop_ctx.alt_sub_ept);
+    io_loop_pubsub(loop_ctx.loop, &loop_ctx.alt_sub_handle, &loop_ctx.write_handle);
+  }
 }
 
 static void read_fd_cb(pk_loop_t *loop, void *handle, int status, void *context)
@@ -914,6 +987,10 @@ static void read_fd_cb(pk_loop_t *loop, void *handle, int status, void *context)
 int io_loop_run(int read_fd, int write_fd)
 {
   loop_ctx.loop = pk_loop_create();
+
+  loop_ctx.alt_pub_ept = NULL;
+  loop_ctx.alt_sub_ept = NULL;
+
   setup_metrics();
 
   void *handle = pk_loop_timer_add(loop_ctx.loop, 1000, timer_handler, NULL);
@@ -921,9 +998,9 @@ int io_loop_run(int read_fd, int write_fd)
 
   if (pub_addr != NULL && read_fd != -1) {
 
-    loop_ctx.pub_ept = pk_endpoint_start(PK_ENDPOINT_PUB);
+    loop_ctx.pub_ept = endpoint_start(PK_ENDPOINT_PUB, false);
     if (loop_ctx.pub_ept == NULL) {
-      die_error("pk_endpoint_start(PK_ENDPOINT_PUB) returned NULL\n");
+      die_error("endpoint_start(PK_ENDPOINT_PUB, false) returned NULL\n");
     }
 
     loop_ctx.read_fd_handle = pk_loop_poll_add(loop_ctx.loop, read_fd, read_fd_cb, NULL);
@@ -955,15 +1032,23 @@ int io_loop_run(int read_fd, int write_fd)
     }
   }
 
+  if (alt_pub_addr != NULL) {
+    debug_printf("setting up alt pub socket");
+    loop_ctx.alt_pub_ept = endpoint_start(PK_ENDPOINT_PUB, true);
+    if (loop_ctx.alt_pub_ept == NULL) {
+      die_error("endpoint_start(PK_ENDPOINT_PUB, true) returned NULL\n");
+    }
+  }
+
   if (sub_addr != NULL && write_fd != -1) {
 
-    loop_ctx.sub_ept = pk_endpoint_start(PK_ENDPOINT_SUB);
+    loop_ctx.sub_ept = endpoint_start(PK_ENDPOINT_SUB, false);
     if (loop_ctx.sub_ept == NULL) {
-      die_error("pk_endpoint_start(PK_ENDPOINT_SUB) returned NULL");
+      die_error("endpoint_start(PK_ENDPOINT_SUB, false) returned NULL");
     }
 
     loop_ctx.loop_sub_handle =
-      pk_loop_endpoint_reader_add(loop_ctx.loop, loop_ctx.sub_ept, sub_reader_cb, NULL);
+      pk_loop_endpoint_reader_add(loop_ctx.loop, loop_ctx.sub_ept, sub_reader_cb, loop_ctx.sub_ept);
 
     if (handle_init(&loop_ctx.sub_handle,
                     loop_ctx.sub_ept,
@@ -985,6 +1070,32 @@ int io_loop_run(int read_fd, int write_fd)
                     filter_out_config)
         != 0) {
       die_error("handle_init for write_fd returned error\n");
+    }
+  }
+
+  if (alt_sub_addr != NULL) {
+
+    debug_printf("setting up alt sub socket");
+
+    loop_ctx.alt_sub_ept = endpoint_start(PK_ENDPOINT_SUB, true);
+    if (loop_ctx.alt_sub_ept == NULL) {
+      die_error("endpoint_start(PK_ENDPOINT_PUB, true) returned NULL\n");
+    }
+
+    loop_ctx.loop_alt_sub_handle = pk_loop_endpoint_reader_add(loop_ctx.loop,
+                                                               loop_ctx.alt_sub_ept,
+                                                               sub_reader_cb,
+                                                               loop_ctx.alt_sub_ept);
+
+    if (handle_init(&loop_ctx.alt_sub_handle,
+                    loop_ctx.alt_sub_ept,
+                    -1,
+                    -1,
+                    FRAMER_NONE_NAME,
+                    FILTER_NONE_NAME,
+                    NULL)
+        != 0) {
+      die_error("handle_init for sub returned error\n");
     }
   }
 

--- a/package/libpiksi/libpiksi/include/libpiksi/sbp_pubsub.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/sbp_pubsub.h
@@ -58,6 +58,29 @@ typedef struct sbp_pubsub_ctx_s sbp_pubsub_ctx_t;
 sbp_pubsub_ctx_t *sbp_pubsub_create(const char *ident, const char *pub_ept, const char *sub_ept);
 
 /**
+ * @brief   Create an SBP PUB/SUB context.
+ * @details Create and initialize an SBP PUB/SUB context. This is a
+ *          helper module used to set up a typical configuration consisting of
+ *          the following:
+ *          @li SBP TX context
+ *          @li SBP RX context
+ *          @li SBP PUB socket, associated with the TX context
+ *          @li SBP SUB socket, associated with the RX context
+ *
+ * @param[in] ident         The identity of this pub/sub pair, typically used for metrics.
+ * @param[in] pub_ept       String describing the SBP PUB endpoint to use.
+ * @param[in] sub_ept       String describing the SBP SUB endpoint to use.
+ * @param[in] server        Is this a server socket?
+ *
+ * @return                  Pointer to the created context, or NULL if the
+ *                          operation failed.
+ */
+sbp_pubsub_ctx_t *sbp_pubsub_create_ex(const char *ident,
+                                       const char *pub_ept,
+                                       const char *sub_ept,
+                                       bool server);
+
+/**
  * @brief   Destroy an SBP PUB/SUB context.
  * @details Deinitialize and destroy an SBP PUB/SUB context.
  *
@@ -88,6 +111,26 @@ sbp_tx_ctx_t *sbp_pubsub_tx_ctx_get(sbp_pubsub_ctx_t *ctx);
  * @return                  Pointer to the SBP RX context.
  */
 sbp_rx_ctx_t *sbp_pubsub_rx_ctx_get(sbp_pubsub_ctx_t *ctx);
+
+/**
+ * @brief   Attach this pubsub pair to a pk_loop_t object.
+ *
+ * @param[in] ctx           Pointer to the context to use.
+ * @param[in] loop          The loop to attach to
+ *
+ * @return                  0 on success, -1 on failure
+ */
+int sbp_pubsub_attach(sbp_pubsub_ctx_t *ctx, pk_loop_t *loop);
+
+/**
+ * @brief   Detach this pubsub pair from a pk_loop_t object.
+ *
+ * @param[in] ctx           Pointer to the context to use.
+ *
+ * @return                  0 on success, -1 on failure
+ */
+int sbp_pubsub_detach(sbp_pubsub_ctx_t *ctx);
+
 
 #ifdef __cplusplus
 } // extern "C"

--- a/package/libpiksi/libpiksi/include/libpiksi/sbp_rx.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/sbp_rx.h
@@ -45,6 +45,20 @@ typedef struct sbp_rx_ctx_s sbp_rx_ctx_t;
 sbp_rx_ctx_t *sbp_rx_create(const char *ident, const char *endpoint);
 
 /**
+ * @brief   Create an SBP RX context.
+ * @details Create and initialize an SBP RX context used to receive SBP
+ *          messages.
+ *
+ * @param[in] ident         The identity of this pub/sub pair, typically used for metrics.
+ * @param[in] endpoint      Description of endpoint to connect to.
+ * @param[in] server        True if this is a server socket.
+ *
+ * @return                  Pointer to the created context, or NULL if the
+ *                          operation failed.
+ */
+sbp_rx_ctx_t *sbp_rx_create_ex(const char *ident, const char *endpoint, bool server);
+
+/**
  * @brief   Destroy an SBP RX context.
  * @details Deinitialize and destroy an SBP RX context.
  *
@@ -172,6 +186,9 @@ void sbp_rx_reader_interrupt_reset(sbp_rx_ctx_t *ctx);
  */
 bool sbp_rx_reader_interrupt_requested(sbp_rx_ctx_t *ctx);
 
+/**
+ * Fetch the underlying enpoint for this object
+ */
 pk_endpoint_t *sbp_rx_endpoint_get(sbp_rx_ctx_t *ctx);
 
 #ifdef __cplusplus

--- a/package/libpiksi/libpiksi/include/libpiksi/sbp_tx.h
+++ b/package/libpiksi/libpiksi/include/libpiksi/sbp_tx.h
@@ -51,6 +51,20 @@ typedef struct sbp_tx_ctx_s sbp_tx_ctx_t;
 sbp_tx_ctx_t *sbp_tx_create(const char *ident, const char *endpoint);
 
 /**
+ * @brief   Create an SBP TX context.
+ * @details Create and initialize an SBP TX context used to send SBP
+ *          messages.
+ *
+ * @param[in] ident         The identity of this pub/sub pair, typically used for metrics.
+ * @param[in] endpoint      Description of endpoint to connect to.
+ * @param[in] server        True if this is a server socket.
+ *
+ * @return                  Pointer to the created context, or NULL if the
+ *                          operation failed.
+ */
+sbp_tx_ctx_t *sbp_tx_create_ex(const char *ident, const char *endpoint, bool server);
+
+/**
  * @brief   Destroy an SBP TX context.
  * @details Deinitialize and destroy an SBP TX context.
  *
@@ -92,6 +106,31 @@ int sbp_tx_send(sbp_tx_ctx_t *ctx, u16 msg_type, u8 len, u8 *payload);
 int sbp_tx_send_from(sbp_tx_ctx_t *ctx, u16 msg_type, u8 len, u8 *payload, u16 sbp_sender_id);
 
 pk_endpoint_t *sbp_tx_endpoint_get(sbp_tx_ctx_t *ctx);
+
+/**
+ * @brief   Attach TX Context to a given Piksi loop
+ * @details Attach TX Context to a given Piksi loop
+ *
+ * @param[in] ctx           Pointer to the SBP TX Context.
+ * @param[in] pk_loop       Pointer to the Piksi loop to use.
+ *
+ * @return                  The operation result.
+ * @retval 0                Context attached successfully.
+ * @retval -1               An error occurred.
+ */
+int sbp_tx_attach(sbp_tx_ctx_t *ctx, pk_loop_t *pk_loop);
+
+/**
+ * @brief   Detach TX Context from a given Piksi loop
+ * @details Detach TX Context from a given Piksi loop
+ *
+ * @param[in] ctx           Pointer to the SBP TX Context.
+ *
+ * @return                  The operation result.
+ * @retval 0                Context detached successfully.
+ * @retval -1               An error occurred.
+ */
+int sbp_tx_detach(sbp_tx_ctx_t *ctx);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/package/libpiksi/libpiksi/src/endpoint.c
+++ b/package/libpiksi/libpiksi/src/endpoint.c
@@ -198,7 +198,7 @@ static void flush_endpoint_metrics(pk_loop_t *loop, void *handle, int status, vo
 /************* pk_endpoint_config *************************************/
 /**********************************************************************/
 
-static pk_endpoint_config_builder_t config_builder;
+static __thread pk_endpoint_config_builder_t config_builder;
 
 static pk_endpoint_config_builder_t cfg_builder_endpoint(const char *endpoint)
 {

--- a/package/libpiksi/libpiksi/src/endpoint.c
+++ b/package/libpiksi/libpiksi/src/endpoint.c
@@ -55,15 +55,19 @@
 /* Maximum number of clients in the listen() backlog */
 #define MAX_BACKLOG 128
 
-/* clang-format off */
+/* #define DEBUG_RECV_IMPL */
+#ifdef DEBUG_RECV_IMPL
+#define RECV_IMPL_DEBUG_LOG(ThePattern, ...) PK_LOG_ANNO(LOG_DEBUG, ThePattern, ##__VA_ARGS__)
+#else
+#define RECV_IMPL_DEBUG_LOG(...)
+#endif
+
 /* #define DEBUG_ENDPOINT */
 #ifdef DEBUG_ENDPOINT
-#  define ENDPOINT_DEBUG_LOG(ThePattern, ...) \
-     PK_LOG_ANNO(LOG_DEBUG, ThePattern, ##__VA_ARGS__)
+#define ENDPOINT_DEBUG_LOG(ThePattern, ...) PK_LOG_ANNO(LOG_DEBUG, ThePattern, ##__VA_ARGS__)
 #else
-#  define ENDPOINT_DEBUG_LOG(...)
+#define ENDPOINT_DEBUG_LOG(...)
 #endif
-/* clang-format on */
 
 #define MI endpoint_metrics_indexes
 #define MT endpoint_metrics_table
@@ -644,7 +648,7 @@ static int recv_impl(client_context_t *ctx, u8 *buffer, size_t *length_loc)
 
     if (length >= 0) {
       if (length == 0) {
-        ENDPOINT_DEBUG_LOG("socket closed");
+        RECV_IMPL_DEBUG_LOG("socket closed");
         if (ctx->node != NULL) record_disconnect(ctx->node);
         PK_METRICS_UPDATE(MR(ctx->ept), MI.read_close_count);
         teardown_client(ctx);
@@ -657,7 +661,7 @@ static int recv_impl(client_context_t *ctx, u8 *buffer, size_t *length_loc)
 
     if (errno == EINTR) {
       /* Retry if interrupted */
-      ENDPOINT_DEBUG_LOG("got EINTR from recvmsg: %s", strerror(errno));
+      RECV_IMPL_DEBUG_LOG("got EINTR from recvmsg: %s", strerror(errno));
       continue;
     }
 

--- a/package/libpiksi/libpiksi/src/sbp_rx.c
+++ b/package/libpiksi/libpiksi/src/sbp_rx.c
@@ -68,6 +68,11 @@ static const char *get_socket_ident(const char *ident)
 
 sbp_rx_ctx_t *sbp_rx_create(const char *ident, const char *endpoint)
 {
+  return sbp_rx_create_ex(ident, endpoint, false);
+}
+
+sbp_rx_ctx_t *sbp_rx_create_ex(const char *ident, const char *endpoint, bool server)
+{
   assert(endpoint != NULL);
 
   sbp_rx_ctx_t *ctx = (sbp_rx_ctx_t *)malloc(sizeof(sbp_rx_ctx_t));
@@ -79,7 +84,7 @@ sbp_rx_ctx_t *sbp_rx_create(const char *ident, const char *endpoint)
   pk_endpoint_config_t cfg = (pk_endpoint_config_t){
     .endpoint = endpoint,
     .identity = get_socket_ident(ident),
-    .type = PK_ENDPOINT_SUB,
+    .type = server ? PK_ENDPOINT_SUB_SERVER : PK_ENDPOINT_SUB,
     .retry_connect = false,
   };
 
@@ -299,5 +304,7 @@ bool sbp_rx_reader_interrupt_requested(sbp_rx_ctx_t *ctx)
 
 pk_endpoint_t *sbp_rx_endpoint_get(sbp_rx_ctx_t *ctx)
 {
+  assert(ctx != NULL);
+
   return ctx->pk_ept;
 }

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -21,6 +21,7 @@
 
 #include <libpiksi/logging.h>
 #include <libpiksi/runit.h>
+#include <libpiksi/util.h>
 
 #include "can.h"
 #include "ports.h"
@@ -43,6 +44,8 @@
 // See https://elixir.bootlin.com/linux/v4.6/source/drivers/usb/gadget/function/u_serial.c#L83
 #define USB_SERIAL_XMIT_SIZE "8192"
 
+#define RUNIT_SERVICE_DIR "/var/run/ports_daemon/sv"
+
 typedef enum {
   PORT_TYPE_UART,
   PORT_TYPE_USB,
@@ -60,19 +63,15 @@ typedef enum {
 
 typedef union {
   struct {
-    char name[16];
     uint32_t port;
   } tcp_server_data;
   struct {
-    char name[16];
     char address[256];
   } tcp_client_data;
   struct {
-    char name[16];
     uint32_t port;
   } udp_server_data;
   struct {
-    char name[16];
     char address[256];
   } udp_client_data;
   struct {
@@ -80,46 +79,14 @@ typedef union {
   } can_data;
 } opts_data_t;
 
-typedef int (*opts_get_fn_t)(char *buf, size_t buf_size, const opts_data_t *opts_data);
+struct port_config_s;
 
-#define RUNIT_SERVICE_DIR "/var/run/ports_daemon/sv"
+typedef int (*opts_get_fn_t)(char *buf,
+                             size_t buf_size,
+                             const opts_data_t *opts_data,
+                             const struct port_config_s *port_config);
 
-static int opts_get_tcp_server(char *buf, size_t buf_size, const opts_data_t *opts_data)
-{
-  uint32_t port = opts_data->tcp_server_data.port;
-  return snprintf(buf, buf_size, "--name %s --tcp-l %u", opts_data->tcp_server_data.name, port);
-}
-
-static int opts_get_tcp_client(char *buf, size_t buf_size, const opts_data_t *opts_data)
-{
-  const char *address = opts_data->tcp_client_data.address;
-  return snprintf(buf, buf_size, "--name %s --tcp-c %s", opts_data->tcp_client_data.name, address);
-}
-
-static int opts_get_udp_server(char *buf, size_t buf_size, const opts_data_t *opts_data)
-{
-  uint32_t port = opts_data->udp_server_data.port;
-  return snprintf(buf, buf_size, "--name %s --udp-l %u", opts_data->udp_server_data.name, port);
-}
-
-static int opts_get_udp_client(char *buf, size_t buf_size, const opts_data_t *opts_data)
-{
-  const char *address = opts_data->udp_client_data.address;
-  return snprintf(buf, buf_size, "--name %s --udp-c %s", opts_data->udp_client_data.name, address);
-}
-
-static int opts_get_can(char *buf, size_t buf_size, const opts_data_t *opts_data)
-{
-  u8 nmbr = opts_data->can_data.number;
-  return snprintf(buf,
-                  buf_size,
-                  "--name can%" PRIu8 " --can %" PRIu32 " --can-f %" PRIu32,
-                  nmbr,
-                  can_get_id(nmbr),
-                  can_get_filter(nmbr));
-}
-
-typedef struct {
+typedef struct port_config_s {
   const char *const name;
   const char *const opts;
   const opts_get_fn_t opts_get;
@@ -132,11 +99,103 @@ typedef struct {
   bool first_start;
 } port_config_t;
 
+static int mode_lookup(const char *mode_name, u8 *mode);
+
+static char *get_fileio_opts(const port_config_t *port_config)
+{
+  static char fileio_opts[256] = {0};
+
+  u8 mode_sbp = MODE_DISABLED;
+
+  int rc = mode_lookup(MODE_NAME_SBP, &mode_sbp);
+  assert(rc == 0);
+
+  if (port_config->mode == mode_sbp) {
+    snprintf_assert(fileio_opts,
+                    sizeof(fileio_opts),
+                    " --pub2 ipc:///var/run/sockets/fileio/%s.sub "
+                    "--sub2 ipc:///var/run/sockets/fileio/%s.pub ",
+                    port_config->name,
+                    port_config->name);
+  }
+  return fileio_opts;
+}
+
+static int opts_get_uart(char *buf,
+                         size_t buf_size,
+                         const opts_data_t *opts_data,
+                         const port_config_t *port_config)
+{
+  (void)opts_data;
+  return snprintf(buf, buf_size, "%s", get_fileio_opts(port_config));
+}
+
+static int opts_get_tcp_server(char *buf,
+                               size_t buf_size,
+                               const opts_data_t *opts_data,
+                               const port_config_t *port_config)
+{
+  uint32_t port = opts_data->tcp_server_data.port;
+  return snprintf(buf,
+                  buf_size,
+                  "--name %s --tcp-l %u%s",
+                  port_config->name,
+                  port,
+                  get_fileio_opts(port_config));
+}
+
+static int opts_get_tcp_client(char *buf,
+                               size_t buf_size,
+                               const opts_data_t *opts_data,
+                               const port_config_t *port_config)
+{
+  const char *address = opts_data->tcp_client_data.address;
+  return snprintf(buf,
+                  buf_size,
+                  "--name %s --tcp-c %s%s",
+                  port_config->name,
+                  address,
+                  get_fileio_opts(port_config));
+}
+
+static int opts_get_udp_server(char *buf,
+                               size_t buf_size,
+                               const opts_data_t *opts_data,
+                               const port_config_t *port_config)
+{
+  uint32_t port = opts_data->udp_server_data.port;
+  return snprintf(buf, buf_size, "--name %s --udp-l %u", port_config->name, port);
+}
+
+static int opts_get_udp_client(char *buf,
+                               size_t buf_size,
+                               const opts_data_t *opts_data,
+                               const port_config_t *port_config)
+{
+  const char *address = opts_data->udp_client_data.address;
+  return snprintf(buf, buf_size, "--name %s --udp-c %s", port_config->name, address);
+}
+
+static int opts_get_can(char *buf,
+                        size_t buf_size,
+                        const opts_data_t *opts_data,
+                        const port_config_t *port_config)
+{
+  (void)port_config;
+  u8 nmbr = opts_data->can_data.number;
+  return snprintf(buf,
+                  buf_size,
+                  "--name can%" PRIu8 " --can %" PRIu32 " --can-f %" PRIu32,
+                  nmbr,
+                  can_get_id(nmbr),
+                  can_get_filter(nmbr));
+}
+
 static port_config_t port_configs[] = {
   {
     .name = "uart0",
     .opts = "--name uart0 --file /dev/ttyPS0 --nonblock --outq " SERIAL_XMIT_SIZE,
-    .opts_get = NULL,
+    .opts_get = opts_get_uart,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
     .mode = MODE_DISABLED,
@@ -147,7 +206,7 @@ static port_config_t port_configs[] = {
   {
     .name = "uart1",
     .opts = "--name uart1 --file /dev/ttyPS1 --nonblock --outq " SERIAL_XMIT_SIZE,
-    .opts_get = NULL,
+    .opts_get = opts_get_uart,
     .type = PORT_TYPE_UART,
     .mode_name_default = MODE_NAME_DEFAULT,
     .mode = MODE_DISABLED,
@@ -181,7 +240,6 @@ static port_config_t port_configs[] = {
   {
     .name = "tcp_server0",
     .opts = "",
-    .opts_data.tcp_server_data.name = "tcp_server0",
     .opts_data.tcp_server_data.port = 55555,
     .opts_get = opts_get_tcp_server,
     .type = PORT_TYPE_TCP_SERVER,
@@ -194,7 +252,6 @@ static port_config_t port_configs[] = {
   {
     .name = "tcp_server1",
     .opts = "",
-    .opts_data.tcp_server_data.name = "tcp_server1",
     .opts_data.tcp_server_data.port = 55556,
     .opts_get = opts_get_tcp_server,
     .type = PORT_TYPE_TCP_SERVER,
@@ -207,7 +264,6 @@ static port_config_t port_configs[] = {
   {
     .name = "tcp_client0",
     .opts = "",
-    .opts_data.tcp_client_data.name = "tcp_client0",
     .opts_data.tcp_client_data.address = "",
     .opts_get = opts_get_tcp_client,
     .type = PORT_TYPE_TCP_CLIENT,
@@ -220,7 +276,6 @@ static port_config_t port_configs[] = {
   {
     .name = "tcp_client1",
     .opts = "",
-    .opts_data.tcp_client_data.name = "tcp_client1",
     .opts_data.tcp_client_data.address = "",
     .opts_get = opts_get_tcp_client,
     .type = PORT_TYPE_TCP_CLIENT,
@@ -233,7 +288,6 @@ static port_config_t port_configs[] = {
   {
     .name = "udp_server0",
     .opts = "",
-    .opts_data.udp_server_data.name = "udp_server0",
     .opts_data.udp_server_data.port = 55557,
     .opts_get = opts_get_udp_server,
     .type = PORT_TYPE_UDP_SERVER,
@@ -246,7 +300,6 @@ static port_config_t port_configs[] = {
   {
     .name = "udp_server1",
     .opts = "",
-    .opts_data.udp_server_data.name = "udp_server1",
     .opts_data.udp_server_data.port = 55558,
     .opts_get = opts_get_udp_server,
     .type = PORT_TYPE_UDP_SERVER,
@@ -259,7 +312,6 @@ static port_config_t port_configs[] = {
   {
     .name = "udp_client0",
     .opts = "",
-    .opts_data.udp_client_data.name = "udp_client0",
     .opts_data.udp_client_data.address = "",
     .opts_get = opts_get_udp_client,
     .type = PORT_TYPE_UDP_CLIENT,
@@ -272,7 +324,6 @@ static port_config_t port_configs[] = {
   {
     .name = "udp_client1",
     .opts = "",
-    .opts_data.udp_client_data.name = "udp_client1",
     .opts_data.udp_client_data.address = "",
     .opts_get = opts_get_udp_client,
     .type = PORT_TYPE_UDP_CLIENT,
@@ -320,7 +371,7 @@ static u8 protocol_index_to_mode(int protocol_index)
 
 static int port_configure(port_config_t *port_config, bool updating_mode)
 {
-  char cmd[512];
+  char cmd[1024];
 
   // clang-format off
   runit_config_t cfg = (runit_config_t){
@@ -362,12 +413,12 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
   }
 
   /* Prepare the command used to launch endpoint_adapter. */
-  char mode_opts[256] = {0};
+  char mode_opts[512] = {0};
   protocol->port_adapter_opts_get(mode_opts, sizeof(mode_opts), port_config->name);
 
-  char opts[256] = {0};
+  char opts[512] = {0};
   if (port_config->opts_get != NULL) {
-    port_config->opts_get(opts, sizeof(opts), &port_config->opts_data);
+    port_config->opts_get(opts, sizeof(opts), &port_config->opts_data, port_config);
   }
 
   snprintf(cmd, sizeof(cmd), "endpoint_adapter %s %s %s", port_config->opts, opts, mode_opts);

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -150,12 +150,7 @@ static int opts_get_tcp_client(char *buf,
                                const port_config_t *port_config)
 {
   const char *address = opts_data->tcp_client_data.address;
-  return snprintf(buf,
-                  buf_size,
-                  "--name %s --tcp-c %s%s",
-                  port_config->name,
-                  address,
-                  get_fileio_opts(port_config));
+  return snprintf(buf, buf_size, "--name %s --tcp-c %s", port_config->name, address);
 }
 
 static int opts_get_udp_server(char *buf,
@@ -217,7 +212,7 @@ static port_config_t port_configs[] = {
   {
     .name = "usb0",
     .opts = "--name usb0 --file /dev/tty.usb0 --nonblock --outq " USB_SERIAL_XMIT_SIZE,
-    .opts_get = NULL,
+    .opts_get = opts_get_uart,
     .type = PORT_TYPE_USB,
     .mode_name_default = MODE_NAME_DEFAULT,
     .mode = MODE_DISABLED,
@@ -229,7 +224,7 @@ static port_config_t port_configs[] = {
     .name = FIXED_SBP_USB_PORT_NAME,
     .opts = "--name " FIXED_SBP_USB_PORT_NAME
             " --file /dev/tty.usb2 --nonblock --outq " USB_SERIAL_XMIT_SIZE,
-    .opts_get = NULL,
+    .opts_get = opts_get_uart,
     .type = PORT_TYPE_USB,
     .mode_name_default = MODE_NAME_DEFAULT,
     .mode = MODE_DISABLED,

--- a/package/sbp_fileio_daemon/overlay/etc/init.d/S81sbp_fileio_daemon_external
+++ b/package/sbp_fileio_daemon/overlay/etc/init.d/S81sbp_fileio_daemon_external
@@ -11,11 +11,32 @@ control_dir="/var/run/sbp_fileio_${daemon_name}"
 dir_perm=0755
 file_perm=0644
 
+## The ports below must be specified in matched pairs
+## and must match up with the ports specified in ports.c
+## of ports_daemon.
+
 name="sbp_fileio_daemon_${daemon_name}"
 cmd="sbp_fileio_daemon \
 --name ${daemon_name} \
---pub ipc:///var/run/sockets/fileio_${daemon_name}.sub \
---sub ipc:///var/run/sockets/fileio_${daemon_name}.pub \
+\
+--pub-s ipc:///var/run/sockets/fileio/tcp_server0.pub \
+--sub-s ipc:///var/run/sockets/fileio/tcp_server0.sub \
+\
+--pub-s ipc:///var/run/sockets/fileio/tcp_server1.pub \
+--sub-s ipc:///var/run/sockets/fileio/tcp_server1.sub \
+\
+--pub-s ipc:///var/run/sockets/fileio/usb0.pub \
+--sub-s ipc:///var/run/sockets/fileio/usb0.sub \
+\
+--pub-s ipc:///var/run/sockets/fileio/usb2.pub \
+--sub-s ipc:///var/run/sockets/fileio/usb2.sub \
+\
+--pub-s ipc:///var/run/sockets/fileio/uart0.pub \
+--sub-s ipc:///var/run/sockets/fileio/uart0.sub \
+\
+--pub-s ipc:///var/run/sockets/fileio/uart1.pub \
+--sub-s ipc:///var/run/sockets/fileio/uart1.sub \
+\
 --basedir $fileio_dir \
 --basedir $persist_dir \
 --basedir $media_dir \

--- a/package/sbp_fileio_daemon/sbp_fileio_daemon/src/main.c
+++ b/package/sbp_fileio_daemon/sbp_fileio_daemon/src/main.c
@@ -21,8 +21,19 @@
 
 #define PROGRAM_NAME "sbp_fileio_daemon"
 
-static const char *pub_endpoint = NULL;
-static const char *sub_endpoint = NULL;
+#define MAX_ENDPOINTS 16
+
+typedef struct endpoint_spec_s {
+  const char *endpoint;
+  bool server;
+} endpoint_spec_t;
+
+static endpoint_spec_t pub_endpoint[MAX_ENDPOINTS] = {0};
+static endpoint_spec_t sub_endpoint[MAX_ENDPOINTS] = {0};
+
+static size_t pub_endpoint_count = 0;
+static size_t sub_endpoint_count = 0;
+
 static path_validator_t *g_pv_ctx = NULL;
 
 static bool allow_factory_mtd = false;
@@ -44,8 +55,10 @@ static void usage(char *command)
   puts("-n, --name    <name>  The name of this fileio daemon");
   puts("-p, --pub     <addr>  The address on which we should write the results of");
   puts("                      MSG_FILEIO_* messages");
+  puts("--pub-s       <addr>  Same as --pub, but open a server socket");
   puts("-s, --sub     <addr>  The address on which we should listen for MSG_FILEIO_*");
   puts("                      messages");
+  puts("--sub-s       <addr>  Same as --sub, but open a server socket");
   puts("-b, --basedir <path>  The base directory that should prefix all read, write,");
   puts("                      remove and list operations.");
   puts("-m, --mtd             Allow read access to /factory/mtd");
@@ -65,7 +78,9 @@ static int parse_options(int argc, char *argv[])
   const struct option long_opts[] = {
     {"name",         required_argument, 0, 'n'},
     {"pub",          required_argument, 0, 'p'},
+    {"pub-s",        required_argument, 0, 'P'},
     {"sub",          required_argument, 0, 's'},
+    {"sub-s",        required_argument, 0, 'S'},
     {"basedir",      required_argument, 0, 'b'},
     {"mtd",          no_argument,       0, 'm'},
     {"imageset",     no_argument,       0, 'i'},
@@ -79,19 +94,37 @@ static int parse_options(int argc, char *argv[])
 
   int c;
   int opt_index;
-  while ((c = getopt_long(argc, argv, "n:p:s:b:midxht", long_opts, &opt_index)) != -1) {
-    switch (c) {
+  while ((c = getopt_long(argc, argv, "n:p:P:s:S:b:midxhty", long_opts, &opt_index)) != -1) {
 
+    bool server = false;
+
+    switch (c) {
     case 'n': {
       sbp_fileio_name = optarg;
     } break;
 
+    case 'P':
+      server = true;
+      /* fall through */
     case 'p': {
-      pub_endpoint = optarg;
+      if (pub_endpoint_count >= MAX_ENDPOINTS) {
+        fprintf(stderr, "Error: too many pub endpoints specified\n");
+        return -1;
+      }
+      pub_endpoint[pub_endpoint_count].server = server;
+      pub_endpoint[pub_endpoint_count++].endpoint = optarg;
     } break;
 
+    case 'S':
+      server = true;
+      /* fall through */
     case 's': {
-      sub_endpoint = optarg;
+      if (sub_endpoint_count >= MAX_ENDPOINTS) {
+        fprintf(stderr, "Error: too many sub endpoints specified\n");
+        return -1;
+      }
+      pub_endpoint[sub_endpoint_count].server = server;
+      sub_endpoint[sub_endpoint_count++].endpoint = optarg;
     } break;
 
     case 'b': {
@@ -137,8 +170,13 @@ static int parse_options(int argc, char *argv[])
     return -1;
   }
 
-  if ((pub_endpoint == NULL) || (sub_endpoint == NULL)) {
+  if ((pub_endpoint_count == 0) || (sub_endpoint_count == 0)) {
     fprintf(stderr, "Endpoints not specified\n");
+    return -1;
+  }
+
+  if (pub_endpoint_count != sub_endpoint_count) {
+    fprintf(stderr, "Endpoints must be specified in pairs\n");
     return -1;
   }
 
@@ -193,10 +231,11 @@ int main(int argc, char *argv[])
 {
   bool setup = false;
   pk_loop_t *loop = NULL;
-  sbp_pubsub_ctx_t *ctx = NULL;
+  sbp_pubsub_ctx_t **pubsub_contexts = NULL;
   char identity[128] = {0};
-
   int ret = EXIT_FAILURE;
+  size_t pubsub_idx = 0;
+
   logging_init(PROGRAM_NAME);
 
   g_pv_ctx = path_validator_create(NULL);
@@ -213,20 +252,30 @@ int main(int argc, char *argv[])
   }
 
   path_validator_setup_metrics(g_pv_ctx, sbp_fileio_name);
-  snprintf_assert(identity, sizeof(identity), "%s/%s", PROGRAM_NAME, sbp_fileio_name);
-
-  ctx = sbp_pubsub_create(identity, pub_endpoint, sub_endpoint);
-  if (ctx == NULL) {
-    goto cleanup;
-  }
 
   loop = pk_loop_create();
   if (loop == NULL) {
     goto cleanup;
   }
 
-  if (sbp_rx_attach(sbp_pubsub_rx_ctx_get(ctx), loop) != 0) {
-    goto cleanup;
+  pubsub_contexts = calloc(MAX_ENDPOINTS, sizeof(sbp_pubsub_ctx_t *));
+  for (pubsub_idx = 0; pubsub_idx < pub_endpoint_count; pubsub_idx++) {
+    snprintf_assert(identity,
+                    sizeof(identity),
+                    "%s/%s/%zu",
+                    PROGRAM_NAME,
+                    sbp_fileio_name,
+                    pubsub_idx);
+    pubsub_contexts[pubsub_idx] = sbp_pubsub_create_ex(identity,
+                                                       pub_endpoint[pubsub_idx].endpoint,
+                                                       sub_endpoint[pubsub_idx].endpoint,
+                                                       pub_endpoint[pubsub_idx].server);
+    if (pubsub_contexts[pubsub_idx] == NULL) {
+      goto cleanup;
+    }
+    if (sbp_pubsub_attach(pubsub_contexts[pubsub_idx], loop) != 0) {
+      goto cleanup;
+    }
   }
 
   if (pk_loop_signal_handler_add(loop, SIGUSR1, sigusr1_signal_cb, NULL) == NULL) {
@@ -243,8 +292,8 @@ int main(int argc, char *argv[])
                            g_pv_ctx,
                            allow_factory_mtd,
                            allow_imageset_bin,
-                           sbp_pubsub_rx_ctx_get(ctx),
-                           sbp_pubsub_tx_ctx_get(ctx));
+                           pubsub_contexts,
+                           pub_endpoint_count);
 
   if (!setup) {
     goto cleanup;
@@ -258,7 +307,13 @@ int main(int argc, char *argv[])
 cleanup:
   piksi_log(LOG_INFO, "loop stopping...");
 
-  sbp_pubsub_destroy(&ctx);
+  for (size_t idx = 0; idx < pubsub_idx; idx++) {
+    sbp_pubsub_destroy(&pubsub_contexts[idx]);
+  }
+
+  free(pubsub_contexts);
+  pubsub_contexts = NULL;
+
   pk_loop_destroy(&loop);
 
   path_validator_destroy(&g_pv_ctx);

--- a/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.c
+++ b/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.c
@@ -108,14 +108,25 @@ static pk_metrics_t *fileio_metrics = NULL;
 
 typedef struct write_request {
   size_t len;
+  size_t pubsub_idx;
   u8 msg_buffer[SBP_FRAMING_MAX_PAYLOAD_SIZE];
 } write_request_t;
+
+typedef struct pubsub_ctx_s {
+  sbp_state_t sbp_state;            /** Used to buffer SBP response packets */
+  u8 send_buffer[SEND_BUFFER_SIZE]; /** Stores serialized outgoing SBP response packets */
+  u32 send_buffer_remaining;        /** Data remaining in `send_buffer` */
+  u32 send_buffer_offset;           /** Current unconsumed offset into `send_buffer` */
+  sbp_rx_ctx_t *rx_ctx;             /** The context to use for incoming data */
+  sbp_tx_ctx_t *tx_ctx;             /** The context to use for outgoing data */
+  pk_endpoint_t *tx_ept;
+} pubsub_ctx_t;
 
 static struct {
   int
     request_pipe[2]; /** Used by write thread to receive incoming write requests through select() */
   write_request_t write_requests[WQ_MAX_PENDING]; /** Ring buffer of incoming write requests */
-  atomic_bool flush_pending;     /** True if a flush of FileIO write data is pending */
+  atomic_size_t flush_pending;   /** >= 0 if a flush of FileIO write data is pending */
   atomic_size_t write_req_index; /** The current first free index of write requests */
   atomic_size_t writes_pending;  /** The number of write requests that are pending for the thread */
 
@@ -129,11 +140,8 @@ static struct {
                           **WARNING** this has the limitation that heavy write operations can
                           potentially starve other operations. */
 
-  sbp_state_t sbp_state;            /** Used to buffer SBP response packets */
-  u8 send_buffer[SEND_BUFFER_SIZE]; /** Stores serialized outgoing SBP response packets */
-  u32 send_buffer_remaining;        /** Data remaining in `send_buffer` */
-  u32 send_buffer_offset;           /** Current unconsumed offset into `send_buffer` */
-  sbp_tx_ctx_t *tx_ctx;             /** The context to use for outgoing data */
+  pubsub_ctx_t *pubsub_contexts;
+  size_t pubsub_count;
 
 } write_thread_ctx;
 
@@ -182,10 +190,10 @@ static open_file_t open_file(const char *path, const char *mode, int oflag, mode
 
 static bool test_control_dir(const char *name);
 
-static void flush_output_sbp(void);
-static void request_flush_output_sbp(void);
+static void flush_output_sbp(size_t pubsub_idx);
+static void request_flush_output_sbp(size_t idx);
 
-static void stage_output_sbp(u8 msg_type, size_t len, u8 *payload);
+static void stage_output_sbp(u8 msg_type, size_t len, u8 *payload, size_t pubsub_idx);
 
 static fd_cache_t fd_cache[FD_CACHE_COUNT] = {[0 ...(FD_CACHE_COUNT - 1)] = {NULL, "", "", 0, 0}};
 
@@ -260,6 +268,7 @@ static void timer_handler(pk_loop_t *loop, void *handle, int status, void *conte
   (void)loop;
   (void)status;
   (void)handle;
+  (void)context;
 
   static int trigger_cache_purge = 0;
   static int trigger_metrics_flush = 0;
@@ -289,8 +298,10 @@ static void timer_handler(pk_loop_t *loop, void *handle, int status, void *conte
     path_validator_flush_metrics(g_pv_ctx);
   }
 
-  sbp_rx_ctx_t *rx_ctx = (sbp_rx_ctx_t *)context;
-  validate_receive_handle(rx_ctx);
+  for (size_t i = 0; i < write_thread_ctx.pubsub_count; i++) {
+    pubsub_ctx_t *ctx = &write_thread_ctx.pubsub_contexts[i];
+    validate_receive_handle(ctx->rx_ctx);
+  }
 
   pk_loop_timer_reset(timer_handle);
 }
@@ -409,31 +420,34 @@ void sbp_fileio_setup_path_validator(path_validator_t *pv_ctx,
   allow_imageset_bin = allow_imageset_bin_;
 }
 
-static void flush_output_sbp(void)
+static void flush_output_sbp(size_t pubsub_idx)
 {
-  if (write_thread_ctx.send_buffer_offset == 0) {
+  pubsub_ctx_t *ctx = &write_thread_ctx.pubsub_contexts[pubsub_idx];
+
+  if (ctx->send_buffer_offset == 0) {
     return;
   }
 
-  pk_endpoint_t *ept = sbp_tx_endpoint_get(write_thread_ctx.tx_ctx);
-  int rc = pk_endpoint_send(ept, write_thread_ctx.send_buffer, write_thread_ctx.send_buffer_offset);
-
+  int rc = pk_endpoint_send(ctx->tx_ept, ctx->send_buffer, ctx->send_buffer_offset);
   if (rc != 0) {
     PK_LOG_ANNO(LOG_WARNING, "pk_endpoint_send reported an error: %d", rc);
   }
 
   /* reset buffer */
-  write_thread_ctx.send_buffer_remaining = sizeof(write_thread_ctx.send_buffer);
-  write_thread_ctx.send_buffer_offset = 0;
+  ctx->send_buffer_remaining = sizeof(ctx->send_buffer);
+  ctx->send_buffer_offset = 0;
 }
 
-static void request_flush_output_sbp(void)
+static void request_flush_output_sbp(size_t idx)
 {
-  if (atomic_load(&write_thread_ctx.flush_pending)) {
-    return;
-  }
+  size_t expected = SIZET_MAX;
 
-  atomic_store(&write_thread_ctx.flush_pending, true);
+  for (;;) {
+    bool success = atomic_compare_exchange_weak(&write_thread_ctx.flush_pending, &expected, idx);
+    if (success) {
+      break;
+    }
+  }
 
   void *write_req_ptr = NULL;
   int rc = write(write_thread_ctx.request_pipe[WRITE], &write_req_ptr, sizeof(write_req_ptr));
@@ -445,9 +459,8 @@ static void request_flush_output_sbp(void)
 
 static void post_receive_buffer(void *context)
 {
-  (void)context;
-
-  request_flush_output_sbp();
+  size_t pubsub_idx = (size_t)context;
+  request_flush_output_sbp(pubsub_idx);
 }
 
 static size_t wq_acquire_index()
@@ -592,8 +605,14 @@ static void *write_thread_handler(void *arg)
 
       if (write_req_ptr == NULL) {
 
-        flush_output_sbp();
-        atomic_store(&write_thread_ctx.flush_pending, false);
+        flush_output_sbp(write_thread_ctx.flush_pending);
+
+        size_t expected = write_thread_ctx.flush_pending;
+        size_t desired = SIZET_MAX;
+
+        bool cmp =
+          atomic_compare_exchange_strong(&write_thread_ctx.flush_pending, &expected, desired);
+        assert(cmp);
 
         continue;
       }
@@ -621,7 +640,10 @@ static void *write_thread_handler(void *arg)
 
       if (write_success) {
         PK_METRICS_UPDATE(MR, MI.write_bytes, PK_METRICS_VALUE((u32)write_count));
-        stage_output_sbp(SBP_MSG_FILEIO_WRITE_RESP, sizeof(reply), (u8 *)&reply);
+        stage_output_sbp(SBP_MSG_FILEIO_WRITE_RESP,
+                         sizeof(reply),
+                         (u8 *)&reply,
+                         write_req->pubsub_idx);
       }
     }
   }
@@ -639,8 +661,8 @@ bool sbp_fileio_setup(const char *name,
                       path_validator_t *pv_ctx,
                       bool allow_factory_mtd_,
                       bool allow_imageset_bin_,
-                      sbp_rx_ctx_t *rx_ctx,
-                      sbp_tx_ctx_t *tx_ctx)
+                      sbp_pubsub_ctx_t *pubsub_contexts[],
+                      size_t pubsub_count)
 {
   if (!test_control_dir(name)) {
     /* failure logging happens within the function */
@@ -660,36 +682,49 @@ bool sbp_fileio_setup(const char *name,
   sbp_fileio_setup_path_validator(pv_ctx, allow_factory_mtd_, allow_imageset_bin_);
 
   bool cb_registered = true;
+  write_thread_ctx.pubsub_contexts = calloc(pubsub_count, sizeof(pubsub_ctx_t));
 
-  /* clang-format off */
-  cb_registered = cb_registered
-    && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_READ_REQ, read_cb, tx_ctx, NULL);
-  cb_registered = cb_registered
-    && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_READ_DIR_REQ, read_dir_cb, tx_ctx, NULL);
-  cb_registered = cb_registered
-    && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_REMOVE, remove_cb, tx_ctx, NULL);
-  cb_registered = cb_registered
-    && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_WRITE_REQ, write_cb, tx_ctx, NULL);
-  cb_registered = cb_registered
-    && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_CONFIG_REQ, config_cb, tx_ctx, NULL);
-  /* clang-format on */
+  for (size_t i = 0; i < pubsub_count; i++) {
 
-  if (!cb_registered) {
-    PK_LOG_ANNO(LOG_ERR, "callback registration failed");
-    return false;
+    sbp_pubsub_ctx_t *pubsub_ctx = pubsub_contexts[i];
+
+    sbp_tx_ctx_t *tx_ctx = sbp_pubsub_tx_ctx_get(pubsub_ctx);
+    sbp_rx_ctx_t *rx_ctx = sbp_pubsub_rx_ctx_get(pubsub_ctx);
+
+    /* clang-format off */
+    cb_registered = cb_registered
+      && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_READ_REQ, read_cb, tx_ctx, NULL);
+    cb_registered = cb_registered
+      && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_READ_DIR_REQ, read_dir_cb, tx_ctx, NULL);
+    cb_registered = cb_registered
+      && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_REMOVE, remove_cb, tx_ctx, NULL);
+    cb_registered = cb_registered
+      && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_WRITE_REQ, write_cb, (void *) i, NULL);
+    cb_registered = cb_registered
+      && 0 == sbp_rx_callback_register(rx_ctx, SBP_MSG_FILEIO_CONFIG_REQ, config_cb, tx_ctx, NULL);
+    /* clang-format on */
+
+    if (!cb_registered) {
+      PK_LOG_ANNO(LOG_ERR, "callback registration failed");
+      return false;
+    }
+
+    sbp_state_init(&write_thread_ctx.pubsub_contexts[i].sbp_state);
+    sbp_state_set_io_context(&write_thread_ctx.pubsub_contexts[i].sbp_state, (void *)i);
+
+    sbp_rx_receive_buffer_cb_set(rx_ctx, post_receive_buffer, (void *)i);
+
+    pubsub_ctx_t *ctx = &write_thread_ctx.pubsub_contexts[i];
+
+    ctx->send_buffer_remaining = sizeof(ctx->send_buffer);
+    ctx->send_buffer_offset = 0;
+
+    ctx->tx_ept = sbp_tx_endpoint_get(tx_ctx);
+    ctx->rx_ctx = rx_ctx;
   }
 
   sbp_sender_id = sbp_sender_id_get();
-
-  sbp_state_init(&write_thread_ctx.sbp_state);
-  sbp_rx_receive_buffer_cb_set(rx_ctx, post_receive_buffer, NULL);
-
-  write_thread_ctx.tx_ctx = tx_ctx;
-
-  write_thread_ctx.send_buffer_remaining = sizeof(write_thread_ctx.send_buffer);
-  write_thread_ctx.send_buffer_offset = 0;
-
-  timer_handle = pk_loop_timer_add(loop, TIMER_PERIOD_MS, timer_handler, rx_ctx);
+  timer_handle = pk_loop_timer_add(loop, TIMER_PERIOD_MS, timer_handler, NULL);
 
   if (timer_handle == NULL) {
     PK_LOG_ANNO(LOG_ERR, "timer setup failed");
@@ -773,6 +808,9 @@ void sbp_fileio_teardown(const char *name)
   if (!disable_threading) {
     pthread_join(write_thread_ctx.thread, NULL);
   }
+
+  free(write_thread_ctx.pubsub_contexts);
+  write_thread_ctx.pubsub_contexts = NULL;
 }
 
 void sbp_fileio_flush(void)
@@ -1187,26 +1225,27 @@ cleanup:
 
 static s32 stage_packed_sbp_buffer(u8 *buff, u32 n, void *context)
 {
-  (void)context;
+  size_t pubsub_idx = (size_t)context;
 
-  u32 len = SWFT_MIN(write_thread_ctx.send_buffer_remaining, n);
+  pubsub_ctx_t *ctx = &write_thread_ctx.pubsub_contexts[pubsub_idx];
+  u32 len = SWFT_MIN(ctx->send_buffer_remaining, n);
 
   if (len != n) {
-    flush_output_sbp();
-    len = SWFT_MIN(write_thread_ctx.send_buffer_remaining, n);
+    flush_output_sbp(pubsub_idx);
+    len = SWFT_MIN(ctx->send_buffer_remaining, n);
   }
 
-  memcpy(&write_thread_ctx.send_buffer[write_thread_ctx.send_buffer_offset], buff, len);
+  memcpy(&ctx->send_buffer[ctx->send_buffer_offset], buff, len);
 
-  write_thread_ctx.send_buffer_remaining -= len;
-  write_thread_ctx.send_buffer_offset += len;
+  ctx->send_buffer_remaining -= len;
+  ctx->send_buffer_offset += len;
 
   return uint32_to_int32(len);
 }
 
-static void stage_output_sbp(u8 msg_type, size_t len, u8 *payload)
+static void stage_output_sbp(u8 msg_type, size_t len, u8 *payload, size_t pubsub_idx)
 {
-  int status = sbp_send_message(&write_thread_ctx.sbp_state,
+  int status = sbp_send_message(&write_thread_ctx.pubsub_contexts[pubsub_idx].sbp_state,
                                 msg_type,
                                 sbp_sender_id,
                                 len,
@@ -1219,7 +1258,7 @@ static void stage_output_sbp(u8 msg_type, size_t len, u8 *payload)
   }
 }
 
-static void queue_file_write(u8 len, u8 msg[])
+static void queue_file_write(u8 len, u8 msg[], size_t pubsub_idx)
 {
   wq_increment_pending_writes();
 
@@ -1227,6 +1266,8 @@ static void queue_file_write(u8 len, u8 msg[])
 
   write_request->len = len;
   memcpy(write_request->msg_buffer, msg, len);
+
+  write_request->pubsub_idx = pubsub_idx;
 
   void *write_req_ptr = write_request;
   int rc = write(write_thread_ctx.request_pipe[WRITE], &write_req_ptr, sizeof(write_req_ptr));
@@ -1246,7 +1287,7 @@ static void queue_file_write(u8 len, u8 msg[])
 static void write_cb(u16 sender_id, u8 len, u8 msg_[], void *context)
 {
   (void)sender_id;
-  (void)context;
+  size_t pubsub_idx = (size_t)context;
 
   msg_fileio_write_req_t *msg = (msg_fileio_write_req_t *)msg_;
 
@@ -1258,15 +1299,15 @@ static void write_cb(u16 sender_id, u8 len, u8 msg_[], void *context)
   }
 
   if (!disable_threading) {
-    queue_file_write(len, msg_);
+    queue_file_write(len, msg_, pubsub_idx);
   } else {
     size_t write_count = 0;
     msg_fileio_write_resp_t reply = {.sequence = msg->sequence};
     if (sbp_fileio_write(msg, len, &write_count)) {
-      stage_output_sbp(SBP_MSG_FILEIO_WRITE_RESP, sizeof(reply), (u8 *)&reply);
+      stage_output_sbp(SBP_MSG_FILEIO_WRITE_RESP, sizeof(reply), (u8 *)&reply, pubsub_idx);
       PK_METRICS_UPDATE(MR, MI.write_bytes, PK_METRICS_VALUE((u32)write_count));
     }
-    flush_output_sbp();
+    flush_output_sbp(pubsub_idx);
   }
 }
 

--- a/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.h
+++ b/package/sbp_fileio_daemon/sbp_fileio_daemon/src/sbp_fileio.h
@@ -15,7 +15,7 @@
 
 #include <libsbp/file_io.h>
 
-#include <libpiksi/sbp_rx.h>
+#include <libpiksi/sbp_pubsub.h>
 #include <libpiksi/sbp_tx.h>
 
 #include "path_validator.h"
@@ -82,8 +82,8 @@ bool sbp_fileio_setup(const char *name,
                       path_validator_t *pv_ctx,
                       bool allow_factory_mtd,
                       bool allow_imageset_bin,
-                      sbp_rx_ctx_t *rx_ctx,
-                      sbp_tx_ctx_t *tx_ctx);
+                      sbp_pubsub_ctx_t *pubsub_contexts[],
+                      size_t pubsub_count);
 
 /**
  * Teardown a named FileIO daemon.

--- a/package/sbp_rtcm3_bridge/src/sbp.c
+++ b/package/sbp_rtcm3_bridge/src/sbp.c
@@ -101,7 +101,9 @@ void sbp_message_send(u16 msg_type, u8 len, u8 *payload, u16 sender_id, void *co
     return;
   }
 
-  sbp_tx_send_from(tx_ctx, msg_type, len, payload, sender_id);
+  if (sbp_tx_send_from(tx_ctx, msg_type, len, payload, sender_id) < 0) {
+    PK_LOG_ANNO(LOG_WARNING, "sbp_tx_send_from failed");
+  }
 }
 
 int sbp_callback_register(u16 msg_type, sbp_msg_callback_t cb, void *context)


### PR DESCRIPTION
## Design notes

This adds a new mode to `endpoint_adapter` and `sbp_fileio_daemon` that allow it to bypass the router, thus removing the need for the complications associated with trying to "fast pass" data through the router.  By adding server sockets to `sbp_fileio_daemon` we can also solve the problem of only responding to fileio data on the port it was received on, which avoids the issue where FileIO response data for a TCP connection would flood the UART.

## Testing

Mostly bench testing with HITL spot checks.  Seeing that this is actually the fastest of all previous methods because it allows FileIO response data to be batched into a large TCP send (rather than a bunch of small ones).  When data flowed through the endpoint_router, then to the `endpoint_adapter` we were forced through a framer at some point, which caused the response data to be cut up into smaller TCP packets.

## To-do
- [x] Clean-up metrics
- [x] Fix short option parsing for sbp_fileio_daemon
- [x] ~Decide if TCP client data transfer sockets are necessary~ -> turning off fileio "bypass" ports for tcp client connections, supporting it for uart, usb and tcp_server.
- [x] ~Test UART / USB data transfer~ -> Seems to work fine now