### PR TITLE
Merge cherry-picks from refs/heads/v2.3.0-release (2713b61f1) into master: Re-enable FileIO on tcp_client{0,1}, OTA fix-ups [ESD-1506] (#1309)

### DIFF
--- a/package/libpiksi/libpiksi/src/sha256.c
+++ b/package/libpiksi/libpiksi/src/sha256.c
@@ -34,6 +34,15 @@ int sha256sum_file(const char *filename, char *sha, size_t sha_size)
 
 int sha256sum_cmp(const char *a, const char *b)
 {
-  assert(strlen(a) == (SHA256SUM_LEN - 1) && strlen(b) == (SHA256SUM_LEN - 1));
+  if (strlen(a) != (SHA256SUM_LEN - 1) || strlen(b) != (SHA256SUM_LEN - 1)) {
+    piksi_log(LOG_ERR,
+              "sha256sum_cmp error: strlen(%s) = %d, strlen(%s) = %d",
+              a,
+              strlen(a),
+              b,
+              strlen(b));
+    return -1;
+  }
+
   return strncmp(a, b, SHA256SUM_LEN);
 }

--- a/package/ota_daemon/src/ota_daemon.c
+++ b/package/ota_daemon/src/ota_daemon.c
@@ -282,7 +282,7 @@ static int ota_version_check(const char *offered)
   }
 
   piksi_log(LOG_INFO, "Current version: %s", current);
-  piksi_log(LOG_INFO, "Offered version: %s", current);
+  piksi_log(LOG_INFO, "Offered version: %s", offered);
 
   int ret = ota_dev_version_check(&offered_parsed, &current_parsed);
 

--- a/package/ota_daemon/src/ota_settings.c
+++ b/package/ota_daemon/src/ota_settings.c
@@ -83,11 +83,11 @@ void ota_settings(pk_settings_ctx_t *ctx)
 {
   pk_settings_register(ctx,
                        "system",
-                       "ota_enabled",
-                       &ota_enabled,
-                       sizeof(ota_enabled),
-                       SETTINGS_TYPE_BOOL,
-                       ota_notify_enable,
+                       "ota_url",
+                       &ota_url,
+                       sizeof(ota_url),
+                       SETTINGS_TYPE_STRING,
+                       ota_notify_generic,
                        NULL);
 
   pk_settings_register(ctx,
@@ -101,10 +101,10 @@ void ota_settings(pk_settings_ctx_t *ctx)
 
   pk_settings_register(ctx,
                        "system",
-                       "ota_url",
-                       &ota_url,
-                       sizeof(ota_url),
-                       SETTINGS_TYPE_STRING,
-                       ota_notify_generic,
+                       "ota_enabled",
+                       &ota_enabled,
+                       sizeof(ota_enabled),
+                       SETTINGS_TYPE_BOOL,
+                       ota_notify_enable,
                        NULL);
 }

--- a/package/ports_daemon/ports_daemon/src/ports.c
+++ b/package/ports_daemon/ports_daemon/src/ports.c
@@ -159,7 +159,12 @@ static int opts_get_tcp_client(char *buf,
                                const port_config_t *port_config)
 {
   const char *address = opts_data->tcp_client_data.address;
-  return snprintf(buf, buf_size, "--name %s --tcp-c %s", port_config->name, address);
+  return snprintf(buf,
+                  buf_size,
+                  "--name %s --tcp-c %s%s",
+                  port_config->name,
+                  address,
+                  get_fileio_opts(port_config));
 }
 
 static int opts_get_udp_server(char *buf,

--- a/package/sbp_fileio_daemon/overlay/etc/init.d/S81sbp_fileio_daemon_external
+++ b/package/sbp_fileio_daemon/overlay/etc/init.d/S81sbp_fileio_daemon_external
@@ -25,6 +25,12 @@ cmd="sbp_fileio_daemon \
 --pub-s ipc:///var/run/sockets/fileio/tcp_server1.pub \
 --sub-s ipc:///var/run/sockets/fileio/tcp_server1.sub \
 \
+--pub-s ipc:///var/run/sockets/fileio/tcp_client0.pub \
+--sub-s ipc:///var/run/sockets/fileio/tcp_client0.sub \
+\
+--pub-s ipc:///var/run/sockets/fileio/tcp_client1.pub \
+--sub-s ipc:///var/run/sockets/fileio/tcp_client1.sub \
+\
 --pub-s ipc:///var/run/sockets/fileio/usb0.pub \
 --sub-s ipc:///var/run/sockets/fileio/usb0.sub \
 \

--- a/scripts/docker.mk
+++ b/scripts/docker.mk
@@ -50,7 +50,7 @@ BUILD_VOLUME_ARGS = \
   -v $(DOCKER_BUILD_VOLUME):/piksi_buildroot/buildroot
 
 RUN_VOLUME_ARGS = \
-  -v $(CURDIR)/buildroot/output_$(VARIANT)/images:/piksi_buildroot/buildroot/output_$(VARIANT)/images
+  -v $(CURDIR)/buildroot/output/$(VARIANT)/images:/piksi_buildroot/buildroot/output/$(VARIANT)/images
 
 else
 


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v2.3.0-release into the integration branch master