### PR TITLE
EX-578: update librtcm, gnss-converters, and libsbp to latest versions

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = 27d542b1080d81624bf87cdcd5bb6fb295f1e8cc
+GNSS_CONVERTORS_VERSION = v0.3.82
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.82
+GNSS_CONVERTORS_VERSION = v0.3.83
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.81
+GNSS_CONVERTORS_VERSION = 27d542b1080d81624bf87cdcd5bb6fb295f1e8cc
 GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.38
+LIBRTCM_VERSION = 580af1909227e6751ed40192626f0f3e59155660
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.40
+LIBRTCM_VERSION = v0.2.41
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = 580af1909227e6751ed40192626f0f3e59155660
+LIBRTCM_VERSION = v0.2.40
 LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_INSTALL_STAGING = YES

--- a/package/libsbp/libsbp.mk
+++ b/package/libsbp/libsbp.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSBP_VERSION = fa37aa69be28f2b8df26288600decf96c980aff5
+LIBSBP_VERSION = v2.5.5
 LIBSBP_SITE = https://github.com/swift-nav/libsbp
 LIBSBP_SITE_METHOD = git
 LIBSBP_INSTALL_STAGING = YES

--- a/package/libsbp/libsbp.mk
+++ b/package/libsbp/libsbp.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBSBP_VERSION = v2.5.1
+LIBSBP_VERSION = fa37aa69be28f2b8df26288600decf96c980aff5
 LIBSBP_SITE = https://github.com/swift-nav/libsbp
 LIBSBP_SITE_METHOD = git
 LIBSBP_INSTALL_STAGING = YES


### PR DESCRIPTION
Update `librtcm` and `gnss-converters` to latest releases to pull in https://github.com/swift-nav/librtcm/pull/80 and https://github.com/swift-nav/gnss-converters/pull/192.

Update `libsbp` to latest release to pull in the OSR message support.

All HITL tests green with some runs also in the msm7 and Orion scenarios:

https://hitl-viewer.ce.swiftnav.com/summary_type=q50&metrics_preset=pass_fail&scenario=live-roof-650-townsend,live-roof-650-townsend-msm7,live-roof-650-townsend-orion,live-roof-650-townsend-dropouts-zero-baseline,live-roof-650-townsend-post&build_type=buildroot_pr&firmware_versions=v2.2.0-develop-2019051319-14-g6a6518dec&groupby_key=scenario_name&display_type=table