### PR TITLE
Update firmware/fpga versions for leap second fix

### DIFF
--- a/external-artifacts.yaml
+++ b/external-artifacts.yaml
@@ -24,19 +24,19 @@ artifact_sets:
     name: multi
     artifacts:
     - name: fpga_bitstream
-      version: v2.3.19
+      version: v2.3.23
       s3_bucket: swiftnav-artifacts
       s3_repository: piksi_fpga
       s3_object: piksi_prod_fpga.bit
       local_path: firmware/prod/piksi_fpga.bit
-      sha256: 484ba408fe4a5b03d2a438fc3f91eb1d6b9c849b6027074336ac9aec514e5b6d
+      sha256: be304a3002fa43aa7a5bf363e230f64693207aca2444437858d8670be4511490
     - name: rtos_elf
-      version: v2.3.19
+      version: v2.3.23
       s3_bucket: swiftnav-artifacts
       s3_repository: piksi_firmware_private
       s3_object: v3/piksi_firmware_v3_prod.stripped.elf
       local_path: firmware/prod/piksi_firmware.elf
-      sha256: 346e65897af5f4d40f544262533406fbc653b08fa90bb1e2f37d3584a8d50151
+      sha256: 8fa12357be6c495fdb6fd9744a615a28897d45936a8a81e164bbd3b0c945e4f7
     - name: piksi_upgrade_tool
       version: v2.2.6
       s3_bucket: swiftnav-artifacts
@@ -48,19 +48,19 @@ artifact_sets:
     name: internal
     artifacts:
     - name: rtos_elf
-      version: v2.3.19
+      version: v2.3.23
       s3_bucket: swiftnav-artifacts
       s3_repository: piksi_firmware_private
       s3_object: v3/piksi_firmware_v3_prod.stripped.elf
       local_path: firmware/prod/piksi_firmware.elf
-      sha256: 346e65897af5f4d40f544262533406fbc653b08fa90bb1e2f37d3584a8d50151
+      sha256: 8fa12357be6c495fdb6fd9744a615a28897d45936a8a81e164bbd3b0c945e4f7
     - name: fpga_bitstream
-      version: v2.3.19
+      version: v2.3.23
       s3_bucket: swiftnav-artifacts
       s3_repository: piksi_fpga
       s3_object: piksi_prod_fpga.bit
       local_path: firmware/prod/piksi_fpga.bit
-      sha256: 484ba408fe4a5b03d2a438fc3f91eb1d6b9c849b6027074336ac9aec514e5b6d
+      sha256: be304a3002fa43aa7a5bf363e230f64693207aca2444437858d8670be4511490
     - name: piksi_upgrade_tool
       version: v2.2.6
       s3_bucket: swiftnav-artifacts
@@ -79,19 +79,19 @@ artifact_sets:
     name: sdk
     artifacts:
     - name: rtos_elf
-      version: v2.3.19
+      version: v2.3.23
       s3_bucket: swiftnav-releases
       s3_repository: piksi_firmware_private
       s3_object: v3/piksi_firmware_v3_prod.stripped.elf
       local_path: firmware/prod/piksi_firmware.elf
-      sha256: 346e65897af5f4d40f544262533406fbc653b08fa90bb1e2f37d3584a8d50151
+      sha256: 8fa12357be6c495fdb6fd9744a615a28897d45936a8a81e164bbd3b0c945e4f7
     - name: fpga_bitstream
-      version: v2.3.19
+      version: v2.3.23
       s3_bucket: swiftnav-releases
       s3_repository: piksi_fpga
       s3_object: piksi_sdk_fpga.bit
       local_path: firmware/prod/piksi_fpga.bit
-      sha256: 51a0673a48ec5c6507cd13b5026994a15548545fcbc6995617dea684d8693c0d
+      sha256: 3032512d629d53f8b34edd876b4f60477dea583883449e4f84e1a402aa997882
     - name: piksi_upgrade_tool
       version: v2.2.6
       s3_bucket: swiftnav-releases

--- a/scripts/pbr_script_lib.py
+++ b/scripts/pbr_script_lib.py
@@ -98,8 +98,8 @@ class Runner(object):
         Run a pipeline and check that it's successful.
         """
         proc = self._make_proc(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        ret = proc.wait()
-        return (ret, proc.stdout.read().decode('utf8'), proc.stderr.read().decode('utf8'))
+        (stdout, stderr) = proc.communicate()
+        return (proc.returncode, stdout.decode('utf8'), stderr.decode('utf8'))
 
     def check(self, stdout=None):
         """


### PR DESCRIPTION
Use 2.3.23 firmware images, tagged 4/4/22 to include leap second fix