### PR TITLE
Use new gnss-converters tag [ESD-1393]

### DIFF
--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,9 +4,12 @@
 #
 ################################################################################
 
-GNSS_CONVERTORS_VERSION = v0.3.84
-GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
+# Workaround a Jenkins issue, this is the hash for v0.3.85 but Jenkins
+#   has cached v0.3.85 incorrectly.
+GNSS_CONVERTORS_VERSION = v0.3.86
+GNSS_CONVERTORS_SITE = git@github.com:swift-nav/gnss-converters.git
 GNSS_CONVERTORS_SITE_METHOD = git
+GNSS_CONVERTORS_GIT_SUBMODULES = YES
 GNSS_CONVERTORS_SUBDIR = c
 GNSS_CONVERTORS_DEPENDENCIES = libswiftnav librtcm libsbp
 GNSS_CONVERTORS_INSTALL_STAGING = YES

--- a/package/gnss_convertors/gnss_convertors.mk
+++ b/package/gnss_convertors/gnss_convertors.mk
@@ -4,10 +4,8 @@
 #
 ################################################################################
 
-# Workaround a Jenkins issue, this is the hash for v0.3.85 but Jenkins
-#   has cached v0.3.85 incorrectly.
 GNSS_CONVERTORS_VERSION = v0.3.86
-GNSS_CONVERTORS_SITE = git@github.com:swift-nav/gnss-converters.git
+GNSS_CONVERTORS_SITE = https://github.com/swift-nav/gnss-converters
 GNSS_CONVERTORS_SITE_METHOD = git
 GNSS_CONVERTORS_GIT_SUBMODULES = YES
 GNSS_CONVERTORS_SUBDIR = c

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 LIBRTCM_VERSION = v0.2.43
-LIBRTCM_SITE = git@github.com:swift-nav/librtcm.git
+LIBRTCM_SITE = https://github.com/swift-nav/librtcm
 LIBRTCM_SITE_METHOD = git
 LIBRTCM_GIT_SUBMODULES = YES
 LIBRTCM_SUBDIR = c

--- a/package/librtcm/librtcm.mk
+++ b/package/librtcm/librtcm.mk
@@ -4,9 +4,10 @@
 #
 ################################################################################
 
-LIBRTCM_VERSION = v0.2.41
-LIBRTCM_SITE = https://github.com/swift-nav/librtcm
+LIBRTCM_VERSION = v0.2.43
+LIBRTCM_SITE = git@github.com:swift-nav/librtcm.git
 LIBRTCM_SITE_METHOD = git
+LIBRTCM_GIT_SUBMODULES = YES
 LIBRTCM_SUBDIR = c
 LIBRTCM_INSTALL_STAGING = YES
 LIBRTCM_MAKE_ENV = CFLAGS=-ggdb3

--- a/package/libsbp/libsbp.mk
+++ b/package/libsbp/libsbp.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 LIBSBP_VERSION = v2.6.4
-LIBSBP_SITE = git@github.com:swift-nav/libsbp.git
+LIBSBP_SITE = https://github.com/swift-nav/libsbp
 LIBSBP_SITE_METHOD = git
 LIBSBP_GIT_SUBMODULES = YES
 LIBSBP_INSTALL_STAGING = YES

--- a/package/libsbp/libsbp.mk
+++ b/package/libsbp/libsbp.mk
@@ -4,9 +4,10 @@
 #
 ################################################################################
 
-LIBSBP_VERSION = v2.5.5
-LIBSBP_SITE = https://github.com/swift-nav/libsbp
+LIBSBP_VERSION = v2.6.4
+LIBSBP_SITE = git@github.com:swift-nav/libsbp.git
 LIBSBP_SITE_METHOD = git
+LIBSBP_GIT_SUBMODULES = YES
 LIBSBP_INSTALL_STAGING = YES
 LIBSBP_SUBDIR = c
 

--- a/package/libswiftnav/libswiftnav.mk
+++ b/package/libswiftnav/libswiftnav.mk
@@ -4,9 +4,10 @@
 #
 ################################################################################
 
-LIBSWIFTNAV_VERSION = v0.1.7
-LIBSWIFTNAV_SITE = https://github.com/swift-nav/libswiftnav
+LIBSWIFTNAV_VERSION = v0.1.8
+LIBSWIFTNAV_SITE = git@github.com:swift-nav/libswiftnav.git
 LIBSWIFTNAV_SITE_METHOD = git
+LIBSWIFTNAV_GIT_SUBMODULES = YES
 LIBSWIFTNAV_INSTALL_STAGING = YES
 
 $(eval $(cmake-package))

--- a/package/libswiftnav/libswiftnav.mk
+++ b/package/libswiftnav/libswiftnav.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 LIBSWIFTNAV_VERSION = v0.1.8
-LIBSWIFTNAV_SITE = git@github.com:swift-nav/libswiftnav.git
+LIBSWIFTNAV_SITE = https://github.com/swift-nav/libswiftnav
 LIBSWIFTNAV_SITE_METHOD = git
 LIBSWIFTNAV_GIT_SUBMODULES = YES
 LIBSWIFTNAV_INSTALL_STAGING = YES

--- a/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
+++ b/package/sbp_rtcm3_bridge/src/sbp_rtcm3_bridge.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include <gnss-converters/rtcm3_sbp.h>
+#include <gnss-converters/sbp_rtcm3.h>
 
 #include <libpiksi/logging.h>
 #include <libpiksi/settings_client.h>


### PR DESCRIPTION
the current gnss-converters code can generate a MSM message for QZSS but fails to handle it in https://github.com/swift-nav/gnss-converters/blob/master/c/src/sbp_rtcm3.c#L92

Additional cmake changes in all repos require submodules to be pulled in as well..