### PR TITLE
Switch back to using the stable tag for Jenkins shared libs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,7 @@
 
 // Use 'ci-jenkins@someref' to pull shared lib from a different branch/tag than the default.
 // Default is configured in Jenkins and should be from "stable" tag.
-
-// TODO: Change from stable-pbr to stable after everything works fine.
-// Meanwhile, the stable-pbr will allow us to quickly fix issues in the shared libs after this gets merged.
-@Library("ci-jenkins@stable-pbr") import com.swiftnav.ci.*
+@Library("ci-jenkins@stable") import com.swiftnav.ci.*
 
 String dockerFile = "scripts/Dockerfile.jenkins"
 String dockerMountArgs = "-v /mnt/efs/refrepo:/mnt/efs/refrepo -v /mnt/efs/buildroot:/mnt/efs/buildroot"


### PR DESCRIPTION
We used the stable-pbr tag during the switchover to jenkins so that it was easier to publish fixes during that process.

Now that the switch has been done for a while, we can return to using the "stable" tag, which makes sure we pull in any necessary future updates to the shared libs.