### PR TITLE
Check for divide by zero, support disabling network check [ESD-1228]

### DIFF
--- a/package/common_init/overlay/etc/init.d/S85network_poll
+++ b/package/common_init/overlay/etc/init.d/S85network_poll
@@ -16,6 +16,7 @@ setup_permissions()
   configure_file_resource $user $piksi_sys_dir/network_available 0644
   configure_file_resource $user $piksi_sys_dir/network_polling_period 0644
   configure_file_resource $user $piksi_sys_dir/network_polling_retry_period 0644
+  configure_file_resource $user $piksi_sys_dir/network_polling_addresses 0644
   configure_file_resource $user $piksi_sys_dir/enable_ping_logging 0644
 
   configure_file_resource $user /var/log/ping.log 0644

--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -1,5 +1,10 @@
 #!/bin/ash
 
+export name="network_poll"
+export log_tag=$name
+
+source /etc/init.d/logging.sh
+
 ## Resources and configuration:
 
 default_check_period=10
@@ -93,8 +98,7 @@ warn_check_disabled()
     return 0
   fi
 
-  echo "Network status LED disabled (network check frequency set to zero)." | \
-    sbp_log --warn
+  logw "Network status LED disabled (network check frequency set to zero)."
 
   warn_check_disabled_logged=y
 }
@@ -145,10 +149,10 @@ ping_addesses()
   addresses="$(cat "$polling_addresses_file")"
 
   if [[ -n "$addresses" ]]; then
+    echo "$addresses" | tr ',' '\n'
+  else
     echo "$default_ping_addresses" | tr ',' '\n'
   fi
-
-  echo "$addresses" | tr ',' '\n' 
 }
 
 run_ping()
@@ -179,7 +183,7 @@ while true; do
   fi
   reset_warn_check_disabled
   if [ x`cat $network_available_file` != "x1" ]; then
-    echo "No route to Internet" | sbp_log --warn
+    logw "No route to Internet"
   fi
 done &
 

--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -143,7 +143,7 @@ log_stop()
   echo "--- PING STOP: $(date -Is)" >>$(ping_log)
 }
 
-ping_addesses()
+ping_addresses()
 {
   local addresses
   addresses="$(cat "$polling_addresses_file")"
@@ -159,7 +159,7 @@ run_ping()
 {
   local IFS=$'\n'
 
-  for address in $(ping_addesses); do
+  for address in $(ping_addresses); do
     if ping -w 5 -c 1 "$address" >>"$(ping_log)" 2>&1; then
       return 0
     fi

--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -84,7 +84,7 @@ warn_check_disabled_logged=
 
 reset_warn_check_disabled()
 {
-  warn_check_disabled_logged=y
+  warn_check_disabled_logged=
 }
 
 warn_check_disabled()

--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -78,9 +78,24 @@ should_warn_on_no_inet()
   fi
 }
 
+warn_check_disabled_logged=
+
+warn_check_disabled()
+{
+  [[ -n "$warn_check_disabled_logged" ]] || return 1
+  echo "Network status check disabled" | sbp_log --warn
+  warn_check_disabled_logged=y
+}
+
 check_enabled()
 {
-  [[ -n "$(cat "$polling_period_file")" ]]
+  if [[ -n "$(cat "$polling_period_file")" ]]; then
+    warn_check_disabled
+    return 1
+  else
+    warn_check_disabled_logged=
+    return 0
+  fi
 }
 
 sleep_connectivity_check()

--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -4,7 +4,7 @@
 
 default_check_period=10
 default_retry_period=1
-default_ping_addresses=8.8.8.8,114.114.114.114
+default_ping_addresses=8.8.8.8
 
 recheck_enabled_period=1
 

--- a/package/common_init/overlay/etc/init.d/network_poll.sh
+++ b/package/common_init/overlay/etc/init.d/network_poll.sh
@@ -98,7 +98,7 @@ warn_check_disabled()
     return 0
   fi
 
-  logw "Network status LED disabled (network check frequency set to zero)."
+  logw --sbp "Network status LED disabled (network check frequency set to zero)."
 
   warn_check_disabled_logged=y
 }
