### PR TITLE
Dzollo/pikis ins forward gnss when initializing or converging

### DIFF
--- a/package/piksi_ins/piksi_ins_version.mk
+++ b/package/piksi_ins/piksi_ins_version.mk
@@ -1,4 +1,4 @@
 # The piksi-releases project is used to manage the piksi_ins version,
 #   any updates here will be overwritten the next time piksi-releases
 #   is run.
-PIKSI_RELEASES_INS_VERSION = v2.3.20
+PIKSI_RELEASES_INS_VERSION = dc5da8752ceab1899dadd1f3237c071480e3fe57 # dzollo/Canadian_rail_10_second_init

--- a/package/piksi_ins/piksi_ins_version.mk
+++ b/package/piksi_ins/piksi_ins_version.mk
@@ -1,4 +1,4 @@
 # The piksi-releases project is used to manage the piksi_ins version,
 #   any updates here will be overwritten the next time piksi-releases
 #   is run.
-PIKSI_RELEASES_INS_VERSION = dc5da8752ceab1899dadd1f3237c071480e3fe57 # dzollo/Canadian_rail_10_second_init
+PIKSI_RELEASES_INS_VERSION = 372164fe4f6afc59b259840b8c73d7e7c8f528e0 #dzollo/forward_gnss_when_initializing_or_converging


### PR DESCRIPTION
/cc @anth-cole @switanis 

This update the piksi_ins repo to forward GNSS only solution whenever the INS is in "initialization" or "converging / aligning" states.