### PR TITLE
Update version of piksi_ins for odometry

### DIFF
--- a/package/piksi_ins/piksi_ins.mk
+++ b/package/piksi_ins/piksi_ins.mk
@@ -17,9 +17,12 @@ endef
 PIKSI_INS_PRE_INSTALL_TARGET_HOOKS += PIKSI_INS_PRE_INSTALL_WARNING
 
 ## The piksi_ins version is managed with piksi-releases
-include ${BR2_EXTERNAL_piksi_buildroot_PATH}/package/piksi_ins/piksi_ins_version.mk
+#include ${BR2_EXTERNAL_piksi_buildroot_PATH}/package/piksi_ins/piksi_ins_version.mk
 
-PIKSI_INS_VERSION = $(PIKSI_RELEASES_INS_VERSION)
+# Use tip of "Stillness_dz_fixes" branch (PR 49) as of Aug 12 2019
+# Includes NHC, Stillness detection, odometry, and version 2.3 bug fixes
+# Will become master as testing continues
+PIKSI_INS_VERSION = ee85ef8ef51c51c81a9789566c33424e3b1463d5
 PIKSI_INS_SITE = git@github.com:swift-nav/pose_daemon_wrapper.git
 PIKSI_INS_SITE_METHOD = git
 PIKSI_INS_GIT_SUBMODULES = YES


### PR DESCRIPTION
This PR should pull in this version of piksi_ins which includes everything we know about. 

https://github.com/swift-nav/pose_daemon_wrapper/pull/49

I expect it to work and not to crash. 

Ideally, when testing approves, we should finalize this branch of pose_daemon_wrapper and just merge it to master, and then undo my hardcoded change in the .mk file. 
