### PR TITLE
Update baseline threshold warning [ESD-1237]

### DIFF
--- a/package/health_daemon/src/baseline_monitor.c
+++ b/package/health_daemon/src/baseline_monitor.c
@@ -32,8 +32,8 @@
 #define FIXED_POSITION 4
 #define POSITION_MODE_MASK 0x07 /* Bits 0-2 */
 
-#define BASELINE_THRESHOLD_M (80000.0f)    /* m */
-#define BASELINE_ALERT_RATE_LIMIT (10000u) /* ms */
+#define BASELINE_THRESHOLD_M (120000.0f)    /* m */
+#define BASELINE_ALERT_RATE_LIMIT (300000u) /* ms */
 
 #define MM_TO_M_FLOAT(val_in_mm) ((float)(val_in_mm) / 1000.0f)
 static health_monitor_t *baseline_monitor;
@@ -88,7 +88,7 @@ static int baseline_threshold_rate_limiting_timer_callback(health_monitor_t *mon
   (void)monitor;
   (void)context;
   if (baseline_monitor_ctx.past_threshold) {
-    sbp_log(LOG_WARNING,
+    sbp_log(LOG_INFO,
             "Baseline Distance Over Threshold: %.4fm",
             baseline_monitor_ctx.distance_over_threshold);
     baseline_monitor_ctx.past_threshold = false;


### PR DESCRIPTION
Rate limit to once every 5 minutes from 10 seconds
Increase threshold to 120 km from 80 km
Change to INFO, from WARNING