@@ -183,7 +183,7 @@ while true; do
   fi
   reset_warn_check_disabled
   if [ x`cat $network_available_file` != "x1" ]; then
-    logw "No route to Internet"
+    logw --sbp "No route to Internet"
   fi
 done &
 

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -483,18 +483,26 @@ static int network_polling_notify(void *context)
 
     [0].name = "network_polling_frequency",
     [0].count = ({
-      snprintf(formatters[0].buf,
-               sizeof(formatters[0].buf),
-               "%.02f",
-               (1.0 / network_polling_frequency));
+      if (network_polling_frequency <= 0) {
+        snprintf(formatters[0].buf, "");
+      } else {
+        snprintf(formatters[0].buf,
+                 sizeof(formatters[0].buf),
+                 "%.02f",
+                 (1.0 / network_polling_frequency));
+      }
     }),
 
     [1].name = "network_polling_retry_frequency",
     [1].count = ({
-      snprintf(formatters[1].buf,
-               sizeof(formatters[1].buf),
-               "%.02f",
-               (1.0 / network_polling_retry_frequency));
+      if (network_polling_frequency <= 0) {
+        snprintf(formatters[1].buf, "");
+      } else {
+        snprintf(formatters[1].buf,
+                 sizeof(formatters[1].buf),
+                 "%.02f",
+                 (1.0 / network_polling_retry_frequency));
+      }
     }),
 
     [2].name = "log_ping_activity",

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -485,26 +485,22 @@ static int network_polling_notify(void *context)
 
     [0].name = "network_polling_frequency",
     [0].count = ({
-      if (network_polling_frequency <= 0) {
-        snprintf(formatters[0].buf, "");
-      } else {
+      network_polling_frequency <= 0 ? 
+        snprintf(formatters[0].buf, sizeof(formatters[0].buf), "") :
         snprintf(formatters[0].buf,
                  sizeof(formatters[0].buf),
                  "%.02f",
                  (1.0 / network_polling_frequency));
-      }
     }),
 
     [1].name = "network_polling_retry_frequency",
     [1].count = ({
-      if (network_polling_frequency <= 0) {
-        snprintf(formatters[1].buf, "");
-      } else {
+      network_polling_frequency <= 0 ? 
+        snprintf(formatters[1].buf, sizeof(formatters[1].buf), "") :
         snprintf(formatters[1].buf,
-                 sizeof(formatters[1].buf),
+                 sizeof(formatters[0].buf),
                  "%.02f",
                  (1.0 / network_polling_retry_frequency));
-      }
     }),
 
     [2].name = "log_ping_activity",

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -494,11 +494,12 @@ static int network_polling_notify(void *context)
 
     [1].name = "network_polling_retry_frequency",
     [1].count = ({
-      network_polling_frequency <= 0 ? snprintf(formatters[1].buf, sizeof(formatters[1].buf), "")
-                                     : snprintf(formatters[1].buf,
-                                                sizeof(formatters[0].buf),
-                                                "%.02f",
-                                                (1.0 / network_polling_retry_frequency));
+      network_polling_retry_frequency <= 0
+        ? snprintf(formatters[1].buf, sizeof(formatters[1].buf), "")
+        : snprintf(formatters[1].buf,
+                   sizeof(formatters[0].buf),
+                   "%.02f",
+                   (1.0 / network_polling_retry_frequency));
     }),
 
     [2].name = "log_ping_activity",

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -47,6 +47,7 @@
 
 static double network_polling_frequency = 0.1;
 static double network_polling_retry_frequency = 1;
+static char network_polling_addresses[1024] = "8.8.8.8,114.114.114.114";
 static bool log_ping_activity = false;
 
 #define RUNIT_SERVICE_DIR "/var/run/piksi_system_daemon/sv"
@@ -54,6 +55,7 @@ static bool log_ping_activity = false;
 
 #define NETWORK_POLLING_PERIOD_FILE "/var/run/piksi_sys/network_polling_period"
 #define NETWORK_POLLING_RETRY_PERIOD_FILE "/var/run/piksi_sys/network_polling_retry_period"
+#define NETWORK_POLLING_ADDRESSES_FILE "/var/run/piksi_sys/network_polling_addresses"
 #define ENABLE_PING_LOGGING_FILE "/var/run/piksi_sys/enable_ping_logging"
 
 static const char const *ip_mode_enum_names[] = {"Static", "DHCP", NULL};
