### PR TITLE
Merge cherry-picks from refs/heads/v2.3.0-release (13a51af15) into master: Switch back to using the stable tag for Jenkins shared libs (#1280)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,7 @@
 
 // Use 'ci-jenkins@someref' to pull shared lib from a different branch/tag than the default.
 // Default is configured in Jenkins and should be from "stable" tag.
-
-// TODO: Change from stable-pbr to stable after everything works fine.
-// Meanwhile, the stable-pbr will allow us to quickly fix issues in the shared libs after this gets merged.
-@Library("ci-jenkins@stable-pbr") import com.swiftnav.ci.*
+@Library("ci-jenkins@stable") import com.swiftnav.ci.*
 
 String dockerFile = "scripts/Dockerfile.jenkins"
 String dockerMountArgs = "-v /mnt/efs/refrepo:/mnt/efs/refrepo -v /mnt/efs/buildroot:/mnt/efs/buildroot"


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v2.3.0-release into the integration branch master