### PR TITLE
Don't change interface_mode outside settings interaction [ESD-1364]

### DIFF
--- a/package/piksi_system_daemon/src/main.c
+++ b/package/piksi_system_daemon/src/main.c
@@ -652,9 +652,10 @@ int main(void)
                        &eth_gateway);
 
   eth_settings_initialized = true;
-  interface_mode =
-    INTERFACE_MODE_ACTIVE; // in case this value was saved to persistent - clear it out
-  eth_update_config();
+  if (interface_mode
+      == INTERFACE_MODE_ACTIVE) { // in case this value was saved to persistent as Config
+    eth_update_config();
+  }
 
   settings_type_t settings_type_time_source;
   pk_settings_register_enum(settings_ctx, system_time_sources, &settings_type_time_source);


### PR DESCRIPTION
If ethernet:interface_mode is persisted as "Config", the post settings register step in `piksi_system_daemon` overrides it to "Active", which creates an inconsistency between the local setting value and `sbp_settings_daemon` cached value. This PR removes the value override and allows a device to boot in "Config" mode.

It could be argued as a feature to be able to boot without updating the ethernet function but I would consider it to be quite risky considering a customer can forget which mode the ethernet settings are in and persist without much thought. Therefore a companion PR should be created to warn the user via console in the case that the mode is "Config" when attempting to persist the settings.