@@ -521,10 +523,11 @@ static int network_polling_notify(void *context)
   }
 
   /* clang-format off */
-  struct { const char* filename; const char* value; } settings_value_files[3] = {
+  struct { const char* filename; const char* value; } settings_value_files[4] = {
     [0].filename = NETWORK_POLLING_PERIOD_FILE,       [0].value = formatters[0].buf,
     [1].filename = NETWORK_POLLING_RETRY_PERIOD_FILE, [1].value = formatters[1].buf,
     [2].filename = ENABLE_PING_LOGGING_FILE,          [2].value = formatters[2].buf,
+    [3].filename = NETWORK_POLLING_ADDRESSES_FILE,    [3].value = network_polling_addresses,
   };
   /* clang-format on */
 
@@ -632,6 +635,14 @@ int main(void)
                        &network_polling_frequency,
                        sizeof(network_polling_frequency),
                        SETTINGS_TYPE_FLOAT,
+                       network_polling_notify,
+                       NULL);
+  pk_settings_register(settings_ctx,
+                       "system",
+                       "connectivity_check_addresses",
+                       &network_polling_addresses,
+                       sizeof(network_polling_addresses),
+                       SETTINGS_TYPE_STRING,
                        network_polling_notify,
                        NULL);
   pk_settings_register(settings_ctx,

--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -47,7 +47,7 @@
 
 static double network_polling_frequency = 0.1;
 static double network_polling_retry_frequency = 1;
-static char network_polling_addresses[1024] = "8.8.8.8,114.114.114.114";
+static char network_polling_addresses[1024] = "8.8.8.8";
 static bool log_ping_activity = false;
 
 #define RUNIT_SERVICE_DIR "/var/run/piksi_system_daemon/sv"
@@ -485,22 +485,20 @@ static int network_polling_notify(void *context)
 
     [0].name = "network_polling_frequency",
     [0].count = ({
-      network_polling_frequency <= 0 ? 
-        snprintf(formatters[0].buf, sizeof(formatters[0].buf), "") :
-        snprintf(formatters[0].buf,
-                 sizeof(formatters[0].buf),
-                 "%.02f",
-                 (1.0 / network_polling_frequency));
+      network_polling_frequency <= 0 ? snprintf(formatters[0].buf, sizeof(formatters[0].buf), "")
+                                     : snprintf(formatters[0].buf,
+                                                sizeof(formatters[0].buf),
+                                                "%.02f",
+                                                (1.0 / network_polling_frequency));
     }),
 
     [1].name = "network_polling_retry_frequency",
     [1].count = ({
-      network_polling_frequency <= 0 ? 
-        snprintf(formatters[1].buf, sizeof(formatters[1].buf), "") :
-        snprintf(formatters[1].buf,
-                 sizeof(formatters[0].buf),
-                 "%.02f",
-                 (1.0 / network_polling_retry_frequency));
+      network_polling_frequency <= 0 ? snprintf(formatters[1].buf, sizeof(formatters[1].buf), "")
+                                     : snprintf(formatters[1].buf,
+                                                sizeof(formatters[0].buf),
+                                                "%.02f",
+                                                (1.0 / network_polling_retry_frequency));
     }),
 
     [2].name = "log_ping_activity",

--- a/scripts/gen-docker-suffix
+++ b/scripts/gen-docker-suffix
@@ -4,6 +4,10 @@ import sys
 import hashlib
 
 sha1 = hashlib.new('sha1')
-sha1.update(sys.stdin.read())
+
+if (sys.version_info > (3, 0)):
+    sha1.update(sys.stdin.read().encode('utf8'))
+else:
+    sha1.update(sys.stdin.read())
 
 print(sha1.hexdigest()[:12])


### PR DESCRIPTION
## Design notes
- Allows the network polling service to be disabled by settings the frequency to zero
- Adds a settings that allows the ping address for the connectivity check to be configured, as such, we're dropping the `114.114.114.114` address

## Testing
- Bench testing by @silverjam and @switanis to confirm that ping IP can be configured successfully and that setting the frequency to zero successfully disables the service.