### PR TITLE
Check for divide by zero, support disabling network check [ESD-1228]

### DIFF
--- a/package/common_init/overlay/etc/init.d/S85network_poll
+++ b/package/common_init/overlay/etc/init.d/S85network_poll
@@ -16,6 +16,7 @@ setup_permissions()
   configure_file_resource $user $piksi_sys_dir/network_available 0644
   configure_file_resource $user $piksi_sys_dir/network_polling_period 0644
   configure_file_resource $user $piksi_sys_dir/network_polling_retry_period 0644
+  configure_file_resource $user $piksi_sys_dir/network_polling_addresses 0644
   configure_file_resource $user $piksi_sys_dir/enable_ping_logging 0644
 
   configure_file_resource $user /var/log/ping.log 0644

--- a/scripts/gen-docker-suffix
+++ b/scripts/gen-docker-suffix
@@ -4,6 +4,10 @@ import sys
 import hashlib
 
 sha1 = hashlib.new('sha1')
-sha1.update(sys.stdin.read())
+
+if (sys.version_info > (3, 0)):
+    sha1.update(sys.stdin.read().encode('utf8'))
+else:
+    sha1.update(sys.stdin.read())
 
 print(sha1.hexdigest()[:12])


### PR DESCRIPTION
Backport #1220 

## Design notes
- Allows the network polling service to be disabled by settings the frequency to zero
- Adds a settings that allows the ping address for the connectivity check to be configured, as such, we're dropping the `114.114.114.114` address

## Testing
- Bench testing by @silverjam and @switanis to confirm that ping IP can be configured successfully and that setting the frequency to zero successfully disables the service.