### PR TITLE
Add protocol blacklist to port mode selection [ESD-1289]

### DIFF
--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -605,9 +605,9 @@ static int mode_enum_names_get(const char ***mode_enum_names, port_config_t *por
       if (strcmp(port_config->blacklist[x], protocol->setting_name) == 0) {
         piksi_log(LOG_DEBUG,
                   "skipping blacklisted protocol - port: %s name: %s",
-                  port_config->blacklist[x],
+                  port_config->name,
                   protocol->setting_name);
-        port_config->blacklisted_indices[x] = 1;
+        port_config->blacklisted_indices[protocol_index] = 1;
         enum_names[protocol_index_to_mode(protocols_used)] = NULL;
         blacklisted = true;
       }

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -27,6 +27,9 @@
 #include "ports.h"
 #include "protocols.h"
 
+#define MAX_NUM_PROTOCOLS 10
+#define MAX_PROTOCOL_NAME_LEN 10
+
 #define MODE_NAME_SBP "SBP"
 
 #define MODE_NAME_DEFAULT MODE_NAME_SBP
@@ -98,8 +101,8 @@ typedef struct port_config_s {
   restart_type_t restart;
   bool first_start;
   const int blacklist_len;
-  const char *const blacklist[10];
-  bool blacklisted_indices[10];
+  const char *const blacklist[MAX_PROTOCOL_NAME_LEN];
+  bool blacklisted_indices[MAX_NUM_PROTOCOLS];
 } port_config_t;
 
 static int mode_lookup(const char *mode_name, u8 *mode, const port_config_t *port_config);
@@ -397,7 +400,7 @@ static u8 protocol_index_to_mode(int protocol_index)
 
 static int blacklisted_mode_lookup(u8 mode, const port_config_t *port_config)
 {
-  assert(mode <= 10);
+  assert(mode <= MAX_NUM_PROTOCOLS);
   int mode_index = mode_to_protocol_index(mode);
   assert(port_config->blacklisted_indices[mode_index] != 1);
 
@@ -413,7 +416,7 @@ static int blacklisted_mode_lookup(u8 mode, const port_config_t *port_config)
 
 static int blacklisted_index_lookup(int index, const port_config_t *port_config)
 {
-  assert(index < 10);
+  assert(index < MAX_NUM_PROTOCOLS);
   for (int i = 0; i <= index; i++) {
     if (port_config->blacklisted_indices[i] == 1) {
       index++;

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -640,7 +640,7 @@ static int mode_enum_names_get(const char ***mode_enum_names, port_config_t *por
   enum_names[MODE_DISABLED] = MODE_NAME_DISABLED;
 
   for (int mode = 1; mode < port_config->mode_map_len; mode++) {
-    const protocol_t *protocol = protocols_get(protocol_index(mode, port_config));
+    const protocol_t *protocol = protocols_get(mode_to_protocol_index(mode, port_config));
     assert(protocol != NULL);
     enum_names[mode] = protocol->setting_name;
   }

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -98,8 +98,8 @@ typedef struct port_config_s {
   restart_type_t restart;
   bool first_start;
   const int blacklist_len;
-  const char* const blacklist[10];
-  int mode_mapping[10]; /* maps from global mode list to port mode sublist */
+  const char *const blacklist[10];
+  int mode_mapping[10];           /* maps from global mode list to port mode sublist */
   int protocol_index_mapping[10]; /* maps from port protocol sublist to global protocol list */
 } port_config_t;
 
@@ -433,7 +433,8 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
     return SETTINGS_WR_OK;
   }
 
-  int protocol_index = port_config->protocol_index_mapping[mode_to_protocol_index(port_config->mode)];
+  int protocol_index =
+    port_config->protocol_index_mapping[mode_to_protocol_index(port_config->mode)];
   const protocol_t *protocol = protocols_get(protocol_index);
   if (protocol == NULL) {
     return SETTINGS_WR_VALUE_REJECTED;
@@ -574,14 +575,18 @@ static int mode_enum_names_get(const char ***mode_enum_names, port_config_t *por
     bool blacklisted = false;
     for (int x = 0; x < port_config->blacklist_len; x++) {
       if (strcmp(port_config->blacklist[x], protocol->setting_name) == 0) {
-        piksi_log(LOG_DEBUG, "skipping blacklisted protocol - port: %s name: %s", port_config->blacklist[x], protocol->setting_name);
+        piksi_log(LOG_DEBUG,
+                  "skipping blacklisted protocol - port: %s name: %s",
+                  port_config->blacklist[x],
+                  protocol->setting_name);
         enum_names[protocol_index_to_mode(protocols_used)] = NULL;
         blacklisted = true;
       }
     }
 
     if (!blacklisted) {
-      port_config->mode_mapping[protocol_index_to_mode(protocol_index)] = protocol_index_to_mode(protocols_used);
+      port_config->mode_mapping[protocol_index_to_mode(protocol_index)] =
+        protocol_index_to_mode(protocols_used);
       port_config->protocol_index_mapping[protocols_used] = protocol_index;
       protocols_used++;
     }

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -462,7 +462,8 @@ static int port_configure(port_config_t *port_config, bool updating_mode)
     return SETTINGS_WR_OK;
   }
 
-  int protocol_index = blacklisted_index_lookup(mode_to_protocol_index(port_config->mode), port_config);
+  int protocol_index =
+    blacklisted_index_lookup(mode_to_protocol_index(port_config->mode), port_config);
   const protocol_t *protocol = protocols_get(protocol_index);
   if (protocol == NULL) {
     return SETTINGS_WR_VALUE_REJECTED;

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -640,7 +640,9 @@ static int mode_enum_names_get(const char ***mode_enum_names, port_config_t *por
   enum_names[MODE_DISABLED] = MODE_NAME_DISABLED;
 
   for (int mode = 1; mode < port_config->mode_map_len; mode++) {
-    enum_names[mode] = protocols_get(mode_to_protocol_index(mode, port_config))->setting_name;
+    const protocol_t *protocol = protocols_get(protocol_index(mode, port_config));
+    assert(protocol != NULL);
+    enum_names[mode] = protocol->setting_name;
   }
   enum_names[port_config->mode_map_len] = NULL;
 


### PR DESCRIPTION
Certain CAN protocols such as J1939 are only applicable to the CAN ports
on the piksi. We should not be allowed to set the USB, UDP/TCP, etc.
ports into J1939 mode.

This commit accomplishes that by introducing protocol blacklists to the
ports daemon. Each port_config_t has a list of strings of protocol names
that are blacklisted on that port.

A list of all protocols is stored in a "global" array. Each port needs
to maintain their own list due to potential blacklisted protocols. Two
additional fields have been added to port_config_t to store the mapping
between these two lists.