### PR TITLE
Merge cherry-picks from refs/heads/v2.3.0-release (2c4d4c58e) into master: Point to the new hitl api URL.

### DIFF
--- a/scripts/hitl_smoke_test
+++ b/scripts/hitl_smoke_test
@@ -19,7 +19,7 @@ import sys
 import json
 
 HITL_API_GITHUB_USER = "swiftnav-travis"
-HITL_API_URL = "https://hitlapi.swiftnav.com/"
+HITL_API_URL = "https://hitl-api.ce.swiftnav.com/"
 
 HITL_API_BUILD_TYPE = "buildroot_pull_request"
 HITL_VIEWER_BUILD_TYPE = "buildroot_pr"


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v2.3.0-release into the integration branch master