### PR TITLE
Merge cherry-picks from refs/heads/v2.3.0-release (849544067) into master: Add NixOS compat patch for ca-certificates [v2.3.0] (#1263)

### DIFF
--- a/board/piksiv3/patches/ca-certificates/0001-nixos-workaround.patch
+++ b/board/piksiv3/patches/ca-certificates/0001-nixos-workaround.patch
@@ -1,0 +1,25 @@
+From 4f9678e397faf7c07372b7ad8c39401f35ed8e36 Mon Sep 17 00:00:00 2001
+From: Jason Mobarak <jason@swiftnav.com>
+Date: Mon, 20 May 2019 15:33:21 -0700
+Subject: [PATCH] nixos compat fix
+
+---
+ mozilla/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mozilla/Makefile b/mozilla/Makefile
+index 6f46118..8393753 100644
+--- a/mozilla/Makefile
++++ b/mozilla/Makefile
+@@ -3,7 +3,7 @@
+ #
+ 
+ all:
+-	python certdata2pem.py
++	PATH=$(CURDIR)/../../../../../../scripts/wrappers/bin:$(PATH) python certdata2pem.py
+ 
+ clean:
+ 	-rm -f *.crt
+-- 
+2.15.0
+

--- a/default.nix
+++ b/default.nix
@@ -75,6 +75,8 @@ let
   # understand this argument, it's added to the bash environement).
   profile = ''
 
+    if [[ -z "$VARIANT" ]]; then export VARIANT=internal; fi
+
     # buildFHSUserEnv seems to export NIX_CFLAGS_COMPILE and NIX_LDFLAGS_BEFORE
     #   but the cc-wrapper wants a var that includes a marker for the build
     #   triplet that it's wrapping:
@@ -83,9 +85,10 @@ let
     export NIX_x86_64_unknown_linux_gnu_LDFLAGS_BEFORE=$NIX_LDFLAGS_BEFORE 
 
     # Make sure buildroot Python loads dynamic modules from the right place
-    export LD_LIBRARY_PATH=$PWD/buildroot/output/host/usr/lib:/lib:/usr/lib
-    export PATH=$PWD/scripts/wrappers/bin:$PWD/buildroot/host_output/host/bin:$PWD/buildroot/output/host/bin:$PATH
-    export LD_LIBRARY_PATH=$PWD/buildroot/host_output/host/usr/lib:$LD_LIBRARY_PATH
+    export PATH=$PWD/scripts/wrappers/bin:$PWD/buildroot/$VARIANT/host_output/host/bin:$PWD/buildroot/output/$VARIANT/host/bin:$PATH
+
+    export LD_LIBRARY_PATH=$PWD/buildroot/output/$VARIANT/host/usr/lib:/lib:/usr/lib
+    export LD_LIBRARY_PATH=$PWD/buildroot/$VARIANT/host_output/host/usr/lib:$LD_LIBRARY_PATH
 
     # See note about hardeningDisable above
     export hardeningDisable=all

--- a/external.mk
+++ b/external.mk
@@ -23,3 +23,9 @@ else
 include $(BR2_EXTERNAL_piksi_buildroot_PATH)/scripts/lto.mk
 
 endif
+
+ifneq ($(IN_PIKSI_SHELL),)
+# Work around issue with libtool scripts on NixOS "discovering" system
+#   libraries instead of the ones built by buildroot.
+TARGET_LDFLAGS += -L$(HOST_DIR)/arm-buildroot-linux-gnueabihf/sysroot/usr/lib
+endif

--- a/scripts/set-shell.mk
+++ b/scripts/set-shell.mk
@@ -26,6 +26,7 @@ PREREQUISITES := \
 	$(FOUND_NIX)$(FOUND_NO_NIX_SHELL)$(FOUND_NO_PIKSI_SHELL)$(FOUND_DISABLE_NIX)
 
 ifeq (ynnn,$(PREREQUISITES))
+$(info >>> *** Wrapping SHELL with Nix wrapper ***)
 SHELL        := $(CURDIR)/scripts/nixwrap.bash
 else
 SHELL        := $(shell which bash)


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v2.3.0-release into the integration branch master