### PR TITLE
Update pose_daemon_wrapper to tip of dzollo/stillness_tuning_settings

### DIFF
--- a/package/piksi_ins/piksi_ins_version.mk
+++ b/package/piksi_ins/piksi_ins_version.mk
@@ -1,4 +1,4 @@
 # The piksi-releases project is used to manage the piksi_ins version,
 #   any updates here will be overwritten the next time piksi-releases
 #   is run.
-PIKSI_RELEASES_INS_VERSION =  97ebcaac821d089dcdc2c73d77f6f1dfabdff714
+PIKSI_RELEASES_INS_VERSION =  d171d796925826b743c1818a8d81e301746bc466

--- a/package/piksi_ins/piksi_ins_version.mk
+++ b/package/piksi_ins/piksi_ins_version.mk
@@ -1,4 +1,4 @@
 # The piksi-releases project is used to manage the piksi_ins version,
 #   any updates here will be overwritten the next time piksi-releases
 #   is run.
-PIKSI_RELEASES_INS_VERSION = v2.3.20
+PIKSI_RELEASES_INS_VERSION =  97ebcaac821d089dcdc2c73d77f6f1dfabdff714

--- a/package/sbp_protocol/src/sbp_router.yml
+++ b/package/sbp_protocol/src/sbp_router.yml
@@ -219,6 +219,7 @@ ports:
           - { action: ACCEPT, prefix: [0x55, 0x20, 0x02] } # MSG_ORIENT_QUAT   **Smoothpose Change**
           - { action: ACCEPT, prefix: [0x55, 0x21, 0x02] } # MSG_ORIENT_EULER  **Smoothpose Change**
           - { action: ACCEPT, prefix: [0x55, 0x22, 0x02] } # MSG_ANGULAR_RATE  **Smoothpose Change**
+          - { action: ACCEPT, prefix: [0x55, 0x03, 0xFF] } # MSG_INS_STATUS    **Smoothpose Change**
           - { action: ACCEPT, prefix: [0x55, 0x01, 0x04] } # MSG_LOG           **Smoothpose Change**
           - { action: REJECT }
 


### PR DESCRIPTION
This incorporates stillness tuning settings from pose_daemon_wrapper into the v2.3.0-release branch of buildroot.