### PR TITLE
Use gitHeadHasTag to gate SDK build [ESD-46]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -424,34 +424,6 @@ def createPrDescription(Map args=[:]) {
     )
 }
 
-def gitBranchName(Map args=[:]) {
-
-    assert args.context
-
-    return args.context.pipe.sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
-}
-
-def prBranchName(Map args=[:]) {
-
-    assert args.context
-
-    def pr = new PullRequest(context: args.context)
-    pr.update()
-
-    return "${pr.data.head.ref}"
-}
-
-def sdkBranchName(Map args=[:]) {
-
-    assert args.context
-
-    if (args.context.isPrPush()) {
-      return prBranchName(context: args.context)
-    }
-
-    return gitBranchName(context: args.context)
-}
-
 def needSdkBuild(Map args=[:]) {
 
     assert args.context
@@ -477,9 +449,9 @@ def needSdkBuild(Map args=[:]) {
       return false
     }
 
-    if (!args.context.isTagPush()) {
+    if (!gitHeadHasTag(context: args.context)) {
 
-      args.context.logger.info("needSdkBuild: false; !isTagPush")
+      args.context.logger.info("needSdkBuild: false; !gitHeadHasTag")
       return false
     }
 


### PR DESCRIPTION
Git helpers moved to `ci-jenkins` on the `stable-pbr` tag (https://github.com/swift-nav/ci-jenkins/commits/stable-pbr) -- use `gitHeadHasTag` to gate SDK builds instead of `context.isTagPush`.

The helper `gitHeadHasTag` was tested [here](https://jenkins-test.ci.swift-nav.com/blue/organizations/jenkins/swift-nav%2Fhello-swift/detail/0.0.9/1/pipeline/22), and seems to correctly detect the presence of a tag:

![Screen Shot 2019-05-15 at 7 44 07 PM](https://user-images.githubusercontent.com/183436/57822786-ef24e000-7749-11e9-926d-7e58352e296f.png)

Since `piksi-releases` pushes new commits and tags together this should allow the PBR release build to detect the tag on the branch push, and trigger an SDK build.